### PR TITLE
single panel selection toggle

### DIFF
--- a/src/main/java/com/mucommander/ui/action/ActionManager.java
+++ b/src/main/java/com/mucommander/ui/action/ActionManager.java
@@ -207,7 +207,8 @@ public class ActionManager {
     	registerAction(new SplitFileAction.Descriptor(),            		new SplitFileAction.Factory());
     	registerAction(new SplitHorizontallyAction.Descriptor(),            new SplitHorizontallyAction.Factory());
     	registerAction(new SplitVerticallyAction.Descriptor(),              new SplitVerticallyAction.Factory());
-    	registerAction(new StopAction.Descriptor(),              			new StopAction.Factory());
+    	registerAction(new ToggleSinglePanelAction.Descriptor(),            new ToggleSinglePanelAction.Factory());
+    	registerAction(new StopAction.Descriptor(),                         new StopAction.Factory());
     	registerAction(new SwapFoldersAction.Descriptor(),       	        new SwapFoldersAction.Factory());
     	registerAction(new SwitchActiveTableAction.Descriptor(),            new SwitchActiveTableAction.Factory());
     	registerAction(new ToggleAutoSizeAction.Descriptor(),               new ToggleAutoSizeAction.Factory());

--- a/src/main/java/com/mucommander/ui/action/impl/ToggleSinglePanelAction.java
+++ b/src/main/java/com/mucommander/ui/action/impl/ToggleSinglePanelAction.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2012 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.mucommander.ui.action.impl;
+
+import java.util.Map;
+
+import javax.swing.KeyStroke;
+
+import com.mucommander.ui.action.AbstractActionDescriptor;
+import com.mucommander.ui.action.ActionCategories;
+import com.mucommander.ui.action.ActionCategory;
+import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.ActionFactory;
+import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.main.MainFrame;
+
+/**
+ * Toggles isVisible state of the right panel, imitating single/two panel view switch.
+ */
+public class ToggleSinglePanelAction extends MuAction {
+
+    private static final float TWO_PANELS_DEFAULT_RATIO = 0.5f;
+    private float previousRatio = TWO_PANELS_DEFAULT_RATIO;
+
+    ToggleSinglePanelAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    private void hideInactivePanel() {
+        mainFrame.getInactivePanel().setVisible(false);
+    }
+
+    private void showInactivePanel() {
+        mainFrame.getInactivePanel().setVisible(true);
+    }
+
+
+    @Override
+    public void performAction() {
+        // we want to restore old two panel ratio
+        boolean isSinglePanelViewNow = mainFrame.toggleSinglePanel();
+
+        
+        if (isSinglePanelViewNow) {
+            previousRatio = mainFrame.getSplitPane().getSplitRatio();
+            hideInactivePanel();
+
+        } else {
+            mainFrame.getSplitPane().setSplitRatio(previousRatio);
+            showInactivePanel();
+        }
+
+    }
+
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
+
+    public static class Factory implements ActionFactory {
+
+        public MuAction createAction(MainFrame mainFrame, Map<String, Object> properties) {
+            return new ToggleSinglePanelAction(mainFrame, properties);
+        }
+    }
+
+    public static class Descriptor extends AbstractActionDescriptor {
+        public static final String ACTION_ID = "ToggleSinglePanel";
+
+        public String getId() {
+            return ACTION_ID;
+        }
+
+        public ActionCategory getCategory() {
+            return ActionCategories.VIEW;
+        }
+
+        public KeyStroke getDefaultAltKeyStroke() {
+            return null;
+        }
+
+        public KeyStroke getDefaultKeyStroke() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/mucommander/ui/layout/ProportionalSplitPane.java
+++ b/src/main/java/com/mucommander/ui/layout/ProportionalSplitPane.java
@@ -122,6 +122,14 @@ public class ProportionalSplitPane extends JSplitPane implements ComponentListen
 
 
     /**
+     * returns current pane split ratio.
+     */
+    public float getSplitRatio() {
+        return this.splitRatio;
+    }
+
+
+    /**
      * Returns the split pane divider component.
      */
     public BasicSplitPaneDivider getDividerComponent() {

--- a/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -103,6 +103,9 @@ public class MainFrame extends JFrame implements LocationListener {
     /** Is this MainFrame active in the foreground ? */
     private boolean foregroundActive;
 
+    /** Is single panel view? */
+    private boolean singlePanel;
+
     /** Contains all registered ActivePanelListener instances, stored as weak references */
     private WeakHashMap<ActivePanelListener, ?> activePanelListeners = new WeakHashMap<ActivePanelListener, Object>();
 
@@ -680,6 +683,28 @@ public class MainFrame extends JFrame implements LocationListener {
         }
     }
     
+
+
+    /**
+     * Returns <code>true</code> if only one panel is show
+     *
+     * @return <code>true</code> if only one panel is show
+     */
+    public boolean isSinglePanel() {
+        return singlePanel;
+    }
+
+    /**
+     * Toggles single panel view state and returns new one
+     *
+     * @return new state for singlePanel boolean
+     */
+
+    public boolean toggleSinglePanel() {
+        singlePanel = !singlePanel;
+        return singlePanel;
+    }
+
 
     ///////////////////////
     // Overridden methods //

--- a/src/main/java/com/mucommander/ui/main/menu/MainMenuBar.java
+++ b/src/main/java/com/mucommander/ui/main/menu/MainMenuBar.java
@@ -127,6 +127,7 @@ import com.mucommander.ui.action.impl.ToggleAutoSizeAction;
 import com.mucommander.ui.action.impl.ToggleCommandBarAction;
 import com.mucommander.ui.action.impl.ToggleHiddenFilesAction;
 import com.mucommander.ui.action.impl.ToggleShowFoldersFirstAction;
+import com.mucommander.ui.action.impl.ToggleSinglePanelAction;
 import com.mucommander.ui.action.impl.ToggleStatusBarAction;
 import com.mucommander.ui.action.impl.ToggleToolBarAction;
 import com.mucommander.ui.action.impl.ToggleTreeAction;
@@ -171,6 +172,8 @@ public class MainMenuBar extends JMenuBar implements ActionListener, MenuListene
     private JCheckBoxMenuItem toggleShowFoldersFirstItem;
     private JCheckBoxMenuItem toggleShowHiddenFilesItem;
     private JCheckBoxMenuItem toggleTreeItem;
+    private JCheckBoxMenuItem toggleSinglePanel;
+
     /* TODO branch private JCheckBoxMenuItem toggleBranchView; */
 
 
@@ -295,6 +298,7 @@ public class MainMenuBar extends JMenuBar implements ActionListener, MenuListene
         toggleShowFoldersFirstItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleShowFoldersFirstAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
         toggleShowHiddenFilesItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleHiddenFilesAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
         toggleTreeItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleTreeAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
+        toggleSinglePanel = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleSinglePanelAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
         /* TODO branch toggleBranchView = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleBranchViewAction.class, mainFrame), menuItemMnemonicHelper); */
 
         viewMenu.add(new JSeparator());
@@ -488,7 +492,9 @@ public class MainMenuBar extends JMenuBar implements ActionListener, MenuListene
             toggleShowHiddenFilesItem.setSelected(MuConfigurations.getPreferences().getVariable(MuPreference.SHOW_HIDDEN_FILES, MuPreferences.DEFAULT_SHOW_HIDDEN_FILES));
             toggleTreeItem.setSelected(activeTable.getFolderPanel().isTreeVisible());
             toggleToggleAutoSizeItem.setSelected(mainFrame.isAutoSizeColumnsEnabled());
-            /* TODO branch toggleBranchView.setSelected(activeTable.getFolderPanel().isBranchView()); */ 
+            toggleSinglePanel.setSelected(mainFrame.isSinglePanel());
+
+            /* TODO branch toggleBranchView.setSelected(activeTable.getFolderPanel().isBranchView()); */
         }
         else if(source==columnsMenu) {
             // Update the selected and enabled state of each column menu item.

--- a/src/main/resources/dictionary.properties
+++ b/src/main/resources/dictionary.properties
@@ -265,6 +265,7 @@ SelectLastRow.label = Select last file in current folder
 SplitEqually.label = Split equally
 SplitVertically.label = Split vertically
 SplitHorizontally.label = Split horizontally
+ToggleSinglePanel.label = Toggle single panel view
 ShowKeyboardShortcuts.label = Keyboard shortcuts
 GoToWebsite.label = Go to website
 GoToForums.label = Go to forums


### PR DESCRIPTION
Sometimes working on 13"/11" laptops with tiled apllictaion layout find myself wanting to switch mucommander to single panel cause some names are unreadable. I know that I can move separator but it is no so handy : drag left then drag right etc.  Did not find such functional already existed so implemented. It even saves previous separation ratio =)

Menu path:  "View" -> "Toggle single panel view"

To illustrate problem here are to pictures for illustration on 13". on 11 its even harder sometimes =)

![two_panel](https://cloud.githubusercontent.com/assets/19550062/15503420/79a983f6-21c2-11e6-93b0-eedc84d5bf5e.jpg)
![one_panel](https://cloud.githubusercontent.com/assets/19550062/15503421/79ae591c-21c2-11e6-9cf7-6d5c250e6fcf.jpg)
