### PR TITLE
#102: Store/Restore Single Panel View state on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin
 .project
 
 /bin
+/classes
 
 ### Gradle template
 .gradle

--- a/src/main/java/com/mucommander/conf/MuPreference.java
+++ b/src/main/java/com/mucommander/conf/MuPreference.java
@@ -75,8 +75,8 @@ public enum MuPreference {
 	LIST_HIDDEN_FILES(MuPreferences.LIST_HIDDEN_FILES),
 	SMB_LM_COMPATIBILITY(MuPreferences.SMB_LM_COMPATIBILITY),
 	SMB_USE_EXTENDED_SECURITY(MuPreferences.SMB_USE_EXTENDED_SECURITY),
-	SHOW_TAB_HEADER(MuPreferences.SHOW_SINGLE_TAB_HEADER);
-	
+	SHOW_TAB_HEADER(MuPreferences.SHOW_SINGLE_TAB_HEADER),
+	USE_SINGLE_PANEL_VIEW(MuPreferences.USE_SINGLE_PANEL_VIEW);
 	private String label;
 	
 	private MuPreference(String label) {

--- a/src/main/java/com/mucommander/conf/MuPreference.java
+++ b/src/main/java/com/mucommander/conf/MuPreference.java
@@ -75,8 +75,7 @@ public enum MuPreference {
 	LIST_HIDDEN_FILES(MuPreferences.LIST_HIDDEN_FILES),
 	SMB_LM_COMPATIBILITY(MuPreferences.SMB_LM_COMPATIBILITY),
 	SMB_USE_EXTENDED_SECURITY(MuPreferences.SMB_USE_EXTENDED_SECURITY),
-	SHOW_TAB_HEADER(MuPreferences.SHOW_SINGLE_TAB_HEADER),
-	USE_SINGLE_PANEL_VIEW(MuPreferences.USE_SINGLE_PANEL_VIEW);
+	SHOW_TAB_HEADER(MuPreferences.SHOW_SINGLE_TAB_HEADER);
 	private String label;
 	
 	private MuPreference(String label) {

--- a/src/main/java/com/mucommander/conf/MuPreferences.java
+++ b/src/main/java/com/mucommander/conf/MuPreferences.java
@@ -236,10 +236,6 @@ public class MuPreferences implements MuPreferencesAPI {
 	public static final String SHOW_SINGLE_TAB_HEADER			   = FILE_TABLE_SECTION + '.' + "show_single_tab_header";
 	/** Default value for 'Always show single tab header" */
 	public static final boolean DEFAULT_SHOW_TAB_HEADER            = false;
-	/** Control whether the single panel view should be used instead of the default two-panel view */
-	public static final String  USE_SINGLE_PANEL_VIEW              = FILE_TABLE_SECTION + '.' + "use_single_panel_view";
-	/** Default value for 'Toggle single panel view' option. */
-	public static final boolean DEFAULT_USE_SINGLE_PANEL_VIEW      = false;
 
 	/** Name of the root element's attribute that contains the version of muCommander used to write the CONFIGURATION file. */
 	static final String VERSION_ATTRIBUTE = "version";

--- a/src/main/java/com/mucommander/conf/MuPreferences.java
+++ b/src/main/java/com/mucommander/conf/MuPreferences.java
@@ -240,9 +240,6 @@ public class MuPreferences implements MuPreferencesAPI {
 	public static final String  USE_SINGLE_PANEL_VIEW              = FILE_TABLE_SECTION + '.' + "use_single_panel_view";
 	/** Default value for 'Show folders first' option. */
 	public static final boolean DEFAULT_USE_SINGLE_PANEL_VIEW      = false;
-	/** Controls whether symlinks should be followed when changing directory. */
-
-
 
 	/** Name of the root element's attribute that contains the version of muCommander used to write the CONFIGURATION file. */
 	static final String VERSION_ATTRIBUTE = "version";

--- a/src/main/java/com/mucommander/conf/MuPreferences.java
+++ b/src/main/java/com/mucommander/conf/MuPreferences.java
@@ -238,7 +238,7 @@ public class MuPreferences implements MuPreferencesAPI {
 	public static final boolean DEFAULT_SHOW_TAB_HEADER            = false;
 	/** Control whether the single panel view should be used instead of the default two-panel view */
 	public static final String  USE_SINGLE_PANEL_VIEW              = FILE_TABLE_SECTION + '.' + "use_single_panel_view";
-	/** Default value for 'Show folders first' option. */
+	/** Default value for 'Toggle single panel view' option. */
 	public static final boolean DEFAULT_USE_SINGLE_PANEL_VIEW      = false;
 
 	/** Name of the root element's attribute that contains the version of muCommander used to write the CONFIGURATION file. */

--- a/src/main/java/com/mucommander/conf/MuPreferences.java
+++ b/src/main/java/com/mucommander/conf/MuPreferences.java
@@ -235,7 +235,14 @@ public class MuPreferences implements MuPreferencesAPI {
 	/** Whether to always show the header of a single tab or not */
 	public static final String SHOW_SINGLE_TAB_HEADER			   = FILE_TABLE_SECTION + '.' + "show_single_tab_header";
 	/** Default value for 'Always show single tab header" */
-	public static final boolean DEFAULT_SHOW_TAB_HEADER	   = false;
+	public static final boolean DEFAULT_SHOW_TAB_HEADER            = false;
+	/** Control whether the single panel view should be used instead of the default two-panel view */
+	public static final String  USE_SINGLE_PANEL_VIEW              = FILE_TABLE_SECTION + '.' + "use_single_panel_view";
+	/** Default value for 'Show folders first' option. */
+	public static final boolean DEFAULT_USE_SINGLE_PANEL_VIEW      = false;
+	/** Controls whether symlinks should be followed when changing directory. */
+
+
 
 	/** Name of the root element's attribute that contains the version of muCommander used to write the CONFIGURATION file. */
 	static final String VERSION_ATTRIBUTE = "version";

--- a/src/main/java/com/mucommander/conf/MuSnapshot.java
+++ b/src/main/java/com/mucommander/conf/MuSnapshot.java
@@ -120,7 +120,9 @@ public class MuSnapshot {
     public static final String  HORIZONTAL_SPLIT_ORIENTATION       = "horizontal";
     /** Default split pane orientation. */
     public static final String  DEFAULT_SPLIT_ORIENTATION          = VERTICAL_SPLIT_ORIENTATION;
-    
+    /** Single panel view toggle state */
+    public static final String  SINGLE_PANEL_VIEW_TOGGLE_STATE     = "single_panel_view";
+
     // - Panels variables ----------------------------------------------------
     // -----------------------------------------------------------------------
     /** Section describing the dynamic information contained in the folder panels */
@@ -262,6 +264,15 @@ public class MuSnapshot {
     	return getWindowPropertiesSection(window) + "." + SPLIT_ORIENTATION;
     }
 
+    /**
+     * Returns snapshot property string for the state of the single panel view toggle for a given window
+     * @param window index of MainFrame
+     * @return the string representation of the toggle state property key
+     */
+    public static String getSinglePanelViewToggleState(int window) {
+        return getWindowPropertiesSection(window) + "." + SINGLE_PANEL_VIEW_TOGGLE_STATE;
+    }
+
 	/**
      * Returns the CONFIGURATION section corresponding to the specified {@link com.mucommander.ui.main.FolderPanel},
      * left or right one in the {@link com.mucommander.ui.main.MainFrame} at the given index.
@@ -275,7 +286,7 @@ public class MuSnapshot {
     }
 	
 	/**
-     * Returns the CONFIGURATION section corresponding to the specified {@link com.mucommander.ui.main.FoldersTreePanel},
+     * Returns the CONFIGURATION section corresponding to the specified {@link com.mucommander.ui.main.tree.FoldersTreePanel},
      * left or right one in the {@link com.mucommander.ui.main.MainFrame} at the given index.
      *
      * @param window index of MainFrame
@@ -323,7 +334,7 @@ public class MuSnapshot {
     }
     
     /**
-     * Returns the CONFIGURATION section that describes the sorting of the specified {@link com.mucommander.ui.main.FileTable},
+     * Returns the CONFIGURATION section that describes the sorting of the specified {@link com.mucommander.ui.main.table.FileTable},
      * left or right one in the {@link com.mucommander.ui.main.MainFrame} at the given index.
      * 
      * @param window index of MainFrame
@@ -622,7 +633,6 @@ public class MuSnapshot {
 
         // Save right panel dynamic properties
         setPanelAttributes(index, false, mainFrame.getRightPanel());
-
     }
     
     private void setPanelAttributes(int index, boolean isLeft, FolderPanel panel) {
@@ -696,7 +706,7 @@ public class MuSnapshot {
     	configuration.setVariable(MuSnapshot.getTreeVisiblityVariable(index, isLeft), panel.isTreeVisible());
         configuration.setVariable(MuSnapshot.getTreeWidthVariable(index, isLeft), panel.getTreeWidth());
     }
-    
+
     private void setWindowAttributes(int index, MainFrame currentMainFrame) {
         Rectangle bounds = currentMainFrame.getBounds();
         configuration.setVariable(getX(index), (int)bounds.getX());
@@ -708,5 +718,8 @@ public class MuSnapshot {
         // Note: the vertical/horizontal terminology used in muCommander is just the opposite of the one used
         // in JSplitPane which is anti-natural / confusing
     	configuration.setVariable(getSplitOrientation(index), currentMainFrame.getSplitPane().getOrientation()==JSplitPane.HORIZONTAL_SPLIT?MuSnapshot.VERTICAL_SPLIT_ORIENTATION:MuSnapshot.HORIZONTAL_SPLIT_ORIENTATION);
+
+        // Save single panel view toggle state
+        configuration.setVariable(getSinglePanelViewToggleState(index), currentMainFrame.isSinglePanel());
     }
 }

--- a/src/main/java/com/mucommander/ui/action/ActionManager.java
+++ b/src/main/java/com/mucommander/ui/action/ActionManager.java
@@ -209,7 +209,7 @@ public class ActionManager {
     	registerAction(new SplitFileAction.Descriptor(),            		new SplitFileAction.Factory());
     	registerAction(new SplitHorizontallyAction.Descriptor(),            new SplitHorizontallyAction.Factory());
     	registerAction(new SplitVerticallyAction.Descriptor(),              new SplitVerticallyAction.Factory());
-    	registerAction(new ToggleSinglePanelAction.Descriptor(),            new ToggleSinglePanelAction.Factory());
+    	registerAction(new ToggleUseSinglePanelAction.Descriptor(),            new ToggleUseSinglePanelAction.Factory());
     	registerAction(new StopAction.Descriptor(),                         new StopAction.Factory());
     	registerAction(new SwapFoldersAction.Descriptor(),       	        new SwapFoldersAction.Factory());
     	registerAction(new SwitchActiveTableAction.Descriptor(),            new SwitchActiveTableAction.Factory());

--- a/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
+++ b/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import javax.swing.KeyStroke;
 
 import com.mucommander.conf.MuConfigurations;
-import com.mucommander.conf.MuPreference;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
@@ -66,7 +65,7 @@ public class ToggleUseSinglePanelAction extends MuAction {
             showInactivePanel();
         }
 
-        MuConfigurations.getPreferences().setVariable(MuPreference.USE_SINGLE_PANEL_VIEW, isSinglePanelViewNow);
+        MuConfigurations.getSnapshot().setVariable("", mainFrame.isSinglePanel());
     }
 
     @Override

--- a/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
+++ b/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
@@ -65,6 +65,8 @@ public class ToggleUseSinglePanelAction extends MuAction {
             mainFrame.getSplitPane().setSplitRatio(previousRatio);
             showInactivePanel();
         }
+
+        MuConfigurations.getPreferences().setVariable(MuPreference.USE_SINGLE_PANEL_VIEW, isSinglePanelViewNow);
     }
 
     @Override

--- a/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
+++ b/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
@@ -22,8 +22,9 @@ import java.util.Map;
 
 import javax.swing.KeyStroke;
 
+import com.mucommander.conf.MuConfigurations;
+import com.mucommander.conf.MuPreference;
 import com.mucommander.ui.action.AbstractActionDescriptor;
-import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.ActionFactory;
@@ -33,12 +34,12 @@ import com.mucommander.ui.main.MainFrame;
 /**
  * Toggles isVisible state of the right panel, imitating single/two panel view switch.
  */
-public class ToggleSinglePanelAction extends MuAction {
+public class ToggleUseSinglePanelAction extends MuAction {
 
     private static final float TWO_PANELS_DEFAULT_RATIO = 0.5f;
     private float previousRatio = TWO_PANELS_DEFAULT_RATIO;
 
-    ToggleSinglePanelAction(MainFrame mainFrame, Map<String, Object> properties) {
+    ToggleUseSinglePanelAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -56,7 +57,6 @@ public class ToggleSinglePanelAction extends MuAction {
         // we want to restore old two panel ratio
         boolean isSinglePanelViewNow = mainFrame.toggleSinglePanel();
 
-        
         if (isSinglePanelViewNow) {
             previousRatio = mainFrame.getSplitPane().getSplitRatio();
             hideInactivePanel();
@@ -65,7 +65,6 @@ public class ToggleSinglePanelAction extends MuAction {
             mainFrame.getSplitPane().setSplitRatio(previousRatio);
             showInactivePanel();
         }
-
     }
 
     @Override
@@ -76,7 +75,7 @@ public class ToggleSinglePanelAction extends MuAction {
     public static class Factory implements ActionFactory {
 
         public MuAction createAction(MainFrame mainFrame, Map<String, Object> properties) {
-            return new ToggleSinglePanelAction(mainFrame, properties);
+            return new ToggleUseSinglePanelAction(mainFrame, properties);
         }
     }
 

--- a/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -266,11 +266,6 @@ public class MainFrame extends JFrame implements LocationListener {
 
         // Set the custom FocusTraversalPolicy that manages focus for both FolderPanel and their sub components.
         setFocusTraversalPolicy(new CustomFocusTraversalPolicy());
-
-        // Restore single panel view state
-        if(MuConfigurations.getPreferences().getVariable(MuPreference.USE_SINGLE_PANEL_VIEW, MuPreferences.DEFAULT_USE_SINGLE_PANEL_VIEW)) {
-            ActionManager.performAction(ToggleUseSinglePanelAction.Descriptor.ACTION_ID, this);
-        }
     }
 
     public MainFrame(ConfFileTableTab leftTab, FileTableConfiguration leftTableConf,

--- a/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -51,6 +51,7 @@ import com.mucommander.conf.MuSnapshot;
 import com.mucommander.ui.action.ActionKeymap;
 import com.mucommander.ui.action.ActionManager;
 import com.mucommander.ui.action.impl.CloseWindowAction;
+import com.mucommander.ui.action.impl.ToggleUseSinglePanelAction;
 import com.mucommander.ui.button.ToolbarMoreButton;
 import com.mucommander.ui.event.ActivePanelListener;
 import com.mucommander.ui.event.LocationEvent;
@@ -265,6 +266,10 @@ public class MainFrame extends JFrame implements LocationListener {
 
         // Set the custom FocusTraversalPolicy that manages focus for both FolderPanel and their subcomponents.
         setFocusTraversalPolicy(new CustomFocusTraversalPolicy());
+
+        if(MuConfigurations.getPreferences().getVariable(MuPreference.USE_SINGLE_PANEL_VIEW, MuPreferences.DEFAULT_USE_SINGLE_PANEL_VIEW)) {
+            ActionManager.performAction(ToggleUseSinglePanelAction.Descriptor.ACTION_ID, this);
+        }
     }
 
     public MainFrame(ConfFileTableTab leftTab, FileTableConfiguration leftTableConf,

--- a/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -267,6 +267,7 @@ public class MainFrame extends JFrame implements LocationListener {
         // Set the custom FocusTraversalPolicy that manages focus for both FolderPanel and their sub components.
         setFocusTraversalPolicy(new CustomFocusTraversalPolicy());
 
+        // Restore single panel view state
         if(MuConfigurations.getPreferences().getVariable(MuPreference.USE_SINGLE_PANEL_VIEW, MuPreferences.DEFAULT_USE_SINGLE_PANEL_VIEW)) {
             ActionManager.performAction(ToggleUseSinglePanelAction.Descriptor.ACTION_ID, this);
         }

--- a/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -261,10 +261,10 @@ public class MainFrame extends JFrame implements LocationListener {
 
         ActionKeymap.registerActions(this);
 
-        // Fire table change events on registered ActivePanelListener instances, to notify of the intial active table.
+        // Fire table change events on registered ActivePanelListener instances, to notify of the initial active table.
         fireActivePanelChanged(activeTable.getFolderPanel());
 
-        // Set the custom FocusTraversalPolicy that manages focus for both FolderPanel and their subcomponents.
+        // Set the custom FocusTraversalPolicy that manages focus for both FolderPanel and their sub components.
         setFocusTraversalPolicy(new CustomFocusTraversalPolicy());
 
         if(MuConfigurations.getPreferences().getVariable(MuPreference.USE_SINGLE_PANEL_VIEW, MuPreferences.DEFAULT_USE_SINGLE_PANEL_VIEW)) {

--- a/src/main/java/com/mucommander/ui/main/frame/DefaultMainFramesBuilder.java
+++ b/src/main/java/com/mucommander/ui/main/frame/DefaultMainFramesBuilder.java
@@ -23,6 +23,8 @@ import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.net.MalformedURLException;
 
+import com.mucommander.ui.action.ActionManager;
+import com.mucommander.ui.action.impl.ToggleUseSinglePanelAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,7 +140,12 @@ public class DefaultMainFramesBuilder extends MainFrameBuilder {
         }
 
         mainFrame.setBounds(new Rectangle(x, y, width, height));
-        
+
+        // Retrieve the Frame's SinglePanelView toggle state...
+        if (MuConfigurations.getSnapshot().getBooleanVariable(MuSnapshot.getSinglePanelViewToggleState(index))) {
+            ActionManager.performAction(ToggleUseSinglePanelAction.Descriptor.ACTION_ID, mainFrame);
+        }
+
         return mainFrame;
 	}
 	

--- a/src/main/java/com/mucommander/ui/main/menu/MainMenuBar.java
+++ b/src/main/java/com/mucommander/ui/main/menu/MainMenuBar.java
@@ -76,7 +76,6 @@ import com.mucommander.ui.action.impl.ExploreBookmarksAction;
 import com.mucommander.ui.action.impl.GoBackAction;
 import com.mucommander.ui.action.impl.GoForwardAction;
 import com.mucommander.ui.action.impl.GoToDocumentationAction;
-import com.mucommander.ui.action.impl.GoToForumsAction;
 import com.mucommander.ui.action.impl.GoToParentAction;
 import com.mucommander.ui.action.impl.GoToParentInBothPanelsAction;
 import com.mucommander.ui.action.impl.GoToParentInOtherPanelAction;
@@ -128,7 +127,7 @@ import com.mucommander.ui.action.impl.ToggleAutoSizeAction;
 import com.mucommander.ui.action.impl.ToggleCommandBarAction;
 import com.mucommander.ui.action.impl.ToggleHiddenFilesAction;
 import com.mucommander.ui.action.impl.ToggleShowFoldersFirstAction;
-import com.mucommander.ui.action.impl.ToggleSinglePanelAction;
+import com.mucommander.ui.action.impl.ToggleUseSinglePanelAction;
 import com.mucommander.ui.action.impl.ToggleStatusBarAction;
 import com.mucommander.ui.action.impl.ToggleToolBarAction;
 import com.mucommander.ui.action.impl.ToggleTreeAction;
@@ -173,7 +172,7 @@ public class MainMenuBar extends JMenuBar implements ActionListener, MenuListene
     private JCheckBoxMenuItem toggleShowFoldersFirstItem;
     private JCheckBoxMenuItem toggleShowHiddenFilesItem;
     private JCheckBoxMenuItem toggleTreeItem;
-    private JCheckBoxMenuItem toggleSinglePanel;
+    private JCheckBoxMenuItem toggleUseSinglePanel;
 
     /* TODO branch private JCheckBoxMenuItem toggleBranchView; */
 
@@ -299,7 +298,7 @@ public class MainMenuBar extends JMenuBar implements ActionListener, MenuListene
         toggleShowFoldersFirstItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleShowFoldersFirstAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
         toggleShowHiddenFilesItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleHiddenFilesAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
         toggleTreeItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleTreeAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
-        toggleSinglePanel = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleSinglePanelAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
+        toggleUseSinglePanel = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleUseSinglePanelAction.Descriptor.ACTION_ID, mainFrame), menuItemMnemonicHelper);
         /* TODO branch toggleBranchView = MenuToolkit.addCheckBoxMenuItem(viewMenu, ActionManager.getActionInstance(ToggleBranchViewAction.class, mainFrame), menuItemMnemonicHelper); */
 
         viewMenu.add(new JSeparator());
@@ -493,7 +492,7 @@ public class MainMenuBar extends JMenuBar implements ActionListener, MenuListene
             toggleShowHiddenFilesItem.setSelected(MuConfigurations.getPreferences().getVariable(MuPreference.SHOW_HIDDEN_FILES, MuPreferences.DEFAULT_SHOW_HIDDEN_FILES));
             toggleTreeItem.setSelected(activeTable.getFolderPanel().isTreeVisible());
             toggleToggleAutoSizeItem.setSelected(mainFrame.isAutoSizeColumnsEnabled());
-            toggleSinglePanel.setSelected(mainFrame.isSinglePanel());
+            toggleUseSinglePanel.setSelected(mainFrame.isSinglePanel());
 
             /* TODO branch toggleBranchView.setSelected(activeTable.getFolderPanel().isBranchView()); */
         }


### PR DESCRIPTION
Hi,

This PR resolves RFE #102.
I have added Preferences to MuPreferences. The preference is stored when the ToggleUseSinglePanelAction is performed. It is restored during MainFrame init, when the action is performed depending on the toggle state.

There is no PullRequest template, so I hope this suffices.

On a side note: this is my first ever contribution to an Open Source project and I'm looking forward to your feedback. Thanks for your quick responses so far, and keeping this project alive! Being an avid user of muCommander myself - this was quite fun. :)

BR,
Thomas
