### PR TITLE
Viewer for binary data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     osgiRuntime project('mucommander-protocol-registry')
     osgiRuntime project('mucommander-protocol-ovirt')
     osgiRuntime project('mucommander-format-libguestfs') // Note that this is a work-in-progress
+
+    osgiRuntime project('mucommander-viewer-text')
+    osgiRuntime project('mucommander-viewer-image')
+    osgiRuntime project('mucommander-viewer-binary')
 }
 
 createBundlesDir.doLast {

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compileOnly project(':mucommander-process')
     compileOnly project(':mucommander-translator')
     compileOnly project(':mucommander-protocol-api')
+    compileOnly project(':mucommander-viewer-api')
 
     compile 'ch.qos.logback:logback-core:1.2.3'
     compile 'ch.qos.logback:logback-classic:1.2.3'
@@ -48,9 +49,13 @@ jar {
         'Export-Package':
             'com.mucommander.process,' +
             'com.mucommander.text,' +
+            'com.mucommander.osgi,' +
             'com.mucommander.ui.dialog,' +
             'com.mucommander.ui.dialog.server,' +
             'com.mucommander.ui.encoding,' +
+            'com.mucommander.ui.theme,' +
+            'com.mucommander.snapshot,' +
+            'com.mucommander.ui.viewer,' +
             'com.mucommander.ui.main',
         'Bundle-Activator': 'com.mucommander.Activator')
 }

--- a/mucommander-core/src/main/java/com/mucommander/Activator.java
+++ b/mucommander-core/src/main/java/com/mucommander/Activator.java
@@ -17,6 +17,8 @@
  */
 package com.mucommander;
 
+import com.mucommander.osgi.FileEditorServiceTracker;
+import com.mucommander.osgi.FileViewerServiceTracker;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -39,6 +41,8 @@ public class Activator implements BundleActivator {
 
     private ProtocolPanelProviderTracker protocolPanelTracker;
     private TranslationTracker translationTracker;
+    private FileViewerServiceTracker viewersTracker;
+    private FileEditorServiceTracker editorsTracker;
 
     /** Registered shutdown-hook */
     private ShutdownHook shutdownHook;
@@ -53,6 +57,10 @@ public class Activator implements BundleActivator {
         protocolPanelTracker.open();
         translationTracker = new TranslationTracker(context);
         translationTracker.open();
+        viewersTracker = new FileViewerServiceTracker(context);
+        viewersTracker.open();
+        editorsTracker = new FileEditorServiceTracker(context);
+        editorsTracker.open();
 
         // Traps VM shutdown
         Runtime.getRuntime().addShutdownHook(shutdownHook = new ShutdownHook());
@@ -64,6 +72,8 @@ public class Activator implements BundleActivator {
         LOGGER.debug("stopping");
         protocolPanelTracker.close();
         translationTracker.close();
+        viewersTracker.close();
+        editorsTracker.close();
         // if the activator performs the shutdown tasks, no need for the shutdown-hook
         if (ShutdownHook.performShutdownTasks())
             Runtime.getRuntime().removeShutdownHook(shutdownHook);

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileEditorService.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileEditorService.java
@@ -1,0 +1,31 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.osgi;
+
+import com.mucommander.commons.file.AbstractFile;
+
+/**
+ * TODO: Interface for file editor service.
+ *
+ * @author Miroslav Hajda
+ */
+public interface FileEditorService {
+
+    boolean canEditFile(AbstractFile file);
+
+}

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileEditorServiceTracker.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileEditorServiceTracker.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.osgi;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registration tracker for file editor service.
+ *
+ * @author hajdam
+ */
+public class FileEditorServiceTracker extends ServiceTracker<FileEditorService, FileEditorService> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileEditorServiceTracker.class);
+    
+    private static final List<FileEditorService> SERVICES = new ArrayList<>();
+
+    public FileEditorServiceTracker(BundleContext context) {
+        super(context, FileEditorService.class, null);
+
+//        context.getAllServiceReferences(FileEditorService.class, "");
+    }
+
+    @Override
+    public FileEditorService addingService(ServiceReference<FileEditorService> reference) {
+        FileEditorService service = super.addingService(reference);
+        SERVICES.add(service);
+//        EditorRegistrar.registerFileEditor(null);
+//        FileFactory.registerArchiveFormat(service.getProvider());
+        LOGGER.info("FileEditorService is registered: " + service);
+        return service;
+    }
+
+    @Override
+    public void removedService(ServiceReference<FileEditorService> reference, FileEditorService service) {
+        // EditorRegistrar.unregisterFileEditor(null);
+        super.removedService(reference, service);
+        SERVICES.add(service);
+        LOGGER.info("FileFormatService is unregistered: " + service);
+    }
+
+    public static List<FileEditorService> getEditorServices() {
+        return SERVICES;
+    }
+}

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileEditorServiceTracker.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileEditorServiceTracker.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Registration tracker for file editor service.
  *
- * @author hajdam
+ * @author Miroslav Hajda
  */
 public class FileEditorServiceTracker extends ServiceTracker<FileEditorService, FileEditorService> {
 

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerService.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerService.java
@@ -63,9 +63,9 @@ public interface FileViewerService {
     boolean canViewFile(AbstractFile file) throws WarnUserException;
 
     /**
-     * Returns a new instance of {@link FileViewer2}.
+     * Returns a new instance of {@link FileViewerWrapper}.
      *
-     * @return a new instance of {@link FileViewer2}.
+     * @return a new instance of {@link FileViewerWrapper}.
      */
     FileViewerWrapper createFileViewer();
 }

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerService.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerService.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.osgi;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.viewer.FileViewerWrapper;
+import com.mucommander.viewer.WarnUserException;
+
+/**
+ * Interface for file viewer service.
+ *
+ * @author Miroslav Hajda
+ */
+public interface FileViewerService {
+
+    /**
+     * Returns tab title for viewer.
+     *
+     * @return tab title
+     */
+    String getTabTitle();
+
+    /**
+     * Returns order priority.
+     *
+     * Reference viewers use:<br>
+     * 20 - image<br>
+     * 10 - text<br>
+     * 0 - binary
+     *
+     * @return order priority
+     */
+    int getOrderPriority();
+
+    /**
+     * Returns <code>true</code> if this factory can create a file viewer for
+     * the specified file.
+     * <p>
+     * The FileEditor may base its decision strictly upon the file's name and
+     * its extension or may wish to read some of the file and compare it to a
+     * magic number.
+     * </p>
+     *
+     * @param file file for which a viewer must be created.
+     * @return <code>true</code> if this factory can create a file viewer for
+     * the specified file.
+     */
+    boolean canViewFile(AbstractFile file) throws WarnUserException;
+
+    /**
+     * Returns a new instance of {@link FileViewer2}.
+     *
+     * @return a new instance of {@link FileViewer2}.
+     */
+    FileViewerWrapper createFileViewer();
+}

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
@@ -66,6 +66,6 @@ public class FileViewerServiceTracker extends ServiceTracker<FileViewerService, 
 
     private static int compareServices(FileViewerService service1, FileViewerService service2) {
         return service1.getOrderPriority() == service2.getOrderPriority() ? 0
-                : service1.getOrderPriority() > service2.getOrderPriority() ? 1 : -1;
+                : service1.getOrderPriority() < service2.getOrderPriority() ? 1 : -1;
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.osgi;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registration tracker for file viewer service.
+ *
+ * @author hajdam
+ */
+public class FileViewerServiceTracker extends ServiceTracker<FileViewerService, FileViewerService> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileViewerServiceTracker.class);
+
+    private static final List<FileViewerService> SERVICES = new ArrayList<>();
+
+    public FileViewerServiceTracker(BundleContext context) {
+        super(context, FileViewerService.class, null);
+    }
+
+    @Override
+    public FileViewerService addingService(ServiceReference<FileViewerService> reference) {
+        FileViewerService service = super.addingService(reference);
+        FileViewerServiceTracker.addViewerService(service);
+        LOGGER.info("FileViewerService is registered: " + service);
+        return service;
+    }
+
+    @Override
+    public void removedService(ServiceReference<FileViewerService> reference, FileViewerService service) {
+        super.removedService(reference, service);
+        SERVICES.remove(service);
+        LOGGER.info("FileViewerService is unregistered: " + service);
+    }
+
+    private static void addViewerService(FileViewerService service) {
+        int index = 0;
+        int orderPriority = service.getOrderPriority();
+        while (index < SERVICES.size() && orderPriority < SERVICES.get(index).getOrderPriority())
+        {
+            index++;
+        }
+        SERVICES.add(index, service);
+    }
+            
+    public static List<FileViewerService> getViewerServices() {
+        return SERVICES;
+    }
+}

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
@@ -56,16 +56,16 @@ public class FileViewerServiceTracker extends ServiceTracker<FileViewerService, 
     }
 
     private static void addViewerService(FileViewerService service) {
-        int index = 0;
-        int orderPriority = service.getOrderPriority();
-        while (index < SERVICES.size() && orderPriority < SERVICES.get(index).getOrderPriority())
-        {
-            index++;
-        }
-        SERVICES.add(index, service);
+        SERVICES.add(service);
+        SERVICES.sort(FileViewerServiceTracker::compareServices);
     }
