### PR TITLE
Prevent switching to discrete graphics on macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ macAppBundle {
     icon = "package/osx/icon.icns"
     bundleAllowMixedLocalizations = "true"
     bundleExtras.put("NSHighResolutionCapable", "true")
+    bundleExtras.put("NSSupportsAutomaticGraphicsSwitching", "true")
     backgroundImage = "package/osx/bg.gif"
     backgroundImageWidth = 450
     backgroundImageHeight = 475


### PR DESCRIPTION
JRE uses hardware acceleration by default leading to background activation of discrete graphics
the corresponding setting in application bundle stops this switching
integrated graphics is now used instead which helps to avoid redundant power drain
see https://developer.apple.com/library/content/qa/qa1734/_index.html