### PR TITLE
#16: Resolve the variables on the fly

### DIFF
--- a/src/main/java/com/mucommander/text/Translator.java
+++ b/src/main/java/com/mucommander/text/Translator.java
@@ -122,16 +122,16 @@ public class Translator {
         // Determines if language is one of the languages declared as available
         if(availableLanguages.contains(locale)) {
             // Language is available
-			resourceBundle= ResourceBundle.getBundle("dictionary", locale);
+            resourceBundle= ResourceBundle.getBundle("dictionary", locale);
             LOGGER.debug("Language "+locale+" is available.");
         }
         else {
             // Language is not available, fall back to default language
-			resourceBundle= ResourceBundle.getBundle("dictionary");
+            resourceBundle= ResourceBundle.getBundle("dictionary");
             LOGGER.debug("Language "+locale+" is not available, falling back to English");
         }
 
-		dictionaryBundle = new Translator.ResolveVariableResourceBundle(resourceBundle);
+        dictionaryBundle = new Translator.ResolveVariableResourceBundle(resourceBundle);
 
         // Set preferred language in configuration file
         MuConfigurations.getPreferences().setVariable(MuPreference.LANGUAGE, locale.toLanguageTag());
@@ -194,70 +194,70 @@ public class Translator {
     	return key;
     }
 
-	/**
-	 * Decorator allowing to resolve the values composed of variables on the fly.
-	 */
-	private static class ResolveVariableResourceBundle extends ResourceBundle {
+    /**
+     * Decorator allowing to resolve the values composed of variables on the fly.
+     */
+    private static class ResolveVariableResourceBundle extends ResourceBundle {
 
-		/**
-		 * Pattern corresponding to a variable.
-		 */
-		private static final Pattern VARIABLE = Pattern.compile("\\$\\[([^]]+)\\]");
-
-		/**
-		 * The underlying resource bundle.
-		 */
-		private final ResourceBundle resourceBundle;
-
-		/**
-		 * The cache containing the
-		 */
-		private final ConcurrentMap<String, String> cache = new ConcurrentHashMap<>();
-
-		/**
-		 * Constructs a {@code ResolveVariableResourceBundle} with the specified underlying
-		 * {@link ResourceBundle}.
-		 * @param resourceBundle The underlying {@link ResourceBundle}.
+        /**
+         * Pattern corresponding to a variable.
          */
-		ResolveVariableResourceBundle(final ResourceBundle resourceBundle) {
-			this.resourceBundle = resourceBundle;
-		}
+        private static final Pattern VARIABLE = Pattern.compile("\\$\\[([^]]+)\\]");
 
-		@Override
-		protected Object handleGetObject(final String key) {
-			Object result = cache.get(key);
-			if (result == null) {
-				result = resourceBundle.getObject(key);
-				if (result instanceof String) {
-					final String value = (String) result;
-					final Matcher matcher = VARIABLE.matcher(value);
-					if (matcher.find()) {
-						int startIndex = 0;
-						final StringBuilder buffer = new StringBuilder(64);
-						while (matcher.find(startIndex)) {
-							buffer.append(value, startIndex, matcher.start());
-							try {
-								buffer.append(handleGetObject(matcher.group(1)));
-							} catch (MissingResourceException e) {
-								if (LOGGER.isDebugEnabled()) {
-									LOGGER.debug("The key '%s' is missing", key);
-								}
-								buffer.append(value, matcher.start(), matcher.end());
-							}
-							startIndex = matcher.end();
-						}
-						buffer.append(value.substring(startIndex));
-						result = buffer.toString();
-						cache.putIfAbsent(key, (String) result);
-					}
-				}
-			}
-			return result;
-		}
+        /**
+         * The underlying resource bundle.
+         */
+        private final ResourceBundle resourceBundle;
 
-		@Override
-		public Enumeration<String> getKeys() {
-			return resourceBundle.getKeys();
-		}
-	}
+        /**
+         * The cache containing the
+         */
+        private final ConcurrentMap<String, String> cache = new ConcurrentHashMap<>();
+
+        /**
+         * Constructs a {@code ResolveVariableResourceBundle} with the specified underlying
+         * {@link ResourceBundle}.
+         * @param resourceBundle The underlying {@link ResourceBundle}.
+         */
+        ResolveVariableResourceBundle(final ResourceBundle resourceBundle) {
+            this.resourceBundle = resourceBundle;
+        }
+
+        @Override
+        protected Object handleGetObject(final String key) {
+            Object result = cache.get(key);
+            if (result == null) {
+                result = resourceBundle.getObject(key);
+                if (result instanceof String) {
+                    final String value = (String) result;
+                    final Matcher matcher = VARIABLE.matcher(value);
+                    if (matcher.find()) {
+                        int startIndex = 0;
+                        final StringBuilder buffer = new StringBuilder(64);
+                        while (matcher.find(startIndex)) {
+                            buffer.append(value, startIndex, matcher.start());
+                            try {
+                                buffer.append(handleGetObject(matcher.group(1)));
+                            } catch (MissingResourceException e) {
+                                if (LOGGER.isDebugEnabled()) {
+                                    LOGGER.debug("The key '%s' is missing", key);
+                                }
+                                buffer.append(value, matcher.start(), matcher.end());
+                            }
+                            startIndex = matcher.end();
+                        }
+                        buffer.append(value.substring(startIndex));
+                        result = buffer.toString();
+                        cache.putIfAbsent(key, (String) result);
+                    }
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public Enumeration<String> getKeys() {
+            return resourceBundle.getKeys();
+        }
+    }
 }

--- a/src/main/java/com/mucommander/text/Translator.java
+++ b/src/main/java/com/mucommander/text/Translator.java
@@ -210,7 +210,8 @@ public class Translator {
         private final ResourceBundle resourceBundle;
 
         /**
-         * The cache containing the
+         * The cache containing the already computed values in case the original value contains at least
+		 * one variable.
          */
         private final ConcurrentMap<String, String> cache = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/mucommander/text/Translator.java
+++ b/src/main/java/com/mucommander/text/Translator.java
@@ -270,8 +270,8 @@ public class Translator {
                     try {
                         buffer.append(ResolveVariableResourceBundle.resolve(matcher.group(1), resource, map));
                     } catch (MissingResourceException e) {
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("The key '%s' is missing", key);
+                        if (LOGGER.isTraceEnabled()) {
+                            LOGGER.trace(   "The key '{}' is missing", key);
                         }
                         buffer.append(value, matcher.start(), matcher.end());
                     }

--- a/src/main/java/com/mucommander/text/Translator.java
+++ b/src/main/java/com/mucommander/text/Translator.java
@@ -211,7 +211,7 @@ public class Translator {
 
         /**
          * The cache containing the already computed values in case the original value contains at least
-		 * one variable.
+    	 * one variable.
          */
         private final ConcurrentMap<String, String> cache = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/mucommander/text/Translator.java
+++ b/src/main/java/com/mucommander/text/Translator.java
@@ -117,7 +117,7 @@ public class Translator {
 
     public static void init() {
     	final Locale locale = getLocale();
-		final ResourceBundle resourceBundle;
+    	final ResourceBundle resourceBundle;
 
         // Determines if language is one of the languages declared as available
         if(availableLanguages.contains(locale)) {

--- a/src/main/java/com/mucommander/text/Translator.java
+++ b/src/main/java/com/mucommander/text/Translator.java
@@ -271,7 +271,7 @@ public class Translator {
                         buffer.append(ResolveVariableResourceBundle.resolve(matcher.group(1), resource, map));
                     } catch (MissingResourceException e) {
                         if (LOGGER.isTraceEnabled()) {
-                            LOGGER.trace(   "The key '{}' is missing", key);
+                            LOGGER.trace("The key '{}' is missing", key);
                         }
                         buffer.append(value, matcher.start(), matcher.end());
                     }

--- a/src/test/java/com/mucommander/text/TranslatorTest.java
+++ b/src/test/java/com/mucommander/text/TranslatorTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2012 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.text;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * A test case for {@link Translator}
+ *
+ * @author Nicolas Filotto (nicolas.filotto@gmail.com)
+ */
+public class TranslatorTest {
+
+    /**
+     * Initializes the Translator.
+     */
+    @BeforeClass
+    public static void init() {
+        Translator.init();
+    }
+
+    /**
+     * Translator can reuse keys
+     */
+    @Test
+    public void reusesKey() {
+        assert Translator.get("key1").equals("Hello");
+        assert Translator.get("key2").equals("World");
+        assert Translator.get("key3").equals("Hello");
+        assert Translator.get("key4").equals("\"Hello the World!\"");
+        assert Translator.get("key5").equals("\"Hello the $[key6]!\"");
+    }
+}

--- a/src/test/java/com/mucommander/text/TranslatorTest.java
+++ b/src/test/java/com/mucommander/text/TranslatorTest.java
@@ -44,6 +44,7 @@ public class TranslatorTest {
         assert Translator.get("key2").equals("World");
         assert Translator.get("key3").equals("Hello");
         assert Translator.get("key4").equals("\"Hello the World!\"");
-        assert Translator.get("key5").equals("\"Hello the $[key6]!\"");
+        assert Translator.get("key5").equals("\"Hello the $[key0]!\"");
+        assert Translator.get("key6").equals("-\"Hello the World!\"-\"Hello the $[key0]!\"-$[key7]-");
     }
 }

--- a/src/test/resources/dictionary.properties
+++ b/src/test/resources/dictionary.properties
@@ -1,0 +1,5 @@
+key1 = Hello
+key2 = World
+key3 = $[key1]
+key4 = "$[key1] the $[key2]!"
+key5 = "$[key1] the $[key6]!"

--- a/src/test/resources/dictionary.properties
+++ b/src/test/resources/dictionary.properties
@@ -2,4 +2,5 @@ key1 = Hello
 key2 = World
 key3 = $[key1]
 key4 = "$[key1] the $[key2]!"
-key5 = "$[key1] the $[key6]!"
+key5 = "$[key1] the $[key0]!"
+key6 = -$[key4]-$[key5]-$[key7]-


### PR DESCRIPTION
A fix proposal for https://github.com/mucommander/mucommander/issues/16:

This PR allows to resolve the variables of type _$[var-name]_ at initialization time thanks to a decorator.