### PR TITLE
Enable building with Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0'
+  }
+}
+
 plugins {
     id 'com.athaydes.osgi-run' version '1.6.0'
     id 'java'
@@ -7,7 +16,10 @@ plugins {
 
 compileJava.options.encoding = 'UTF-8'
 
-repositories.jcenter()
+repositories {
+    jcenter()
+    mavenCentral()
+}
 
 dependencies {
     osgiRuntime project('mucommander-core')
@@ -42,7 +54,34 @@ dependencies {
 
 runOsgi {
     configSettings = 'felix'
-    config += [ 'org.osgi.framework.system.packages.extra': 'sun.security.action,com.apple.eawt,com.apple.eio', 'felix.log.level': 1 ]
+    osgiMain = 'org.apache.felix:org.apache.felix.main:6.0.3'
+    config += [
+        'org.osgi.framework.system.packages.extra':
+            'sun.net.www,' +
+            'sun.misc,' +
+            'com.sun.tools.javac,' +
+            'sun.plugin.protocol,' + //optional
+            'com.sun.java.browser.net,' + //optional
+            'javax.annotation,' +
+            'weblogic,' +
+            'sun.tools.native2ascii,' +
+            'sun.rmi.rmic,' +
+            'org.tukaani,' +
+            'org.tukaani.xz,' +
+            'org.apache.harmony.luni.util,' +
+            'org.apache.env,' +
+            'kaffe.util,' +
+            'javax.mail.internet,' +
+            'javax.activation,' +
+            'gnu.classpath,' +
+            'gnu.gcj,' +
+            'com.sun.tools.javah,' +
+            'com.sun.tools.javah.oldjavah,' +
+            'sun.tools.javac,' +
+            'sun.security.action,' +
+            'com.apple.eawt,' +
+            'com.apple.eio',
+        'felix.log.level': 1 ]
 }
 
 allprojects {

--- a/mucommander-ar/build.gradle
+++ b/mucommander-ar/build.gradle
@@ -6,10 +6,8 @@
  * user guide available at https://docs.gradle.org/3.5/userguide/java_library_plugin.html
  */
 
-// Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+   id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,29 +20,19 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.ar'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.ar.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-ar',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.ar',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.ar.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-archiver/build.gradle
+++ b/mucommander-archiver/build.gradle
@@ -8,8 +8,7 @@
 
 // Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+   id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -24,29 +23,18 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'org.apache.tools.bzip2',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive.tar',
-            'com.mucommander.commons.file.archive.tar.provider',
-            'com.mucommander.commons.file.archive.zip',
-            'com.mucommander.commons.file.archive.zip.provider',
-            'com.mucommander.commons.io',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archiver'
-       }
+   bnd ('Bundle-Name': 'muCommander-archiver',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archiver',
+        'Specification-Title': 'muCommander',
+        'Specification-Vendor': 'Arik Hadas',
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-bzip2/build.gradle
+++ b/mucommander-bzip2/build.gradle
@@ -8,8 +8,7 @@
 
 // Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,29 +21,19 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.util',
-            'org.apache.tools.bzip2',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.bzip2'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.bzip2.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-bzip2',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.bzip2',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.bzip2.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-commons-collections/build.gradle
+++ b/mucommander-commons-collections/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories.jcenter()
@@ -12,21 +11,17 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with collection tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.collections'
-       }
+    bnd ('Bundle-Name': 'muCommander-commons-collection',
+         'Bundle-Vendor': 'muCommander',
+         'Bundle-Description': 'Collection related utilities',
+         'Bundle-DocURL': 'https://www.mucommander.com',
+         'Export-Package': 'com.mucommander.commons.collections',
+         'Specification-Title': "muCommander",
+         'Specification-Vendor': "Arik Hadas",
+         'Specification-Version': version,
+         'Implementation-Title': "muCommander",
+         'Implementation-Vendor': "Arik Hadas",
+         'Implementation-Version': revision.substring(0, 7),
+         'Build-Date': new Date().format('yyyyMMdd'),
+         'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-commons-conf/build.gradle
+++ b/mucommander-commons-conf/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories.jcenter()
@@ -12,27 +11,17 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.runtime',
-            'javax.xml.parsers',
-            'javax.xml.transform',
-            'javax.xml.transform.sax',
-            'javax.xml.transform.stream',
-            'org.osgi.framework',
-            'org.xml.sax',
-            'org.xml.sax.helpers'
-           instruction 'Export-Package', 'com.mucommander.commons.conf'
-       }
+    bnd ('Bundle-Name': 'muCommander-common-conf',
+         'Bundle-Vendor': 'muCommander',
+         'Bundle-Description': 'Configuration related utilities',
+         'Bundle-DocURL': 'https://www.mucommander.com',
+         'Export-Package': 'com.mucommander.commons.conf',
+         'Specification-Title': "muCommander",
+         'Specification-Vendor': "Arik Hadas",
+         'Specification-Version': version,
+         'Implementation-Title': "muCommander",
+         'Implementation-Vendor': "Arik Hadas",
+         'Implementation-Version': revision.substring(0, 7),
+         'Build-Date': new Date().format('yyyyMMdd'),
+         'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.26'
     compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.apache.ant:ant:1.10.5'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
 
     testCompile 'org.testng:testng:6.11'
     testCompile 'junit:junit:4.12'

--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -1,9 +1,11 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
-repositories.jcenter()
+repositories {
+    jcenter()
+//    maven { url "http://mvnrepository.com/artifact" }
+}
 
 dependencies {
     compile project(':mucommander-commons-io')
@@ -14,7 +16,7 @@ dependencies {
     compile 'net.java.dev.jna:jna-platform:4.4.0'
     compile 'org.slf4j:slf4j-api:1.7.26'
     compile 'commons-collections:commons-collections:3.2.2'
-    compile 'org.apache.ant:ant:1.10.5'
+    compile 'org.apache.ant:ant:1.10.6'
     compile 'org.osgi:osgi.core:7.0.0'
 
     testCompile 'org.testng:testng:6.11'
@@ -22,48 +24,28 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with file tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.conf',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.commons.util',
-            'org.apache.commons.collections.map',
-            'org.apache.tools.bzip2',
-            'org.osgi.framework',
-            'org.osgi.util.tracker',
-            'org.slf4j',
-            'org.xml.sax',
-            'org.xml.sax.helpers',
-            'javax.swing',
-            'javax.swing.filechooser',
-            'javax.swing.tree',
-            'javax.xml.parsers'
-           instruction 'Export-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.icon',
-            'com.mucommander.commons.file.icon.impl',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.file.protocol.local',
-            'com.mucommander.commons.file.util'
-            instruction 'Bundle-Activator', 'com.mucommander.commons.file.osgi.Activator'
-       }
+    bnd ('Bundle-Name': 'muCommander-commons-file',
+         'Bundle-Vendor': 'muCommander',
+         'Bundle-Description': 'Component with file-level utilities',
+         'Bundle-DocURL': 'https://www.mucommander.com',
+         'Bundle-Activator': 'com.mucommander.commons.file.osgi.Activator',
+         'Export-Package':
+            'com.mucommander.commons.file,' +
+            'com.mucommander.commons.file.archive,' +
+            'com.mucommander.commons.file.connection,' +
+            'com.mucommander.commons.file.filter,' +
+            'com.mucommander.commons.file.icon,' +
+            'com.mucommander.commons.file.icon.impl,' +
+            'com.mucommander.commons.file.osgi,' +
+            'com.mucommander.commons.file.protocol,' +
+            'com.mucommander.commons.file.protocol.local,' +
+            'com.mucommander.commons.file.util',
+         'Specification-Title': "muCommander",
+         'Specification-Vendor': "Arik Hadas",
+         'Specification-Version': version,
+         'Implementation-Title': "muCommander",
+         'Implementation-Vendor': "Arik Hadas",
+         'Implementation-Version': revision.substring(0, 7),
+         'Build-Date': new Date().format('yyyyMMdd'),
+         'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-commons-io/build.gradle
+++ b/mucommander-commons-io/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories.jcenter()
@@ -13,25 +12,16 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes("Specification-Title": "muCommander",
-                   "Specification-Vendor": "Arik Hadas",
-                   "Specification-Version": version,
-                   "Implementation-Title": "muCommander",
-                   "Implementation-Vendor": "Arik Hadas",
-                   "Implementation-Version": revision.substring(0, 7),
-                   "Build-Date": new Date().format('yyyyMMdd'),
-                   "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-        instruction 'Bundle-Vendor', 'muCommander'
-        instruction 'Bundle-Description', 'Library with I/O tools'
-        instruction 'Import-Package',
-         'com.ibm.icu.text',
-         'org.osgi.framework',
-         'org.slf4j'
-        instruction 'Export-Package',
-         'com.mucommander.commons.io',
-         'com.mucommander.commons.io.base64',
-         'com.mucommander.commons.io.bom',
-         'com.mucommander.commons.io.security'
-       }
+    bnd ('Bundle-Name': 'muCommander-commons-io',
+         'Bundle-Vendor': 'muCommander',
+         'Bundle-Description': 'Library with I/O tools',
+         'Export-Package': 'com.mucommander.commons.io, com.mucommander.commons.io.base64, com.mucommander.commons.io.bom, com.mucommander.commons.io.security',
+         'Specification-Title': "muCommander",
+         'Specification-Vendor': "Arik Hadas",
+         'Specification-Version': version,
+         'Implementation-Title': "muCommander",
+         'Implementation-Vendor': "Arik Hadas",
+         'Implementation-Version': revision.substring(0, 7),
+         'Build-Date': new Date().format('yyyyMMdd'),
+         'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-commons-runtime/build.gradle
+++ b/mucommander-commons-runtime/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories.jcenter()
@@ -11,22 +10,18 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with runtime tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.runtime'
-       }
+    bnd ('Bundle-Name': 'muCommander-commons-runtime',
+         'Bundle-Description': 'Runtime utilities',
+         'Bundle-Vendor': 'muCommander',
+         'Bundle-DocURL': 'https://www.mucommander.com',
+         'Export-Package': 'com.mucommander.commons.runtime',
+         'Specification-Title': "muCommander",
+         'Specification-Vendor': "Arik Hadas",
+         'Specification-Version': version,
+         'Implementation-Title': "muCommander",
+         'Implementation-Vendor': "Arik Hadas",
+         'Implementation-Version': revision.substring(0, 7),
+         'Build-Date': new Date().format('yyyyMMdd'),
+         'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-commons-util/build.gradle
+++ b/mucommander-commons-util/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories.jcenter()
@@ -12,21 +11,17 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with utility tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.util'
-       }
+    bnd ('Bundle-Name': 'muCommander-commons-utils',
+         'Bundle-Vendor': 'muCommander',
+         'Bundle-Description': 'Other utilities',
+         'Bundle-DocURL': 'https://www.mucommander.com',
+         'Export-Package': 'com.mucommander.commons.util',
+         'Specification-Title': "muCommander",
+         'Specification-Vendor': "Arik Hadas",
+         'Specification-Version': version,
+         'Implementation-Title': "muCommander",
+         'Implementation-Vendor': "Arik Hadas",
+         'Implementation-Version': revision.substring(0, 7),
+         'Build-Date': new Date().format('yyyyMMdd'),
+         'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile 'org.jmdns:jmdns:3.5.1'
     compile 'org.slf4j:slf4j-api:1.7.26'
     compile 'com.beust:jcommander:1.66'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
 
     compileOnly files('libs/java-extension.jar')
 

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -1,7 +1,8 @@
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
+
+apply plugin: 'java'
 
 repositories.jcenter()
 
@@ -30,70 +31,25 @@ dependencies {
 }
 
 jar {
-   manifest {
-       attributes("Specification-Title": "muCommander",
-                  "Specification-Vendor": "Arik Hadas",
-                  "Specification-Version": version,
-                  "Implementation-Title": "muCommander",
-                  "Implementation-Vendor": "Arik Hadas",
-                  "Implementation-Version": revision.substring(0, 7),
-                  "Build-Date": new Date().format('yyyyMMdd'),
-                  "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-       name = 'muCommander-core'
-       instruction 'Bundle-Vendor', 'muCommander'
-       instruction 'Bundle-Description', 'The core part of muCommander'
-       instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-       instruction 'Import-Package',
-        'ch.qos.logback.classic',
-        'ch.qos.logback.classic.spi',
-        'ch.qos.logback.core',
-        'ch.qos.logback.core.encoder',
-        'com.mucommander.commons.collections',
-        'com.mucommander.commons.conf',
-        'com.mucommander.commons.file',
-        'com.mucommander.commons.file.archive',
-        'com.mucommander.commons.file.archiver',
-        'com.mucommander.commons.file.connection',
-        'com.mucommander.commons.file.filter',
-        'com.mucommander.commons.file.icon',
-        'com.mucommander.commons.file.icon.impl',
-        'com.mucommander.commons.file.protocol',
-        'com.mucommander.commons.file.protocol.local',
-        'com.mucommander.commons.file.util',
-        'com.mucommander.commons.io',
-        'com.mucommander.commons.io.base64',
-        'com.mucommander.commons.io.bom',
-        'com.mucommander.commons.io.security',
-        'com.mucommander.commons.util',
-        'com.mucommander.commons.runtime',
-        'javax.jmdns',
-        'javax.swing',
-        'javax.swing.border',
-        'javax.swing.event',
-        'javax.swing.filechooser',
-        'javax.swing.plaf',
-        'javax.swing.plaf.basic',
-        'javax.swing.table',
-        'javax.swing.text',
-        'javax.swing.tree',
-        'javax.xml.parsers',
-        'org.osgi.framework',
-        'org.osgi.util.tracker',
-        'org.slf4j',
-        'org.xml.sax',
-        'org.xml.sax.helpers'
-       instruction 'DynamicImport-Package',
-        'com.apple.eawt',
-        'com.apple.eio',
-        'sun.security.action'
-       instruction 'Export-Package',
-        'com.mucommander.text',
-        'com.mucommander.ui.dialog',
-        'com.mucommander.ui.dialog.server',
-        'com.mucommander.ui.encoding',
-        'com.mucommander.ui.main',
-        'com.mucommander.ui.main.osgi',
-        'com.mucommander.process'
-       instruction 'Bundle-Activator', 'com.mucommander.Activator'
-   }
+   bnd ('Bundle-Name': 'muCommander-core',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'The core part of muCommander',
+        'Bundle-DocURL': 'https://www.mucommander.com',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml",
+        'Import-Package': 'com.apple.*;resolution:=dynamic,sun.security.action;resolution:=dynamic,*',
+        'Export-Package':
+            'com.mucommander.process,' +
+            'com.mucommander.text,' +
+            'com.mucommander.ui.dialog,' +
+            'com.mucommander.ui.dialog.server,' +
+            'com.mucommander.ui.encoding,' +
+            'com.mucommander.ui.main',
+        'Bundle-Activator': 'com.mucommander.Activator')
 }

--- a/mucommander-ftp/build.gradle
+++ b/mucommander-ftp/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -17,7 +15,6 @@ dependencies {
     compile project(':mucommander-core')
     compile 'commons-net:commons-net:3.6'
 
-    // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 
     testCompile 'org.testng:testng:6.11'
@@ -28,36 +25,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.encoding',
-            'com.mucommander.ui.main',
-            'javax.swing',
-            'org.apache.commons.net.ftp',
-            'org.apache.commons.net.ftp.parser',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.ftp'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.ftp.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-ftp',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.ftp',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.ftp.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-gzip/build.gradle
+++ b/mucommander-gzip/build.gradle
@@ -6,10 +6,8 @@
  * user guide available at https://docs.gradle.org/3.5/userguide/java_library_plugin.html
  */
 
-// Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,28 +20,19 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.gzip'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.gzip.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-gzip',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.gzip',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.gzip.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-hadoop/build.gradle
+++ b/mucommander-hadoop/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile project(':mucommander-commons-file')
     compile project(':mucommander-core')
     compile 'org.apache.hadoop:hadoop-core:0.20.2'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
     compile 'commons-logging:commons-logging:1.2'
 
     // Use JUnit test framework

--- a/mucommander-hadoop/build.gradle
+++ b/mucommander-hadoop/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -29,37 +27,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Plugin for HTTP protocol'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'javax.net.ssl',
-            'javax.swing',
-            'org.apache.hadoop.conf',
-            'org.apache.hadoop.fs',
-            'org.apache.hadoop.fs.permission',
-            'org.apache.hadoop.security',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.hadoop'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.hadoop.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-hadoop',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Plugin for HTTP protocol',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.hadoop',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.hadoop.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-http/build.gradle
+++ b/mucommander-http/build.gradle
@@ -15,7 +15,7 @@ plugins {
 dependencies {
     compile project(':mucommander-commons-file')
     compile project(':mucommander-core')
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
 
     testCompile 'org.testng:testng:6.11'
     testCompile project(':mucommander-commons-file')

--- a/mucommander-http/build.gradle
+++ b/mucommander-http/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -25,33 +23,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Plugin for HTTP protocol'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'javax.net.ssl',
-            'javax.swing',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.protocol.http'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.http.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-http',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Plugin for HTTP protocol',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.protocol.http',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.http.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-iso/build.gradle
+++ b/mucommander-iso/build.gradle
@@ -8,8 +8,7 @@
 
 // Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+   id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,29 +21,19 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.iso'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.iso.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-iso',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.iso',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.iso.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-libguestfs/build.gradle
+++ b/mucommander-libguestfs/build.gradle
@@ -7,8 +7,7 @@
  */
 
 plugins {
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -19,32 +18,21 @@ dependencies {
     runtime files('/usr/share/java/libguestfs.jar')
 }
 
-// In this section you declare where to find the dependencies of your project
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.util',
-            'com.redhat.et.libguestfs',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.libguestfs'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.libguestfs.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-libguestfs',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.libguestfs',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.libguestfs.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-libguestfs/build.gradle
+++ b/mucommander-libguestfs/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     compile project(':mucommander-commons-file')
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
     // TODO: find a way not to duplicate the following java-binding
     compileOnly files('libs/libguestfs.jar')
     runtime files('/usr/share/java/libguestfs.jar')

--- a/mucommander-lst/build.gradle
+++ b/mucommander-lst/build.gradle
@@ -8,8 +8,7 @@
 
 // Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,28 +21,19 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.lst'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.lst.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-lst',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.lst',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.lst.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-nfs/build.gradle
+++ b/mucommander-nfs/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 configurations {
@@ -34,36 +32,19 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       from { configurations.library.collect { it.isDirectory() ? it : zipTree(it) } }
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.encoding',
-            'com.mucommander.ui.main',
-            'javax.swing',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.nfs'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.nfs.Activator'
-       }
+   from { configurations.library.collect { it.isDirectory() ? it : zipTree(it) } }
+   bnd ('Bundle-Name': 'muCommander-nfs',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.nfs',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.nfs.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-ovirt/build.gradle
+++ b/mucommander-ovirt/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile project(':mucommander-commons-util')
     compile project(':mucommander-core')
     compile 'org.ovirt.engine.api:sdk:4.2.1'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
 
     testCompile 'org.testng:testng:6.11'
     testCompile files(project(':mucommander-commons-file').sourceSets.test.output)

--- a/mucommander-ovirt/build.gradle
+++ b/mucommander-ovirt/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -27,40 +25,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Plugin for browsing/uploading/downloading virtual disks from oVirt'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.file.util',
-            'com.mucommander.commons.file.protocol.http',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.commons.util',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'javax.net.ssl',
-            'javax.swing',
-            'org.osgi.framework',
-            'org.ovirt.engine.sdk4',
-            'org.ovirt.engine.sdk4.internal.containers',
-            'org.ovirt.engine.sdk4.services',
-            'org.ovirt.engine.sdk4.types',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.ovirt'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.ovirt.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-oVirt',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Plugin for browsing/uploading/downloading virtual disks from oVirt',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.ovirt',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.ovirt.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-rar/build.gradle
+++ b/mucommander-rar/build.gradle
@@ -18,7 +18,7 @@ configurations {
 
 dependencies {
     compile project(':mucommander-commons-file')
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
 
     // TODO: set this dependency properly
     compileOnly 'com.github.junrar:junrar:3.0.0'

--- a/mucommander-rar/build.gradle
+++ b/mucommander-rar/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 configurations {
@@ -19,10 +17,8 @@ configurations {
 dependencies {
     compile project(':mucommander-commons-file')
     compile 'org.osgi:osgi.core:7.0.0'
-
-    // TODO: set this dependency properly
-    compileOnly 'com.github.junrar:junrar:3.0.0'
-    library 'com.github.junrar:junrar:3.0.0'
+    compile 'org.apache.commons:commons-vfs2:2.3'
+    compile 'com.github.junrar:junrar:4.0.0'
 
     testCompile 'org.testng:testng:6.11'
 }
@@ -31,30 +27,19 @@ dependencies {
 repositories.jcenter()
 
 jar {
-    from { configurations.library.collect { it.isDirectory() ? it : zipTree(it) } }
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            //'com.github.junrar',
-            //'com.github.junrar.exception',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.rar'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.rar.Activator'
-       }
+   from { configurations.library.collect { it.isDirectory() ? it : zipTree(it) } }
+   bnd ('Bundle-Name': 'muCommander-rar',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.rar',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.rar.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-registry/build.gradle
+++ b/mucommander-registry/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile project(':mucommander-core')
     compile project(':mucommander-tar')
     compile 'org.ovirt.engine.api:sdk:4.2.1'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
     compile 'com.googlecode.json-simple:json-simple:1.1.1'
 
     testCompile 'org.testng:testng:6.11'

--- a/mucommander-registry/build.gradle
+++ b/mucommander-registry/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -29,44 +27,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.archive.tar',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.file.util',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.commons.util',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'com.mucommander.process',
-            'javax.net.ssl',
-            'javax.swing',
-            'org.json.simple',
-            'org.json.simple.parser',
-            'org.osgi.framework',
-            'org.ovirt.engine.sdk4',
-            'org.ovirt.engine.sdk4.internal.containers',
-            'org.ovirt.engine.sdk4.services',
-            'org.ovirt.engine.sdk4.types',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.registry'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.registry.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-registry', 
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.registry',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.registry.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-s3/build.gradle
+++ b/mucommander-s3/build.gradle
@@ -7,19 +7,17 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
     compile project(':mucommander-commons-file')
     compile project(':mucommander-core')
     compile 'net.java.dev.jets3t:jets3t:0.9.4'
-    compile group: 'commons-logging', name: 'commons-logging', version: '1.2'
-    compile group: 'javax.xml', name: 'jaxrpc-api', version: '1.1'
-    compile group: 'apache-bsf', name: 'bsf', version: '2.4.0'
-    compile group: 'javax.jms', name: 'jms', version: '1.1'
+    compile 'commons-logging:commons-logging:1.2'
+    compile 'javax.xml:jaxrpc-api:1.1'
+    compile 'javax.jms:jms:1.1'
+    compile 'org.glassfish:javax.xml.soap:10.0-b28'
     compile files('libs/mail.osgi-1.4.jar')
 
     testCompile 'org.testng:testng:6.11'
@@ -31,39 +29,18 @@ repositories.jcenter()
 repositories.mavenCentral()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'javax.swing',
-            'javax.xml.rpc',
-            'org.jets3t.service.impl.rest.httpclient',
-            'org.jets3t.service',
-            'org.jets3t.service.model',
-            'org.jets3t.service.security',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'DynamicImport-Package',
-            'com.sun.java.browser.net'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.s3'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.s3.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-s3',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.s3',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.s3.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-sevenzip/build.gradle
+++ b/mucommander-sevenzip/build.gradle
@@ -6,10 +6,8 @@
  * user guide available at https://docs.gradle.org/3.5/userguide/java_library_plugin.html
  */
 
-// Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+   id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,28 +20,19 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.file.archive.sevenzip'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.sevenzip.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-7z',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.file.archive.sevenzip',
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.sevenzip.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }
 

--- a/mucommander-sftp/build.gradle
+++ b/mucommander-sftp/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile project(':mucommander-core')
     compile 'com.jcraft:jsch:0.1.53'
     compile 'com.jcraft:jzlib:1.1.3'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compile 'org.osgi:osgi.core:7.0.0'
 
     testCompile 'org.testng:testng:6.11'
     testCompile files(project(':mucommander-commons-file').sourceSets.test.output)

--- a/mucommander-sftp/build.gradle
+++ b/mucommander-sftp/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -27,33 +25,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.jcraft.jsch',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'javax.swing',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.sftp'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.sftp.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-sftp',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.sftp',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.sftp.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-smb/build.gradle
+++ b/mucommander-smb/build.gradle
@@ -7,9 +7,7 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -28,36 +26,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.encoding',
-            'com.mucommander.ui.main',
-            'javax.swing',
-            'jcifs.smb',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.smb'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.smb.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-smb',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.smb',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.smb.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-tar/build.gradle
+++ b/mucommander-tar/build.gradle
@@ -8,8 +8,7 @@
 
 // Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+   id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -22,32 +21,21 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.util',
-            'org.apache.tools.bzip2',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package',
-            'com.mucommander.commons.file.archive.tar',
-            'com.mucommander.commons.file.archive.tar.provider'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.tar.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-tar',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package':
+            'com.mucommander.commons.file.archive.tar,' +
+            'com.mucommander.commons.file.archive.tar.provider',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml",
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.tar.Activator')
 }
 

--- a/mucommander-vsphere/build.gradle
+++ b/mucommander-vsphere/build.gradle
@@ -7,15 +7,15 @@
  */
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
     compile project(':mucommander-commons-file')
     compile project(':mucommander-core')
     compile 'javax.xml.ws:jaxws-api:2.2.12'
+
+    runtime 'javax.jws:javax.jws-api:1.1'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
@@ -27,36 +27,18 @@ dependencies {
 repositories.jcenter()
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.connection',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.file.protocol',
-            'com.mucommander.commons.file.util',
-            'com.mucommander.commons.runtime',
-            'com.mucommander.text',
-            'com.mucommander.ui.dialog.server',
-            'com.mucommander.ui.main',
-            'com.vmware.vim25',
-            'javax.swing',
-            'javax.xml.soap',
-            'javax.xml.ws.soap',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package', 'com.mucommander.commons.protocol.vsphere'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.protocol.vsphere.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-vSphere',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package': 'com.mucommander.commons.protocol.vsphere',
+        'Bundle-Activator': 'com.mucommander.commons.file.protocol.vsphere.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml")
 }

--- a/mucommander-zip/build.gradle
+++ b/mucommander-zip/build.gradle
@@ -8,8 +8,7 @@
 
 // Apply the java-library plugin to add support for Java Library
 plugins {
-   id 'java-library'
-   id 'osgi'
+   id 'biz.aQute.bnd.builder'
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -24,31 +23,21 @@ dependencies {
 }
 
 jar {
-       manifest {
-           attributes("Specification-Title": "muCommander",
-                      "Specification-Vendor": "Arik Hadas",
-                      "Specification-Version": version,
-                      "Implementation-Title": "muCommander",
-                      "Implementation-Vendor": "Arik Hadas",
-                      "Implementation-Version": revision.substring(0, 7),
-                      "Build-Date": new Date().format('yyyyMMdd'),
-                      "Build-URL": "http://www.mucommander.com/version/nightly.xml")
-           instruction 'Bundle-Vendor', 'muCommander'
-           instruction 'Bundle-Description', 'Library with configuration tools'
-           instruction 'Bundle-DocURL', 'http://www.mucommander.com'
-           instruction 'Import-Package',
-            'com.mucommander.commons.file',
-            'com.mucommander.commons.file.archive',
-            'com.mucommander.commons.file.filter',
-            'com.mucommander.commons.file.osgi',
-            'com.mucommander.commons.io',
-            'com.mucommander.commons.util',
-            'org.osgi.framework',
-            'org.slf4j'
-           instruction 'Export-Package',
-            'com.mucommander.commons.file.archive.zip',
-            'com.mucommander.commons.file.archive.zip.provider'
-           instruction 'Bundle-Activator', 'com.mucommander.commons.file.archive.zip.Activator'
-       }
+   bnd ('Bundle-Name': 'muCommander-zip',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library with configuration tools',
+        'Bundle-DocURL': 'http://www.mucommander.com',
+        'Export-Package':
+            'com.mucommander.commons.file.archive.zip,' +
+            'com.mucommander.commons.file.archive.zip.provider',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-URL': "http://www.mucommander.com/version/nightly.xml",
+        'Bundle-Activator': 'com.mucommander.commons.file.archive.zip.Activator')
 }
 


### PR DESCRIPTION
The currently used OSGi plugin [is deprecated](https://docs.gradle.org/current/userguide/osgi_plugin.html) and the default version of the OSGi framework used by osgi-run does not work with recent Java versions. Therefore, switching to the [Bnd](https://github.com/bndtools/bnd/blob/master/biz.aQute.bnd.gradle/README.md#gradle-plugin-for-workspace-builds) and updating the OSGi framework (Apache Felix) to version 6.0.3. 