### PR TITLE
fix #209: assign default shortcut for edit credentials dialog

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/EditCredentialsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/EditCredentialsAction.java
@@ -17,6 +17,7 @@
 
 package com.mucommander.ui.action.impl;
 
+import java.awt.event.KeyEvent;
 import java.util.Map;
 
 import javax.swing.KeyStroke;
@@ -69,6 +70,6 @@ public class EditCredentialsAction extends MuAction {
 
 		public KeyStroke getDefaultAltKeyStroke() { return null; }
 
-		public KeyStroke getDefaultKeyStroke() { return null; }
+		public KeyStroke getDefaultKeyStroke() { return KeyStroke.getKeyStroke(KeyEvent.VK_K, KeyEvent.ALT_DOWN_MASK | KeyEvent.CTRL_DOWN_MASK); }
     }
 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -46,6 +46,7 @@ Improvements:
 - Upgrade various dependencies.
 - Default drag and drop action that was initiated from outside of the application to 'COPY' rather than to 'MOVE'.
 - Enable pinning to taskbar on Windows 7+.
+- Assign default keyboard shortcut for edit credentials dialog: ALT+CTRL+K.
 
 Localization:
 - French translation is updated.


### PR DESCRIPTION
The default shortcut would be: ALT+CTRL+K