### PR TITLE
Fix some issues with S3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,12 @@ runOsgi {
             'com.apple.eawt,' +
             'com.apple.eio',
         'felix.log.level': 1 ]
+    wrapInstructions {
+        manifest("httpclient.*") {
+            // enable httpclient to instantiate factories that reside in jets3t
+            instruction 'DynamicImport-Package', 'org.jets3t.service.utils', '*'
+        }
+    }
 }
 
 allprojects {

--- a/mucommander-s3/src/main/java/com/mucommander/commons/file/protocol/s3/S3ProtocolProvider.java
+++ b/mucommander-s3/src/main/java/com/mucommander/commons/file/protocol/s3/S3ProtocolProvider.java
@@ -50,9 +50,9 @@ public class S3ProtocolProvider implements ProtocolProvider {
         String bucketName;
 
         if(instantiationParams.isEmpty()) {
-        	service = new RestS3Service(new AWSCredentials(credentials.getLogin(), credentials.getPassword()));
-        	Jets3tProperties props = new Jets3tProperties();
-        	props.setProperty("s3service.s3-endpoint", url.getHost());
+            Jets3tProperties props = new Jets3tProperties();
+            props.setProperty("s3service.s3-endpoint", url.getHost());
+            service = new RestS3Service(new AWSCredentials(credentials.getLogin(), credentials.getPassword()), null, null, props);
         }
         else {
             service = (S3Service)instantiationParams.get("service");


### PR DESCRIPTION
- Propagate the provided server to `jets3t`, otherwise it always defaults to `s3.amazonaws.com`
- Enable `httpclient` to access the `org.jets3t.service.utils` package in `jets3t`

Still need to check the authentication process.