### PR TITLE
fixed custom command without selection does not run

### DIFF
--- a/src/main/java/com/mucommander/command/Command.java
+++ b/src/main/java/com/mucommander/command/Command.java
@@ -328,23 +328,26 @@ public class Command implements Comparable<Command> {
     }
     
     /**
-     * Returns whether this command contains keyword.
+     * Returns whether this command contains keywords referencing selected file.
      * <p>
-     * Returns true as long as KEYWORD_HEADER is found as leading char in any token.
-     * Illegal tokens like $xyz still return true.
+     * Returns true if command contains keywords referencing selected file, e.g. $f,$n,$p,$e,$b.
+     * Returns false otherwise, e.g. $j, $xyz, etc.
      * </p>
-     * @return whether this command contains keyword.
+     * @return whether this command contains keywords referencing selected file.
      */
-    public synchronized boolean hasKeywordToken() {
+    public synchronized boolean hasSelectedFileKeyword() {
     	String[] tokens = getTokens();
         for (String token : tokens) {
-            if (token.length() > 0) {
-                if (token.charAt(0) == KEYWORD_HEADER) {
-                    return true;
-                }
+            // Not using regexp because it depends on the definition of KEYWORD_*
+            if (token.startsWith("" + KEYWORD_HEADER + KEYWORD_PATH)
+                    || token.startsWith("" + KEYWORD_HEADER + KEYWORD_NAME)
+                    || token.startsWith("" + KEYWORD_HEADER + KEYWORD_EXTENSION)
+                    || token.startsWith("" + KEYWORD_HEADER + KEYWORD_NAME_WITHOUT_EXTENSION)
+                    || token.startsWith("" + KEYWORD_HEADER + KEYWORD_PARENT)) {
+                return true;
             }
         }
-        // No token with KEYWORD_HEADER found
+        // No token with file referencing keyword found
         return false;
     }
 

--- a/src/main/java/com/mucommander/ui/action/impl/CommandAction.java
+++ b/src/main/java/com/mucommander/ui/action/impl/CommandAction.java
@@ -81,7 +81,7 @@ public class CommandAction extends MuAction {
         selectedFiles = mainFrame.getActiveTable().getSelectedFiles();
 
         // If no files are either selected or marked, aborts.
-        if(command.hasKeywordToken() && selectedFiles.size() == 0)
+        if(command.hasSelectedFileKeyword() && selectedFiles.size() == 0)
             return;
 
         // If we're working with local files, go ahead and runs the command.


### PR DESCRIPTION
Hi, I'm trying to customize the toolbar and run into this bug. The custom commands are not executed if no files are selected, even when the command does not contain keywords like $f, e.g. simply launch calc.

I added a method hasKeywordToken() in Command and used in CommandAction. Please let me know if this is not the right way to fix it.

PS: just want to say great work! I just started using it. And the latest transition to gradle made set up much easier.
