### PR TITLE
support for retina displays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ macAppBundle {
     jvmVersion = "1.6+"
     icon = "package/osx/icon.icns"
     bundleAllowMixedLocalizations = "true"
+    bundleExtras.put("NSHighResolutionCapable", "true")
 
     javaProperties.put("java.system.class.loader", "com.mucommander.commons.file.AbstractFileClassLoader")
     javaProperties.put("com.apple.smallTabs", "true")


### PR DESCRIPTION
Changed macAppBundle configuration to include
NSHighResolutionCapable=true into application Info.plist. 
As a result we get nicer looking fonts on retina displays.