-            
+
     public static List<FileViewerService> getViewerServices() {
         return SERVICES;
+    }
+
+    private static int compareServices(FileViewerService service1, FileViewerService service2) {
+        return service1.getOrderPriority() == service2.getOrderPriority() ? 0
+                : service1.getOrderPriority() > service2.getOrderPriority() ? 1 : -1;
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
+++ b/mucommander-core/src/main/java/com/mucommander/osgi/FileViewerServiceTracker.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Registration tracker for file viewer service.
  *
- * @author hajdam
+ * @author Miroslav Hajda
  */
 public class FileViewerServiceTracker extends ServiceTracker<FileViewerService, FileViewerService> {
 

--- a/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshot.java
@@ -59,7 +59,7 @@ public class MuSnapshot {
 
 	private static final MuSnapshot instance = new MuSnapshot();
         
-        private final List<SnapshotHandler> handlers = new ArrayList<>();
+    private final List<MuSnapshotable> snapshotables = new ArrayList<>();
 	
 	// - Last screen variables -----------------------------------------------
     // -----------------------------------------------------------------------
@@ -576,7 +576,7 @@ public class MuSnapshot {
         XmlConfigurationReader reader = new XmlConfigurationReader();
         configuration.read(reader);
     
-        for (SnapshotHandler handler : handlers) {
+        for (MuSnapshotable handler : snapshotables) {
             handler.read(configuration);
         }
     }
@@ -612,7 +612,7 @@ public class MuSnapshot {
     	
     	setGlobalHistory();
 
-        for (SnapshotHandler handler : handlers) {
+        for (MuSnapshotable handler : snapshotables) {
             handler.write(configuration);
         }
 
@@ -718,12 +718,12 @@ public class MuSnapshot {
         configuration.setVariable(getSinglePanelViewToggleState(index), currentMainFrame.isSinglePanel());
     }
     
-    public static void registerHandler(SnapshotHandler handler) {
-        instance.handlers.add(handler);
+    public static void registerHandler(MuSnapshotable snapshotable) {
+        instance.snapshotables.add(snapshotable);
     }
     
-    public static void unregisterHandler(SnapshotHandler handler) {
-        instance.handlers.remove(handler);
+    public static void unregisterHandler(MuSnapshotable snapshotable) {
+        instance.snapshotables.remove(snapshotable);
     }
 
     public static Configuration getSnapshot() {

--- a/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshot.java
@@ -45,7 +45,7 @@ import com.mucommander.ui.main.table.Column;
 import com.mucommander.ui.main.table.FileTable;
 import com.mucommander.ui.main.tabs.FileTableTab;
 import com.mucommander.ui.main.tabs.FileTableTabs;
-import com.mucommander.ui.viewer.text.TextViewer;
+import java.util.ArrayList;
 
 /**
  * muCommander specific wrapper for the <code>com.mucommander.conf</code> API which is used to save 'dynamic' configurations.
@@ -58,6 +58,8 @@ public class MuSnapshot {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MuSnapshot.class);
 
 	private static final MuSnapshot instance = new MuSnapshot();
+        
+        private final List<SnapshotHandler> handlers = new ArrayList<>();
 	
 	// - Last screen variables -----------------------------------------------
     // -----------------------------------------------------------------------
@@ -68,22 +70,8 @@ public class MuSnapshot {
     /** Last known screen height. */
     public static final String  SCREEN_HEIGHT                      = SCREEN_SECTION + "." + "height";
 
-    // - Text file presenter (viewer/editor) variables -----------------------
- 	// -----------------------------------------------------------------------
- 	/** Section describing information about features used by the last file presenter instance. */
- 	private static final String  FILE_PRESENTER_SECTION            = "file_presenter";
- 	/** Section describing information specific to text file presenter. */
- 	private static final String TEXT_FILE_PRESENTER_SECTION        = FILE_PRESENTER_SECTION + "." + "text";
- 	/** Whether or not to wrap long lines. */
- 	public static final String  TEXT_FILE_PRESENTER_LINE_WRAP      = TEXT_FILE_PRESENTER_SECTION + "." + "line_wrap";
- 	/** Default wrap value. */
- 	public static final boolean DEFAULT_LINE_WRAP                  = false;
- 	/** Whether or not to show line numbers. */
- 	public static final String  TEXT_FILE_PRESENTER_LINE_NUMBERS   = TEXT_FILE_PRESENTER_SECTION + "." + "line_numbers";
- 	/** Default line numbers value. */
- 	public static final boolean DEFAULT_LINE_NUMBERS               = true;
-    /** Last known file presenter full screen mode. */
-    public static final String  TEXT_FILE_PRESENTER_FULL_SCREEN    = TEXT_FILE_PRESENTER_SECTION + "." + "full_screen";
+    /** Section describing information about features used by the last file presenter instance. */
+    public static final String  FILE_PRESENTER_SECTION            = "file_presenter";
 
     // - Location history ---- -----------------------------------------------
     // -----------------------------------------------------------------------
@@ -587,6 +575,10 @@ public class MuSnapshot {
     void read() throws IOException, ConfigurationException {
         XmlConfigurationReader reader = new XmlConfigurationReader();
         configuration.read(reader);
+    
+        for (SnapshotHandler handler : handlers) {
+            handler.read(configuration);
+        }
     }
 
     /**
@@ -620,15 +612,11 @@ public class MuSnapshot {
     	
     	setGlobalHistory();
 
-    	setTextPresenterProperties();
+        for (SnapshotHandler handler : handlers) {
+            handler.write(configuration);
+        }
 
         configuration.write();
-    }
-
-    private void setTextPresenterProperties() {
-    	configuration.setVariable(MuSnapshot.TEXT_FILE_PRESENTER_FULL_SCREEN, TextViewer.isFullScreen());
-    	configuration.setVariable(MuSnapshot.TEXT_FILE_PRESENTER_LINE_WRAP, TextViewer.isLineWrap());
-    	configuration.setVariable(MuSnapshot.TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewer.isLineNumbers());
     }
 
     private void setFrameAttributes(MainFrame mainFrame, int index) {
@@ -728,6 +716,14 @@ public class MuSnapshot {
 
         // Save single panel view toggle state
         configuration.setVariable(getSinglePanelViewToggleState(index), currentMainFrame.isSinglePanel());
+    }
+    
+    public static void registerHandler(SnapshotHandler handler) {
+        instance.handlers.add(handler);
+    }
+    
+    public static void unregisterHandler(SnapshotHandler handler) {
+        instance.handlers.remove(handler);
     }
 
     public static Configuration getSnapshot() {

--- a/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshotable.java
+++ b/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshotable.java
@@ -21,11 +21,11 @@ package com.mucommander.snapshot;
 import com.mucommander.commons.conf.Configuration;
 
 /**
- * Snapshot support for modules.
+ * Configuration snapshoting support for modules.
  *
  * @author Miroslav Hajda
  */
-public interface SnapshotHandler {
+public interface MuSnapshotable {
     
     /**
      * Performs loading/reading of snapshot preferences.

--- a/mucommander-core/src/main/java/com/mucommander/snapshot/SnapshotHandler.java
+++ b/mucommander-core/src/main/java/com/mucommander/snapshot/SnapshotHandler.java
@@ -23,7 +23,7 @@ import com.mucommander.commons.conf.Configuration;
 /**
  * Snapshot support for modules.
  *
- * @author hajdam
+ * @author Miroslav Hajda
  */
 public interface SnapshotHandler {
     

--- a/mucommander-core/src/main/java/com/mucommander/snapshot/SnapshotHandler.java
+++ b/mucommander-core/src/main/java/com/mucommander/snapshot/SnapshotHandler.java
@@ -16,18 +16,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer;
+package com.mucommander.snapshot;
+
+import com.mucommander.commons.conf.Configuration;
 
 /**
- * This exception is thrown by {@link com.mucommander.ui.viewer.ViewerFactory} and
- * {@link com.mucommander.ui.viewer.EditorFactory} when the user should be warned about something before going ahead
- * with viewing/editing a file. {@link #getMessage()} contains the message to display to the user.
+ * Snapshot support for modules.
  *
- * @author Maxence Bernard
+ * @author hajdam
  */
-public class WarnUserException extends Exception {
-
-    public WarnUserException(String localizedMessage) {
-        super(localizedMessage);
-    }
+public interface SnapshotHandler {
+    
+    /**
+     * Performs loading/reading of snapshot preferences.
+     * 
+     * @param configuration configuration
+     */
+    void read(Configuration configuration);
+    
+    /**
+     * Performs storing/writing of snapshot preferences.
+     * 
+     * @param configuration configuration
+     */
+    void write(Configuration configuration);
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorFactory.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorFactory.java
@@ -19,6 +19,7 @@
 package com.mucommander.ui.viewer;
 
 import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.viewer.WarnUserException;
 
 /**
  * A common interface for instantiating {@link FileEditor} implementations, and finding out if a editor is capable

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorRegistrar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorRegistrar.java
@@ -31,6 +31,7 @@ import com.mucommander.text.Translator;
 import com.mucommander.ui.dialog.QuestionDialog;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.WindowManager;
+import com.mucommander.viewer.WarnUserException;
 
 /**
  * EditorRegistrar maintains a list of registered file editors and provides methods to dynamically register file editors
@@ -42,10 +43,6 @@ public class EditorRegistrar {
 	
     /** List of registered file editors */ 
     private final static java.util.List<EditorFactory> editorFactories = new Vector<EditorFactory>();
-
-    static {
-        registerFileEditor(new com.mucommander.ui.viewer.text.TextFactory());
-    }
 
     /**
      * Registers a FileEditor.

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/FileViewer.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/FileViewer.java
@@ -36,8 +36,6 @@ import java.awt.event.KeyEvent;
  */
 public abstract class FileViewer extends FilePresenter implements ActionListener {
 	
-    
-	
     /** Close menu item */
     private JMenuItem closeItem;
     

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerFactory.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerFactory.java
@@ -19,6 +19,7 @@
 package com.mucommander.ui.viewer;
 
 import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.viewer.WarnUserException;
 
 /**
  * A common interface for instantiating {@link FileViewer} implementations, and finding out if a viewer is capable

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/image/package.html
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/image/package.html
@@ -1,3 +1,0 @@
-<body>
-  Provides image viewing classes.
-</body>

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/text/package.html
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/text/package.html
@@ -1,3 +1,0 @@
-<body>
-  Provides text files viewing and editing classes.
-</body>

--- a/mucommander-viewer-api/build.gradle
+++ b/mucommander-viewer-api/build.gradle
@@ -1,0 +1,24 @@
+dependencies {
+    compile project(':mucommander-commons-file')
+    compile project(':mucommander-commons-util')
+
+    testCompile 'org.testng:testng:6.11'
+}
+
+repositories.jcenter()
+
+jar {
+   bnd ('Bundle-Name': 'muCommander-viewer-api',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library for viewer/editor API',
+        'Bundle-DocURL': 'https://www.mucommander.com',
+        'Export-Package': 'com.mucommander.viewer',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-Url': "https://www.mucommander.com/version/nightly.xml")
+}

--- a/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileEditorWrapper.java
+++ b/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileEditorWrapper.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer;
+
+import com.mucommander.commons.file.AbstractFile;
+import java.io.IOException;
+import javax.swing.JComponent;
+
+/**
+ * Interface for File editor.
+ *
+ * @author Miroslav Hajda
+ */
+public interface FileEditorWrapper {
+
+    /**
+     * Opens a given AbstractFile for display.
+     *
+     * @param file the file to be presented
+     * @throws IOException in case of an I/O problem
+     */
+    void open(AbstractFile file) throws IOException;
+
+    /**
+     * Returns panel for viewer.
+     *
+     * @return component instance
+     */
+    JComponent getUI();
+}

--- a/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileEditorWrapper.java
+++ b/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileEditorWrapper.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import javax.swing.JComponent;
 
 /**
- * Interface for File editor.
+ * Interface for file editor.
  *
  * @author Miroslav Hajda
  */

--- a/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileViewerWrapper.java
+++ b/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileViewerWrapper.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import javax.swing.JComponent;
 
 /**
- * Interface for File viewer.
+ * Interface for file viewer.
  * 
  * TODO: Currently doesn't replace FileViewer, but is intended to do so with
  * possible support for tabbing in file viewer dialog in the future.

--- a/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileViewerWrapper.java
+++ b/mucommander-viewer-api/src/main/java/com/mucommander/viewer/FileViewerWrapper.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer;
+
+import com.mucommander.commons.file.AbstractFile;
+import java.awt.Frame;
+import java.io.IOException;
+import javax.swing.JComponent;
+
+/**
+ * Interface for File viewer.
+ * 
+ * TODO: Currently doesn't replace FileViewer, but is intended to do so with
+ * possible support for tabbing in file viewer dialog in the future.
+ *
+ * @author Miroslav Hajda
+ */
+public interface FileViewerWrapper {
+
+    /**
+     * Opens a given AbstractFile for display.
+     *
+     * @param file the file to be presented
+     * @throws IOException in case of an I/O problem
+     */
+    void open(AbstractFile file) throws IOException;
+
+    /**
+     * Returns panel for viewer.
+     *
+     * @return component instance
+     */
+    JComponent getViewerComponent();
+
+    /**
+     * Sets parent frame.
+     *
+     * @param frame window frame
+     */
+    void setFrame(Frame frame);
+}

--- a/mucommander-viewer-api/src/main/java/com/mucommander/viewer/WarnUserException.java
+++ b/mucommander-viewer-api/src/main/java/com/mucommander/viewer/WarnUserException.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.mucommander.viewer;
+
+/**
+ * This exception is thrown by {@link com.mucommander.ui.viewer.ViewerFactory} and
+ * {@link com.mucommander.ui.viewer.EditorFactory} when the user should be warned about something before going ahead
+ * with viewing/editing a file. {@link #getMessage()} contains the message to display to the user.
+ *
+ * @author Maxence Bernard
+ */
+public class WarnUserException extends Exception {
+
+    public WarnUserException(String localizedMessage) {
+        super(localizedMessage);
+    }
+}

--- a/mucommander-viewer-binary/build.gradle
+++ b/mucommander-viewer-binary/build.gradle
@@ -1,0 +1,32 @@
+dependencies {
+    compile project(':mucommander-core')
+    compile project(':mucommander-viewer-api')
+    compile project(':mucommander-preferences')
+    compile project(':mucommander-translator')
+    compile project(':mucommander-commons-file')
+    compile project(':mucommander-commons-util')
+
+    compile 'org.exbin.deltahex:deltahex-swing:0.1.2'
+    compile 'org.exbin.deltahex:deltahex-swing:0.1.2'
+
+    testCompile 'org.testng:testng:6.11'
+}
+
+repositories.jcenter()
+
+jar {
+   bnd ('Bundle-Name': 'muCommander-viewer-binary',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library for hexadecimal viewer/editor',
+        'Bundle-DocURL': 'https://www.mucommander.com',
+        'Export-Package': 'com.mucommander.viewer.binary',
+        'Bundle-Activator': 'com.mucommander.viewer.binary.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Miroslav Hajda",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Miroslav Hajda",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-Url': "https://www.mucommander.com/version/nightly.xml")
+}

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/Activator.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/Activator.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.binary;
+
+import com.mucommander.osgi.FileViewerService;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * Binary files viewer.
+ *
+ * TODO:<br>
+ * - editation mode<br>
+ * - status bar<br>
+ * - dynamic files loading<br>
+ * - snapshot for settings<br>
+ * - support for encoding<br>
+ * - translation support<br>
+ * - searching<br>
+ * - popup menu<br>
+ *
+ * @author Miroslav Hajda
+ */
+public class Activator implements BundleActivator {
+
+    private ServiceRegistration<FileViewerService> viewerRegistration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        viewerRegistration = context.registerService(FileViewerService.class, new BinaryFileViewerService(), null);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        viewerRegistration.unregister();
+    }
+}

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryFactory.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryFactory.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.binary;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.ui.viewer.FileViewer;
+import com.mucommander.ui.viewer.ViewerFactory;
+
+/**
+ * <code>BinaryFactory</code> implementation for creating binary viewers.
+ *
+ * @author Miroslav Hajda
+ */
+public class BinaryFactory implements ViewerFactory {
+
+    public BinaryFactory() {
+    }
+
+    @Override
+    public boolean canViewFile(AbstractFile file) {
+        // Do not allow directories
+        if (file.isDirectory()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public FileViewer createFileViewer() {
+        return new BinaryViewer();
+    }
+}

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryFileViewerService.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryFileViewerService.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.binary;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.osgi.FileViewerService;
+import com.mucommander.viewer.FileViewerWrapper;
+
+/**
+ * <code>FileViewerService</code> implementation for creating binary viewers.
+ *
+ * @author Miroslav Hajda
+ */
+public class BinaryFileViewerService implements FileViewerService {
+
+    @Override
+    public String getTabTitle() {
+        return "Binary";
+    }
+
+    @Override
+    public int getOrderPriority() {
+        return 0;
+    }
+
+    @Override
+    public boolean canViewFile(AbstractFile file) {
+        return !file.isDirectory();
+    }
+
+    @Override
+    public FileViewerWrapper createFileViewer() {
+        return new BinaryViewer();
+    }
+}

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
@@ -1,0 +1,310 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.binary;
+
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Graphics;
+import java.awt.event.ActionEvent;
+import java.io.IOException;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.commons.util.ui.helper.MenuToolkit;
+import com.mucommander.commons.util.ui.helper.MnemonicHelper;
+import com.mucommander.text.Translator;
+import com.mucommander.ui.theme.ColorChangedEvent;
+import com.mucommander.ui.theme.FontChangedEvent;
+import com.mucommander.ui.theme.Theme;
+import com.mucommander.ui.theme.ThemeListener;
+import com.mucommander.ui.theme.ThemeManager;
+import com.mucommander.ui.viewer.FileFrame;
+import com.mucommander.ui.viewer.FileViewer;
+import com.mucommander.viewer.FileViewerWrapper;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.event.ActionListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.ButtonGroup;
+import javax.swing.JComponent;
+import javax.swing.JRadioButtonMenuItem;
+import org.exbin.deltahex.CodeType;
+import org.exbin.deltahex.EditationAllowed;
+import org.exbin.deltahex.HexCharactersCase;
+import org.exbin.deltahex.swing.CodeArea;
+import org.exbin.utils.binary_data.ByteArrayEditableData;
+
+/**
+ * General viewer for binary files.
+ *
+ * @author Miroslav Hajda
+ */
+class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapper {
+    
+    private Frame frame;
+
+    /**
+     * Menu bar
+     */
+    // Menus //
+    // Menus //
+    private JMenu editMenu;
+    private JMenu viewMenu;
+    private JMenu codeTypeMenu;
+    private JMenu hexCharacterCaseMenu;
+    // Items //
+    private javax.swing.ButtonGroup codeTypeButtonGroup;
+    private javax.swing.ButtonGroup hexCharacterCaseButtonGroup;
+    private JMenuItem copyItem;
+    private JMenuItem selectAllItem;
+    private javax.swing.JRadioButtonMenuItem binaryCodeTypeRadioButtonMenuItem;
+    private javax.swing.JRadioButtonMenuItem octalCodeTypeRadioButtonMenuItem;
+    private javax.swing.JRadioButtonMenuItem decimalCodeTypeRadioButtonMenuItem;
+    private javax.swing.JRadioButtonMenuItem hexadecimalCodeTypeRadioButtonMenuItem;
+    private javax.swing.JRadioButtonMenuItem lowerCaseRadioButtonMenuItem;
+    private javax.swing.JRadioButtonMenuItem upperCaseRadioButtonMenuItem;
+
+//    private Action copyEditAction;
+//    private Action selectAllAction;
+
+    private BinaryViewerImpl binaryViewerImpl;
+
+    public BinaryViewer() {
+        binaryViewerImpl = new BinaryViewerImpl();
+
+        setComponentToPresent(binaryViewerImpl);
+
+        // Create Go menu
+        MnemonicHelper menuMnemonicHelper = new MnemonicHelper();
+
+        initMenuBars();
+    }
+    
+    private void initMenuBars() {
+    	editMenu = new JMenu(Translator.get("text_viewer.edit"));
+    	MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
+
+    	copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
+        copyItem.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    binaryViewerImpl.copy();
+                }
+        });
+
+    	selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
+        selectAllItem.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    binaryViewerImpl.selectAll();
+                }
+        });
+
+    	// View menu
+    	viewMenu = new JMenu(Translator.get("text_viewer.view"));
+        
+        codeTypeMenu = new JMenu("Code Type");
+
+        codeTypeButtonGroup = new ButtonGroup();
+        binaryCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
+        codeTypeButtonGroup.add(binaryCodeTypeRadioButtonMenuItem);
+        binaryCodeTypeRadioButtonMenuItem.setText("Binary");
+        binaryCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                binaryViewerImpl.setCodeType(CodeType.BINARY);
+            }
+        });
+        codeTypeMenu.add(binaryCodeTypeRadioButtonMenuItem);
+
+        octalCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
+        codeTypeButtonGroup.add(octalCodeTypeRadioButtonMenuItem);
+        octalCodeTypeRadioButtonMenuItem.setText("Octal");
+        octalCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                binaryViewerImpl.setCodeType(CodeType.OCTAL);
+            }
+        });
+        codeTypeMenu.add(octalCodeTypeRadioButtonMenuItem);
+
+        decimalCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
+        codeTypeButtonGroup.add(decimalCodeTypeRadioButtonMenuItem);
+        decimalCodeTypeRadioButtonMenuItem.setText("Decimal");
+        decimalCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                binaryViewerImpl.setCodeType(CodeType.DECIMAL);
+            }
+        });
+        codeTypeMenu.add(decimalCodeTypeRadioButtonMenuItem);
+
+        hexadecimalCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
+        codeTypeButtonGroup.add(hexadecimalCodeTypeRadioButtonMenuItem);
+        hexadecimalCodeTypeRadioButtonMenuItem.setSelected(true);
+        hexadecimalCodeTypeRadioButtonMenuItem.setText("Hexadecimal");
+        hexadecimalCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                binaryViewerImpl.setCodeType(CodeType.HEXADECIMAL);
+            }
+        });
+        codeTypeMenu.add(hexadecimalCodeTypeRadioButtonMenuItem);
+        viewMenu.add(codeTypeMenu);
+
+        hexCharacterCaseMenu = new JMenu("Hex Character Case");
+        hexCharacterCaseButtonGroup = new ButtonGroup();
+
+        upperCaseRadioButtonMenuItem = new JRadioButtonMenuItem();
+        hexCharacterCaseButtonGroup.add(upperCaseRadioButtonMenuItem);
+        upperCaseRadioButtonMenuItem.setSelected(true);
+        upperCaseRadioButtonMenuItem.setText("Upper Case");
+        upperCaseRadioButtonMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                binaryViewerImpl.setHexCharactersCase(HexCharactersCase.UPPER);
+            }
+        });
+        hexCharacterCaseMenu.add(upperCaseRadioButtonMenuItem);
+
+        lowerCaseRadioButtonMenuItem = new JRadioButtonMenuItem();
+        hexCharacterCaseButtonGroup.add(lowerCaseRadioButtonMenuItem);
+        lowerCaseRadioButtonMenuItem.setText("Lower Case");
+        lowerCaseRadioButtonMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                binaryViewerImpl.setHexCharactersCase(HexCharactersCase.LOWER);
+            }
+        });
+        hexCharacterCaseMenu.add(lowerCaseRadioButtonMenuItem);
+        viewMenu.add(hexCharacterCaseMenu);
+    }
+
+    @Override
+    public JMenuBar getMenuBar() {
+        JMenuBar menuBar = super.getMenuBar();
+
+        menuBar.add(editMenu);
+        menuBar.add(viewMenu);
+
+        return menuBar;
+    }
+
+    private synchronized void loadFile(AbstractFile file) throws IOException {
+        FileFrame frame = getFrame();
+        frame.setCursor(new Cursor(Cursor.WAIT_CURSOR));
+
+        ByteArrayEditableData data = new ByteArrayEditableData();
+        try {
+            data.loadFromStream(file.getInputStream());
+        } catch (IOException ex) {
+            Logger.getLogger(BinaryViewer.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
+        binaryViewerImpl.setData(data);
+
+        frame.setCursor(Cursor.getDefaultCursor());
+    }
+
+    private void updateFrame() {
+        FileFrame frame = getFrame();
+
+        // Revalidate, pack and repaint should be called in this order
+        frame.setTitle(this.getTitle());
+        binaryViewerImpl.revalidate();
+        frame.pack();
+        frame.getContentPane().repaint();
+    }
+
+    @Override
+    public void show(AbstractFile file) throws IOException {
+        loadFile(file);
+    }
+
+    @Override
+    public String getTitle() {
+        return super.getTitle();
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Object source = e.getSource();
+
+        super.actionPerformed(e);
+    }
+
+    /**
+     * Returns panel for viewer.
+     *
+     * @return component instance
+     */
+    @Override
+    public JComponent getViewerComponent() {
+        return this;
+    }
+
+    @Override
+    public void setFrame(Frame frame) {
+        this.frame = frame;
+    }
+
+    private class BinaryViewerImpl extends CodeArea implements ThemeListener {
+
+        private Color backgroundColor;
+
+        BinaryViewerImpl() {
+            backgroundColor = ThemeManager.getCurrentColor(Theme.EDITOR_BACKGROUND_COLOR);
+            super.setBackground(backgroundColor);
+            ThemeManager.addCurrentThemeListener(this);
+            setEditationAllowed(EditationAllowed.READ_ONLY);
+        }
+
+        @Override
+        public void paint(Graphics g) {
+            super.paint(g);
+        }
+
+        @Override
+        public synchronized Dimension getPreferredSize() {
+            return new Dimension(750, 500);
+        }
+
+        /**
+         * Receives theme color changes notifications.
+         */
+        @Override
+        public void colorChanged(ColorChangedEvent event) {
+            if (event.getColorId() == Theme.EDITOR_BACKGROUND_COLOR) {
+                backgroundColor = event.getColor();
+                super.setBackground(backgroundColor);
+                repaint();
+            }
+        }
+
+        /**
+         * Not used, implemented as a no-op.
+         */
+        @Override
+        public void fontChanged(FontChangedEvent event) {
+        }
+    }
+}

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
@@ -59,13 +59,12 @@ import org.exbin.utils.binary_data.ByteArrayEditableData;
  * @author Miroslav Hajda
  */
 class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapper {
-    
+
     private Frame frame;
 
     /**
      * Menu bar
      */
-    // Menus //
     // Menus //
     private JMenu editMenu;
     private JMenu viewMenu;
@@ -83,9 +82,6 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
     private javax.swing.JRadioButtonMenuItem lowerCaseRadioButtonMenuItem;
     private javax.swing.JRadioButtonMenuItem upperCaseRadioButtonMenuItem;
 
-//    private Action copyEditAction;
-//    private Action selectAllAction;
-
     private BinaryViewerImpl binaryViewerImpl;
 
     public BinaryViewer() {
@@ -93,35 +89,32 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
 
         setComponentToPresent(binaryViewerImpl);
 
-        // Create Go menu
-        MnemonicHelper menuMnemonicHelper = new MnemonicHelper();
-
         initMenuBars();
     }
-    
+
     private void initMenuBars() {
-    	editMenu = new JMenu(Translator.get("text_viewer.edit"));
-    	MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
+        editMenu = new JMenu(Translator.get("text_viewer.edit"));
+        MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
 
-    	copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
+        copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
         copyItem.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    binaryViewerImpl.copy();
-                }
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                binaryViewerImpl.copy();
+            }
         });
 
