### PR TITLE
Improvements to shell script gradlew

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -6,24 +6,34 @@
 ##
 ##############################################################################
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS=""
 
 APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
+APP_BASE_NAME="$(basename "$BASH_SOURCE")"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
 
 warn ( ) {
-    echo "$*"
+    echo "$*" >&2
 }
 
 die ( ) {
-    echo
-    echo "$*"
-    echo
+    echo >&2
+    echo "$*" >&2
+    echo >&2
     exit 1
+}
+
+is_var_set_and_not_empty ()
+{
+  if [ -z "${!1:-}" ]; then return 1; else return 0; fi
 }
 
 # OS specific support (must be 'true' or 'false').
@@ -44,7 +54,7 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched.
 if $cygwin ; then
-    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+    is_var_set_and_not_empty JAVA_HOME && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
 fi
 
 # Attempt to set APP_HOME
@@ -65,10 +75,10 @@ cd "`dirname \"$PRG\"`/" >&-
 APP_HOME="`pwd -P`"
 cd "$SAVED" >&-
 
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+CLASSPATH="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
 
 # Determine the Java command to use to start the JVM.
-if [ -n "$JAVA_HOME" ] ; then
+if is_var_set_and_not_empty JAVA_HOME ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
         # IBM's JDK on AIX uses strange locations for the executables
         JAVACMD="$JAVA_HOME/jre/sh/java"
@@ -83,7 +93,7 @@ location of your Java installation."
     fi
 else
     JAVACMD="java"
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    which "$JAVACMD" >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no '$JAVACMD' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
@@ -107,7 +117,7 @@ fi
 
 # For Darwin, add options to specify how the application appears in the dock
 if $darwin; then
-    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+    GRADLE_OPTS="${GRADLE_OPTS:-} \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -119,46 +129,39 @@ if $cygwin ; then
     ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
     SEP=""
     for dir in $ROOTDIRSRAW ; do
-        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        ROOTDIRS="${ROOTDIRS:-}$SEP$dir"
         SEP="|"
     done
+    # This pattern matches strings that start with an absolute path like "/usr".
+    # Paths embedded in an argument will be missed. For example, an argument like "--prefix=/usr" will not be converted to a Windows path.
     OURCYGPATTERN="(^($ROOTDIRS))"
     # Add a user-defined pattern to the cygpath arguments
-    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+    if is_var_set_and_not_empty GRADLE_CYGPATTERN; then
         OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
     fi
-    # Now convert the arguments - kludge to limit ourselves to /bin/sh
-    i=0
-    for arg in "$@" ; do
-        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
-        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
 
-        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
-            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
-        else
-            eval `echo args$i`="\"$arg\""
-        fi
-        i=$((i+1))
+    declare -a CONVERTED_ARGS
+    for arg in "$@" ; do
+      if [[ $arg =~ $OURCYGPATTERN ]]; then
+        CONVERTED_ARGS+=("$(cygpath --path --ignore --mixed "$arg")")
+      else
+        CONVERTED_ARGS+=("$arg")
+      fi
     done
-    case $i in
-        (0) set -- ;;
-        (1) set -- "$args0" ;;
-        (2) set -- "$args0" "$args1" ;;
-        (3) set -- "$args0" "$args1" "$args2" ;;
-        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
-        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
-        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
-        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
-        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
-        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
-    esac
+
+    set -- "${CONVERTED_ARGS[@]}"
+
+    if false; then
+      printf -v QUOTED_ARGS "%q  " "$@"
+      echo "Found $# arguments: $QUOTED_ARGS"
+    fi
 fi
 
 # Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {
     JVM_OPTS=("$@")
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+eval splitJvmOpts $DEFAULT_JVM_OPTS ${JAVA_OPTS:-} ${GRADLE_OPTS:-}
 JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
 exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"


### PR DESCRIPTION
- Make it more robust, so that it stops on error.
  In the past, this script would blindly carry on after a command failed.
- Error on undefined variables, so that it is harder to
  make mistakes when maintaining the script.
- Warnings and errors are now output to stderr instead of stdout.
- This script can now handle more than 9 command-line arguments on Cygwin.