### PR TITLE
Fix Libguestfs plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 runOsgi {
     configSettings = 'felix'
     osgiMain = 'org.apache.felix:org.apache.felix.main:6.0.3'
+    javaArgs = '-Djava.library.path=/usr/local/lib' // for Libguestfs
     config += [
         'org.osgi.framework.system.packages.extra':
             'sun.net.www,' +

--- a/mucommander-libguestfs/build.gradle
+++ b/mucommander-libguestfs/build.gradle
@@ -13,9 +13,7 @@ plugins {
 dependencies {
     compile project(':mucommander-commons-file')
     compile 'org.osgi:osgi.core:7.0.0'
-    // TODO: find a way not to duplicate the following java-binding
-    compileOnly files('libs/libguestfs.jar')
-    runtime files('/usr/share/java/libguestfs.jar')
+    compile files('libs/libguestfs.jar')
 }
 
 repositories.jcenter()


### PR DESCRIPTION
This PR solves two problems:
1. That Libguestfs jar file may be named differently in `/usr/share/java` and thus the OSGi bundle is not created properly.
2. Libguestfs is not provided with the path to the JNI layer of the Java binding.