-    	selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
+        selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
         selectAllItem.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    binaryViewerImpl.selectAll();
-                }
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                binaryViewerImpl.selectAll();
+            }
         });
 
-    	// View menu
-    	viewMenu = new JMenu(Translator.get("text_viewer.view"));
-        
+        // View menu
+        viewMenu = new JMenu(Translator.get("text_viewer.view"));
+
         codeTypeMenu = new JMenu("Code Type");
 
         codeTypeButtonGroup = new ButtonGroup();

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
@@ -19,8 +19,6 @@ package com.mucommander.viewer.binary;
 
 import java.awt.Color;
 import java.awt.Cursor;
-import java.awt.Graphics;
-import java.awt.event.ActionEvent;
 import java.io.IOException;
 
 import javax.swing.JMenu;
@@ -41,6 +39,7 @@ import com.mucommander.ui.viewer.FileViewer;
 import com.mucommander.viewer.FileViewerWrapper;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -97,20 +96,10 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
         MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
 
         copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
-        copyItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                binaryViewerImpl.copy();
-            }
-        });
+        copyItem.addActionListener(binaryViewerImpl::copy);
 
         selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
-        selectAllItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                binaryViewerImpl.selectAll();
-            }
-        });
+        selectAllItem.addActionListener(binaryViewerImpl::selectAll);
 
         // View menu
         viewMenu = new JMenu(Translator.get("text_viewer.view"));
@@ -121,33 +110,24 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
         binaryCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
         codeTypeButtonGroup.add(binaryCodeTypeRadioButtonMenuItem);
         binaryCodeTypeRadioButtonMenuItem.setText("Binary");
-        binaryCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                binaryViewerImpl.setCodeType(CodeType.BINARY);
-            }
+        binaryCodeTypeRadioButtonMenuItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.setCodeType(CodeType.BINARY);
         });
         codeTypeMenu.add(binaryCodeTypeRadioButtonMenuItem);
 
         octalCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
         codeTypeButtonGroup.add(octalCodeTypeRadioButtonMenuItem);
         octalCodeTypeRadioButtonMenuItem.setText("Octal");
-        octalCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                binaryViewerImpl.setCodeType(CodeType.OCTAL);
-            }
+        octalCodeTypeRadioButtonMenuItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.setCodeType(CodeType.OCTAL);
         });
         codeTypeMenu.add(octalCodeTypeRadioButtonMenuItem);
 
         decimalCodeTypeRadioButtonMenuItem = new JRadioButtonMenuItem();
         codeTypeButtonGroup.add(decimalCodeTypeRadioButtonMenuItem);
         decimalCodeTypeRadioButtonMenuItem.setText("Decimal");
-        decimalCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                binaryViewerImpl.setCodeType(CodeType.DECIMAL);
-            }
+        decimalCodeTypeRadioButtonMenuItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.setCodeType(CodeType.DECIMAL);
         });
         codeTypeMenu.add(decimalCodeTypeRadioButtonMenuItem);
 
@@ -155,11 +135,8 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
         codeTypeButtonGroup.add(hexadecimalCodeTypeRadioButtonMenuItem);
         hexadecimalCodeTypeRadioButtonMenuItem.setSelected(true);
         hexadecimalCodeTypeRadioButtonMenuItem.setText("Hexadecimal");
-        hexadecimalCodeTypeRadioButtonMenuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                binaryViewerImpl.setCodeType(CodeType.HEXADECIMAL);
-            }
+        hexadecimalCodeTypeRadioButtonMenuItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.setCodeType(CodeType.HEXADECIMAL);
         });
         codeTypeMenu.add(hexadecimalCodeTypeRadioButtonMenuItem);
         viewMenu.add(codeTypeMenu);
@@ -171,22 +148,16 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
         hexCharacterCaseButtonGroup.add(upperCaseRadioButtonMenuItem);
         upperCaseRadioButtonMenuItem.setSelected(true);
         upperCaseRadioButtonMenuItem.setText("Upper Case");
-        upperCaseRadioButtonMenuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                binaryViewerImpl.setHexCharactersCase(HexCharactersCase.UPPER);
-            }
+        upperCaseRadioButtonMenuItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.setHexCharactersCase(HexCharactersCase.UPPER);
         });
         hexCharacterCaseMenu.add(upperCaseRadioButtonMenuItem);
 
         lowerCaseRadioButtonMenuItem = new JRadioButtonMenuItem();
         hexCharacterCaseButtonGroup.add(lowerCaseRadioButtonMenuItem);
         lowerCaseRadioButtonMenuItem.setText("Lower Case");
-        lowerCaseRadioButtonMenuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                binaryViewerImpl.setHexCharactersCase(HexCharactersCase.LOWER);
-            }
+        lowerCaseRadioButtonMenuItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.setHexCharactersCase(HexCharactersCase.LOWER);
         });
         hexCharacterCaseMenu.add(lowerCaseRadioButtonMenuItem);
         viewMenu.add(hexCharacterCaseMenu);
@@ -218,31 +189,9 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
         frame.setCursor(Cursor.getDefaultCursor());
     }
 
-    private void updateFrame() {
-        FileFrame frame = getFrame();
-
-        // Revalidate, pack and repaint should be called in this order
-        frame.setTitle(this.getTitle());
-        binaryViewerImpl.revalidate();
-        frame.pack();
-        frame.getContentPane().repaint();
-    }
-
     @Override
     public void show(AbstractFile file) throws IOException {
         loadFile(file);
-    }
-
-    @Override
-    public String getTitle() {
-        return super.getTitle();
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        Object source = e.getSource();
-
-        super.actionPerformed(e);
     }
 
     /**
@@ -269,11 +218,6 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
             super.setBackground(backgroundColor);
             ThemeManager.addCurrentThemeListener(this);
             setEditationAllowed(EditationAllowed.READ_ONLY);
-        }
-
-        @Override
-        public void paint(Graphics g) {
-            super.paint(g);
         }
 
         @Override

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/BinaryViewer.java
@@ -96,10 +96,14 @@ class BinaryViewer extends FileViewer implements ActionListener, FileViewerWrapp
         MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
 
         copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
-        copyItem.addActionListener(binaryViewerImpl::copy);
+        copyItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.copy();
+        });
 
         selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
-        selectAllItem.addActionListener(binaryViewerImpl::selectAll);
+        selectAllItem.addActionListener((ActionEvent evt) -> {
+            binaryViewerImpl.selectAll();
+        });
 
         // View menu
         viewMenu = new JMenu(Translator.get("text_viewer.view"));

--- a/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/package.html
+++ b/mucommander-viewer-binary/src/main/java/com/mucommander/viewer/binary/package.html
@@ -1,0 +1,3 @@
+<body>
+  Provides an binary/hexadecimal editor capability.
+</body>

--- a/mucommander-viewer-image/build.gradle
+++ b/mucommander-viewer-image/build.gradle
@@ -1,0 +1,27 @@
+dependencies {
+    compile project(':mucommander-core')
+    compile project(':mucommander-commons-file')
+    compile project(':mucommander-viewer-api')
+    compile project(':mucommander-translator')
+
+    testCompile 'org.testng:testng:6.11'
+}
+
+repositories.jcenter()
+
+jar {
+   bnd ('Bundle-Name': 'muCommander-viewer-image',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library for hexadecimal viewer/editor',
+        'Bundle-DocURL': 'https://www.mucommander.com',
+        'Export-Package': 'com.mucommander.viewer.image',
+        'Bundle-Activator': 'com.mucommander.viewer.image.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-Url': "https://www.mucommander.com/version/nightly.xml")
+}

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/Activator.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/Activator.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.image;
+
+import com.mucommander.osgi.FileViewerService;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * Activator for viewer for image files.
+ *
+ * @author Miroslav Hajda
+ */
+public class Activator implements BundleActivator {
+
+    private ServiceRegistration<FileViewerService> viewerRegistration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        viewerRegistration = context.registerService(FileViewerService.class, new ImageFileViewerService(), null);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        viewerRegistration.unregister();
+    }
+}

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageFactory.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageFactory.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer.image;
+package com.mucommander.viewer.image;
 
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.filter.ExtensionFilenameFilter;

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageFileViewerService.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageFileViewerService.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.image;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.commons.file.filter.ExtensionFilenameFilter;
+import com.mucommander.osgi.FileViewerService;
+import com.mucommander.ui.viewer.FileFrame;
+import com.mucommander.viewer.FileViewerWrapper;
+import java.awt.Frame;
+import java.io.IOException;
+import javax.swing.JComponent;
+
+/**
+ * <code>FileViewerService</code> implementation for creating image viewers.
+ *
+ * @author Nicolas Rinaudo
+ */
+public class ImageFileViewerService implements FileViewerService {
+
+    /**
+     * Used to filter out file extensions that the image viewer cannot open.
+     */
+    private ExtensionFilenameFilter filter;
+
+    public ImageFileViewerService() {
+        filter = new ExtensionFilenameFilter(new String[]{".png", ".gif", ".jpg", ".jpeg"});
+        filter.setCaseSensitive(false);
+    }
+
+    @Override
+    public String getTabTitle() {
+        return "Image";
+    }
+
+    @Override
+    public int getOrderPriority() {
+        return 20;
+    }
+
+    @Override
+    public boolean canViewFile(AbstractFile file) {
+        // Do not allow directories
+        if (file.isDirectory()) {
+            return false;
+        }
+
+        return filter.accept(file);
+    }
+
+    @Override
+    public FileViewerWrapper createFileViewer() {
+        final ImageViewer viewer = new ImageViewer();
+        return new FileViewerWrapper() {
+            @Override
+            public void open(AbstractFile file) throws IOException {
+                viewer.open(file);
+            }
+
+            @Override
+            public JComponent getViewerComponent() {
+                return viewer;
+            }
+
+            @Override
+            public void setFrame(Frame frame) {
+                viewer.setFrame((FileFrame) frame);
+            }
+        };
+    }
+}

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewer.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewer.java
@@ -17,7 +17,7 @@
  */
 
 
-package com.mucommander.ui.viewer.image;
+package com.mucommander.viewer.image;
 
 import java.awt.Color;
 import java.awt.Cursor;

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/package.html
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/package.html
@@ -1,0 +1,3 @@
+<body>
+  Provides an image viewer capability.
+</body>

--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -1,0 +1,29 @@
+dependencies {
+    compile project(':mucommander-core')
+    compile project(':mucommander-commons-file')
+    compile project(':mucommander-viewer-api')
+    compile project(':mucommander-translator')
+    compile project(':mucommander-encoding')
+    compile project(":mucommander-preferences")
+
+    testCompile 'org.testng:testng:6.11'
+}
+
+repositories.jcenter()
+
+jar {
+   bnd ('Bundle-Name': 'muCommander-viewer-text',
+        'Bundle-Vendor': 'muCommander',
+        'Bundle-Description': 'Library for textual viewer/editor',
+        'Bundle-DocURL': 'https://www.mucommander.com',
+        'Export-Package': 'com.mucommander.viewer.text',
+        'Bundle-Activator': 'com.mucommander.viewer.text.Activator',
+        'Specification-Title': "muCommander",
+        'Specification-Vendor': "Arik Hadas",
+        'Specification-Version': version,
+        'Implementation-Title': "muCommander",
+        'Implementation-Vendor': "Arik Hadas",
+        'Implementation-Version': revision.substring(0, 7),
+        'Build-Date': new Date().format('yyyyMMdd'),
+        'Build-Url': "https://www.mucommander.com/version/nightly.xml")
+}

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/Activator.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/Activator.java
@@ -1,0 +1,58 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2016 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.text;
+
+import com.mucommander.osgi.FileEditorService;
+import com.mucommander.osgi.FileViewerService;
+import com.mucommander.snapshot.MuSnapshot;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import static com.mucommander.ui.viewer.EditorRegistrar.registerFileEditor;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * Activator for viewer for text files.
+ *
+ * @author Miroslav Hajda
+ */
+public class Activator implements BundleActivator {
+
+    private ServiceRegistration<FileViewerService> viewerRegistration;
+    private ServiceRegistration<FileEditorService> editorRegistration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        // TODO: The TextFactory must be the last FileViewer to be registered (otherwise it would open other factories file types)
+//        registerFileViewer(new com.mucommander.viewer.text.TextFactory());
+
+        MuSnapshot.registerHandler(new TextViewerSnapshot());
+
+        registerFileEditor(new com.mucommander.viewer.text.TextFactory());
+
+        TextFileViewerService service = new TextFileViewerService();
+
+        viewerRegistration = context.registerService(FileViewerService.class, service, null);
+        editorRegistration = context.registerService(FileEditorService.class, service, null);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        viewerRegistration.unregister();
+        editorRegistration.unregister();
+    }
+}

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/Activator.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/Activator.java
@@ -37,9 +37,6 @@ public class Activator implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
-        // TODO: The TextFactory must be the last FileViewer to be registered (otherwise it would open other factories file types)
-//        registerFileViewer(new com.mucommander.viewer.text.TextFactory());
-
         MuSnapshot.registerHandler(new TextViewerSnapshot());
 
         registerFileEditor(new com.mucommander.viewer.text.TextFactory());

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/FindDialog.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/FindDialog.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer.text;
+package com.mucommander.viewer.text;
 
 import com.mucommander.commons.util.ui.dialog.DialogToolkit;
 import com.mucommander.commons.util.ui.dialog.FocusDialog;

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer.text;
+package com.mucommander.viewer.text;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer.text;
+package com.mucommander.viewer.text;
 
 import java.awt.Font;
 import java.awt.Insets;

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextFactory.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextFactory.java
@@ -16,12 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer.text;
+package com.mucommander.viewer.text;
 
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.io.BinaryDetector;
-import com.mucommander.text.Translator;
 import com.mucommander.ui.viewer.*;
+import com.mucommander.viewer.WarnUserException;
+import com.mucommander.text.Translator;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextFileViewerService.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextFileViewerService.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.viewer.text;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.commons.io.BinaryDetector;
+import com.mucommander.osgi.FileEditorService;
+import com.mucommander.osgi.FileViewerService;
+import com.mucommander.ui.viewer.FileFrame;
+import com.mucommander.viewer.FileViewerWrapper;
+import com.mucommander.viewer.WarnUserException;
+import com.mucommander.text.Translator;
+import java.awt.Frame;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.swing.JComponent;
+
+/**
+ * <code>FileViewerService</code> and <code>FileEditorService</code>
+ * implementation for creating text viewers and editors.
+ *
+ * @author Nicolas Rinaudo
+ */
+public class TextFileViewerService implements FileViewerService, FileEditorService {
+
+    @Override
+    public String getTabTitle() {
+        return "Text";
+    }
+    
+    @Override
+    public int getOrderPriority() {
+        return 10;
+    }
+
+    @Override
+    public boolean canViewFile(AbstractFile file) throws WarnUserException {
+        // Do not allow directories
+        if (file.isDirectory()) {
+            return false;
+        }
+
+        // Warn the user if the file looks like a binary file
+        InputStream in = null;
+        try {
+            in = file.getInputStream();
+            if (BinaryDetector.guessBinary(in)) {
+                return false;
+            }
+        } catch (IOException e) {
+            // Not much too do
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e2) {
+                }
+            }
+        }
+
+        // Warn the user if the file is large that a certain size as the whole file is loaded into memory
+        // (in a JTextArea)
+        if (file.getSize() > 1048576) {
+            throw new WarnUserException(Translator.get("file_viewer.large_file_warning"));
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean canEditFile(AbstractFile file) {
+        // Do not allow directories
+        if (file.isDirectory()) {
+            return false;
+        }
+
+        // Warn the user if the file looks like a binary file
+        InputStream in = null;
+        try {
+            in = file.getInputStream();
+            if (BinaryDetector.guessBinary(in)) {
+                return false;
+            }
+        } catch (IOException e) {
+            // Not much too do
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e2) {
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public FileViewerWrapper createFileViewer() {
+        final TextViewer viewer = new TextViewer();
+        return new FileViewerWrapper() {
+            @Override
+            public void open(AbstractFile file) throws IOException {
+                viewer.open(file);
+            }
+
+            @Override
+            public JComponent getViewerComponent() {
+                return viewer;
+            }
+
+            @Override
+            public void setFrame(Frame frame) {
+                viewer.setFrame((FileFrame) frame);
+            }
+        };
+    }
+}

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextLineNumbersPanel.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextLineNumbersPanel.java
@@ -1,4 +1,4 @@
-package com.mucommander.ui.viewer.text;
+package com.mucommander.viewer.text;
 
 import java.awt.Color;
 import java.awt.Dimension;

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
@@ -105,6 +105,7 @@ public class TextViewer extends FileViewer implements EncodingListener {
 
         getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_M, ActionEvent.CTRL_MASK), CUSTOM_FULL_SCREEN_EVENT);
     	getActionMap().put(CUSTOM_FULL_SCREEN_EVENT, new AbstractAction() {
+                @Override
     		public void actionPerformed(ActionEvent e){
     			setFullScreen(!frame.isFullScreen());
     			frame.setFullScreen(isFullScreen());
@@ -289,6 +290,7 @@ public class TextViewer extends FileViewer implements EncodingListener {
     // EncodingListener implementation //
     /////////////////////////////////////
 
+    @Override
     public void encodingChanged(Object source, String oldEncoding, String newEncoding) {
     	try {
     		// Reload the file using the new encoding

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
@@ -57,15 +57,15 @@ import com.mucommander.ui.viewer.FileViewer;
  */
 public class TextViewer extends FileViewer implements EncodingListener {
 
-	public final static String CUSTOM_FULL_SCREEN_EVENT = "CUSTOM_FULL_SCREEN_EVENT";
+    public final static String CUSTOM_FULL_SCREEN_EVENT = "CUSTOM_FULL_SCREEN_EVENT";
 
-	private TextEditorImpl textEditorImpl;
+    private TextEditorImpl textEditorImpl;
 
-	private static boolean fullScreen = MuSnapshot.getSnapshot().getBooleanVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_FULL_SCREEN);
+    private static boolean fullScreen = MuSnapshot.getSnapshot().getBooleanVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_FULL_SCREEN);
 
-	private static boolean lineWrap = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_WRAP, TextViewerSnapshot.DEFAULT_LINE_WRAP);
+    private static boolean lineWrap = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_WRAP, TextViewerSnapshot.DEFAULT_LINE_WRAP);
 
-	private static boolean lineNumbers = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewerSnapshot.DEFAULT_LINE_NUMBERS);
+    private static boolean lineNumbers = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewerSnapshot.DEFAULT_LINE_NUMBERS);
 
     /** Menu items */
     // Menus //
@@ -79,24 +79,24 @@ public class TextViewer extends FileViewer implements EncodingListener {
     private JMenuItem findPreviousItem;
     private JMenuItem toggleLineWrapItem;
     private JMenuItem toggleLineNumbersItem;
-    
+
     private String encoding;
-    
+
     TextViewer() {
-    	this(new TextEditorImpl(false));
+        this(new TextEditorImpl(false));
     }
-    
+
     TextViewer(TextEditorImpl textEditorImpl) {
-    	this.textEditorImpl = textEditorImpl;
+        this.textEditorImpl = textEditorImpl;
 
-    	setComponentToPresent(textEditorImpl.getTextArea());
-    	
-    	showLineNumbers(lineNumbers);
-    	textEditorImpl.wrap(lineWrap);
+        setComponentToPresent(textEditorImpl.getTextArea());
 
-    	initMenuBarItems();
+        showLineNumbers(lineNumbers);
+        textEditorImpl.wrap(lineWrap);
+
+        initMenuBarItems();
     }
-    
+
     @Override
     public void setFrame(final FileFrame frame) {
         super.setFrame(frame);
@@ -104,38 +104,38 @@ public class TextViewer extends FileViewer implements EncodingListener {
         frame.setFullScreen(isFullScreen());
 
         getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_M, ActionEvent.CTRL_MASK), CUSTOM_FULL_SCREEN_EVENT);
-    	getActionMap().put(CUSTOM_FULL_SCREEN_EVENT, new AbstractAction() {
-                @Override
-    		public void actionPerformed(ActionEvent e){
-    			setFullScreen(!frame.isFullScreen());
-    			frame.setFullScreen(isFullScreen());
-    		}
-    	});
+        getActionMap().put(CUSTOM_FULL_SCREEN_EVENT, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setFullScreen(!frame.isFullScreen());
+                frame.setFullScreen(isFullScreen());
+            }
+        });
     }
 
     static void setFullScreen(boolean fullScreen) {
-		TextViewer.fullScreen = fullScreen;
-	}
+        TextViewer.fullScreen = fullScreen;
+    }
 
-	public static boolean isFullScreen() {
-		return fullScreen;
-	}
+    public static boolean isFullScreen() {
+        return fullScreen;
+    }
 
-	static void setLineWrap(boolean lineWrap) {
-		TextViewer.lineWrap = lineWrap;
-	}
+    static void setLineWrap(boolean lineWrap) {
+        TextViewer.lineWrap = lineWrap;
+    }
 
-	public static boolean isLineWrap() {
-		return lineWrap;
-	}
+    public static boolean isLineWrap() {
+        return lineWrap;
+    }
 
-	static void setLineNumbers(boolean lineNumbers) {
-		TextViewer.lineNumbers = lineNumbers;
-	}
+    static void setLineNumbers(boolean lineNumbers) {
+        TextViewer.lineNumbers = lineNumbers;
+    }
 
-	public static boolean isLineNumbers() {
-		return lineNumbers;
-	}
+    public static boolean isLineNumbers() {
+        return lineNumbers;
+    }
 
     void startEditing(AbstractFile file, DocumentListener documentListener) throws IOException {
         // Auto-detect encoding
@@ -144,23 +144,24 @@ public class TextViewer extends FileViewer implements EncodingListener {
         InputStream in = null;
 
         try {
-            if(file.isFileOperationSupported(FileOperation.RANDOM_READ_FILE)) {
-                try { in = file.getRandomAccessInputStream(); }
-                catch(IOException e) {
+            if (file.isFileOperationSupported(FileOperation.RANDOM_READ_FILE)) {
+                try {
+                    in = file.getRandomAccessInputStream();
+                } catch (IOException e) {
                     // In that case we simply get an InputStream
                 }
             }
 
-            if(in==null)
+            if (in == null) {
                 in = file.getInputStream();
+            }
 
             String encoding = EncodingDetector.detectEncoding(in);
 
-            if(in instanceof RandomAccessInputStream) {
+            if (in instanceof RandomAccessInputStream) {
                 // Seek to the beginning of the file and reuse the stream
-                ((RandomAccessInputStream)in).seek(0);
-            }
-            else {
+                ((RandomAccessInputStream) in).seek(0);
+            } else {
                 // TODO: it would be more efficient to use some sort of PushBackInputStream, though we can't use PushBackInputStream because we don't want to keep pushing back for the whole InputStream lifetime
 
                 // Close the InputStream and open a new one
@@ -172,11 +173,11 @@ public class TextViewer extends FileViewer implements EncodingListener {
 
             // Load the file into the text area
             loadDocument(in, encoding, documentListener);
-        }
-        finally {
-            if(in != null) {
-                try {in.close();}
-                catch(IOException e) {
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
                     // Nothing to do here.
                 }
             }
@@ -186,72 +187,72 @@ public class TextViewer extends FileViewer implements EncodingListener {
     void loadDocument(InputStream in, final String encoding, DocumentListener documentListener) throws IOException {
         // If the encoding is UTF-something, wrap the stream in a BOMInputStream to filter out the byte-order mark
         // (see ticket #245)
-        if(encoding != null && encoding.toLowerCase().startsWith("utf")) {
+        if (encoding != null && encoding.toLowerCase().startsWith("utf")) {
             in = new BOMInputStream(in);
         }
 
         // If the given encoding is invalid (null or not supported), default to "UTF-8" 
-        this.encoding = encoding==null || !Charset.isSupported(encoding) ? "UTF-8" : encoding;
+        this.encoding = encoding == null || !Charset.isSupported(encoding) ? "UTF-8" : encoding;
 
         textEditorImpl.read(new BufferedReader(new InputStreamReader(in, this.encoding)));
-        
+
         // Listen to document changes
         if(documentListener!=null)
             textEditorImpl.addDocumentListener(documentListener);
     }
-    
+
     @Override
     public JMenuBar getMenuBar() {
-    	JMenuBar menuBar = super.getMenuBar();
-    	
-    	// Encoding menu
-    	EncodingMenu encodingMenu = new EncodingMenu(new DialogOwner(getFrame()), encoding);
+        JMenuBar menuBar = super.getMenuBar();
+
+        // Encoding menu
+        EncodingMenu encodingMenu = new EncodingMenu(new DialogOwner(getFrame()), encoding);
         encodingMenu.addEncodingListener(this);
 
         menuBar.add(editMenu);
         menuBar.add(viewMenu);
         menuBar.add(encodingMenu);
-        
+
         return menuBar;
     }
-    
+
     String getEncoding() {
-    	return encoding;
+        return encoding;
     }
-    
+
     protected void showLineNumbers(boolean show) {
-    	setRowHeaderView(show ? new TextLineNumbersPanel(textEditorImpl.getTextArea()) : null);
-    	setLineNumbers(show);
+        setRowHeaderView(show ? new TextLineNumbersPanel(textEditorImpl.getTextArea()) : null);
+        setLineNumbers(show);
     }
 
     protected void wrapLines(boolean wrap) {
-    	textEditorImpl.wrap(wrap);
-    	setLineWrap(wrap);
+        textEditorImpl.wrap(wrap);
+        setLineWrap(wrap);
     }
 
     protected void initMenuBarItems() {
-    	// Edit menu
-    	editMenu = new JMenu(Translator.get("text_viewer.edit"));
-    	MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
+        // Edit menu
+        editMenu = new JMenu(Translator.get("text_viewer.edit"));
+        MnemonicHelper menuItemMnemonicHelper = new MnemonicHelper();
 
-    	copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
+        copyItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.copy"), menuItemMnemonicHelper, null, this);
 
-    	selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
-    	editMenu.addSeparator();
+        selectAllItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.select_all"), menuItemMnemonicHelper, null, this);
+        editMenu.addSeparator();
 
-    	findItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.find"), menuItemMnemonicHelper, KeyStroke.getKeyStroke(KeyEvent.VK_F, KeyEvent.CTRL_DOWN_MASK), this);
-    	findNextItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.find_next"), menuItemMnemonicHelper, KeyStroke.getKeyStroke(KeyEvent.VK_F3, 0), this);
-    	findPreviousItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.find_previous"), menuItemMnemonicHelper, KeyStroke.getKeyStroke(KeyEvent.VK_F3, KeyEvent.SHIFT_DOWN_MASK), this);
-    	
-    	// View menu
-    	viewMenu = new JMenu(Translator.get("text_viewer.view"));
-    	
-    	toggleLineWrapItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, Translator.get("text_viewer.line_wrap"), menuItemMnemonicHelper, null, this);
-    	toggleLineWrapItem.setSelected(textEditorImpl.isWrap());
-    	toggleLineNumbersItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, Translator.get("text_viewer.line_numbers"), menuItemMnemonicHelper, null, this);
-    	toggleLineNumbersItem.setSelected(getRowHeader().getView() != null);
+        findItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.find"), menuItemMnemonicHelper, KeyStroke.getKeyStroke(KeyEvent.VK_F, KeyEvent.CTRL_DOWN_MASK), this);
+        findNextItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.find_next"), menuItemMnemonicHelper, KeyStroke.getKeyStroke(KeyEvent.VK_F3, 0), this);
+        findPreviousItem = MenuToolkit.addMenuItem(editMenu, Translator.get("text_viewer.find_previous"), menuItemMnemonicHelper, KeyStroke.getKeyStroke(KeyEvent.VK_F3, KeyEvent.SHIFT_DOWN_MASK), this);
+
+        // View menu
+        viewMenu = new JMenu(Translator.get("text_viewer.view"));
+
+        toggleLineWrapItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, Translator.get("text_viewer.line_wrap"), menuItemMnemonicHelper, null, this);
+        toggleLineWrapItem.setSelected(textEditorImpl.isWrap());
+        toggleLineNumbersItem = MenuToolkit.addCheckBoxMenuItem(viewMenu, Translator.get("text_viewer.line_numbers"), menuItemMnemonicHelper, null, this);
+        toggleLineNumbersItem.setSelected(getRowHeader().getView() != null);
     }
-    
+
     ///////////////////////////////
     // FileViewer implementation //
     ///////////////////////////////
@@ -260,7 +261,7 @@ public class TextViewer extends FileViewer implements EncodingListener {
     public void show(AbstractFile file) throws IOException {
         startEditing(file, null);
     }
-    
+
     ///////////////////////////////////
     // ActionListener implementation //
     ///////////////////////////////////
@@ -269,21 +270,21 @@ public class TextViewer extends FileViewer implements EncodingListener {
         Object source = e.getSource();
 
         if(source == copyItem)
-        	textEditorImpl.copy();
+            textEditorImpl.copy();
         else if(source == selectAllItem)
-        	textEditorImpl.selectAll();
+            textEditorImpl.selectAll();
         else if(source == findItem)
-        	textEditorImpl.find();
+            textEditorImpl.find();
         else if(source == findNextItem)
-        	textEditorImpl.findNext();
+            textEditorImpl.findNext();
         else if(source == findPreviousItem)
-        	textEditorImpl.findPrevious();
+            textEditorImpl.findPrevious();
         else if(source == toggleLineWrapItem)
-        	setLineWrap(toggleLineWrapItem.isSelected());
+            setLineWrap(toggleLineWrapItem.isSelected());
         else if(source == toggleLineNumbersItem)
-        	showLineNumbers(toggleLineNumbersItem.isSelected());
+            showLineNumbers(toggleLineNumbersItem.isSelected());
         else
-        	super.actionPerformed(e);
+            super.actionPerformed(e);
     }
 
     /////////////////////////////////////
@@ -292,13 +293,12 @@ public class TextViewer extends FileViewer implements EncodingListener {
 
     @Override
     public void encodingChanged(Object source, String oldEncoding, String newEncoding) {
-    	try {
-    		// Reload the file using the new encoding
-    		// Note: loadDocument closes the InputStream
-    		loadDocument(getCurrentFile().getInputStream(), newEncoding, null);
-    	}
-    	catch(IOException ex) {
-    		InformationDialog.showErrorDialog(getFrame(), Translator.get("read_error"), Translator.get("file_editor.cannot_read_file", getCurrentFile().getName()));
-    	}   
+        try {
+            // Reload the file using the new encoding
+            // Note: loadDocument closes the InputStream
+            loadDocument(getCurrentFile().getInputStream(), newEncoding, null);
+        } catch (IOException ex) {
+            InformationDialog.showErrorDialog(getFrame(), Translator.get("read_error"), Translator.get("file_editor.cannot_read_file", getCurrentFile().getName()));
+        }
     }
 }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.mucommander.ui.viewer.text;
+package com.mucommander.viewer.text;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -42,7 +42,6 @@ import com.mucommander.commons.io.bom.BOMInputStream;
 import com.mucommander.commons.util.ui.dialog.DialogOwner;
 import com.mucommander.commons.util.ui.helper.MenuToolkit;
 import com.mucommander.commons.util.ui.helper.MnemonicHelper;
-import com.mucommander.conf.MuConfigurations;
 import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.text.Translator;
 import com.mucommander.ui.dialog.InformationDialog;
@@ -62,11 +61,11 @@ public class TextViewer extends FileViewer implements EncodingListener {
 
 	private TextEditorImpl textEditorImpl;
 
-	private static boolean fullScreen = MuSnapshot.getSnapshot().getBooleanVariable(MuSnapshot.TEXT_FILE_PRESENTER_FULL_SCREEN);
+	private static boolean fullScreen = MuSnapshot.getSnapshot().getBooleanVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_FULL_SCREEN);
 
-	private static boolean lineWrap = MuSnapshot.getSnapshot().getVariable(MuSnapshot.TEXT_FILE_PRESENTER_LINE_WRAP, MuSnapshot.DEFAULT_LINE_WRAP);
+	private static boolean lineWrap = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_WRAP, TextViewerSnapshot.DEFAULT_LINE_WRAP);
 
-	private static boolean lineNumbers = MuSnapshot.getSnapshot().getVariable(MuSnapshot.TEXT_FILE_PRESENTER_LINE_NUMBERS, MuSnapshot.DEFAULT_LINE_NUMBERS);
+	private static boolean lineNumbers = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewerSnapshot.DEFAULT_LINE_NUMBERS);
 
     /** Menu items */
     // Menus //

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
@@ -1,7 +1,19 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * This file is part of muCommander, http://www.mucommander.com
+ * Copyright (C) 2002-2018 Maxence Bernard
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package com.mucommander.viewer.text;
 
@@ -10,8 +22,9 @@ import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 import com.mucommander.snapshot.SnapshotHandler;
 
 /**
+ * Snapshot preferences for text editor.
  *
- * @author hajdam
+ * @author Miroslav Hajda
  */
 public final class TextViewerSnapshot implements SnapshotHandler {
 
@@ -47,8 +60,8 @@ public final class TextViewerSnapshot implements SnapshotHandler {
 
     @Override
     public void write(Configuration configuration) {
-    	configuration.setVariable(TEXT_FILE_PRESENTER_FULL_SCREEN, TextViewer.isFullScreen());
-    	configuration.setVariable(TEXT_FILE_PRESENTER_LINE_WRAP, TextViewer.isLineWrap());
-    	configuration.setVariable(TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewer.isLineNumbers());
+        configuration.setVariable(TEXT_FILE_PRESENTER_FULL_SCREEN, TextViewer.isFullScreen());
+        configuration.setVariable(TEXT_FILE_PRESENTER_LINE_WRAP, TextViewer.isLineWrap());
+        configuration.setVariable(TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewer.isLineNumbers());
     }
 }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
@@ -19,14 +19,14 @@ package com.mucommander.viewer.text;
 
 import com.mucommander.commons.conf.Configuration;
 import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
-import com.mucommander.snapshot.SnapshotHandler;
+import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for text editor.
  *
  * @author Miroslav Hajda
  */
-public final class TextViewerSnapshot implements SnapshotHandler {
+public final class TextViewerSnapshot implements MuSnapshotable {
 
     /**
      * Section describing information specific to text file presenter.
@@ -55,7 +55,6 @@ public final class TextViewerSnapshot implements SnapshotHandler {
 
     @Override
     public void read(Configuration configuration) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
@@ -1,0 +1,54 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.mucommander.viewer.text;
+
+import com.mucommander.commons.conf.Configuration;
+import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
+import com.mucommander.snapshot.SnapshotHandler;
+
+/**
+ *
+ * @author hajdam
+ */
+public final class TextViewerSnapshot implements SnapshotHandler {
+
+    /**
+     * Section describing information specific to text file presenter.
+     */
+    private static final String TEXT_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "text";
+    /**
+     * Whether or not to wrap long lines.
+     */
+    public static final String TEXT_FILE_PRESENTER_LINE_WRAP = TEXT_FILE_PRESENTER_SECTION + "." + "line_wrap";
+    /**
+     * Default wrap value.
+     */
+    public static final boolean DEFAULT_LINE_WRAP = false;
+    /**
+     * Whether or not to show line numbers.
+     */
+    public static final String TEXT_FILE_PRESENTER_LINE_NUMBERS = TEXT_FILE_PRESENTER_SECTION + "." + "line_numbers";
+    /**
+     * Default line numbers value.
+     */
+    public static final boolean DEFAULT_LINE_NUMBERS = true;
+    /**
+     * Last known file presenter full screen mode.
+     */
+    public static final String TEXT_FILE_PRESENTER_FULL_SCREEN = TEXT_FILE_PRESENTER_SECTION + "." + "full_screen";
+
+    @Override
+    public void read(Configuration configuration) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void write(Configuration configuration) {
+    	configuration.setVariable(TEXT_FILE_PRESENTER_FULL_SCREEN, TextViewer.isFullScreen());
+    	configuration.setVariable(TEXT_FILE_PRESENTER_LINE_WRAP, TextViewer.isLineWrap());
+    	configuration.setVariable(TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewer.isLineNumbers());
+    }
+}

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/package.html
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/package.html
@@ -1,0 +1,3 @@
+<body>
+  Provides an text viewer/editor capability.
+</body>

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ include 'mucommander-preferences'
 include 'mucommander-process'
 include 'mucommander-translator'
 include 'mucommander-protocol-api'
+include 'mucommander-viewer-api'
 
 include 'mucommander-archiver'
 include 'mucommander-format-ar'
@@ -32,6 +33,9 @@ include 'mucommander-protocol-s3'
 include 'mucommander-protocol-sftp'
 include 'mucommander-protocol-smb'
 include 'mucommander-protocol-vsphere'
+include 'mucommander-viewer-text'
+include 'mucommander-viewer-image'
+include 'mucommander-viewer-binary'
 
 include 'apache-bzip2'
 


### PR DESCRIPTION
This introduces hexadecimal viewer for binary data based on BinEd (formely deltahex) library.

This is suppose to be sequence of separate smaller changes which can be easily read and considered/discussed.

- Added OSGI service for file viewer (and stub for file editor)
- Added OSGI service for configuration snapshots
- Text and image viewers/editor moved to separate modules
- Added new module for binary viewer (no editor yet) - viewer is used when viewed file is neither detected as text or image

Next steps should include refactoring viewers to use interface instead of abstract class + support switching between different viewers in single window.