### PR TITLE
DRY: add a property to ask for a bundled Windows installer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,14 +118,11 @@ runOsgi {
     }
 }
 
-task run() {
-    dependsOn 'runOsgi'
-}
+task run(dependsOn: 'runOsgi')
 
 ext {
     // Open the Git repository in the project's root directory.
     git = grgit.open(dir: project.rootDir)
-
     // Get commit id of HEAD.
     revision = git.head().id
 }
@@ -314,7 +311,6 @@ task copyInfoToAppOutputDir(type: Copy) {
     include "readme.txt"
     into "${->project.buildDir}/${->project.macAppBundle.appOutputDir}/"
 }
-
 createDmg.dependsOn copyInfoToAppOutputDir
 
 launch4j {

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,8 @@ ext {
     git = grgit.open(dir: project.rootDir)
     // Get commit id of HEAD.
     revision = git.head().id
+    // Whether or not to bundle the JRE in order to create a 'standalone' executable
+    bundleJRE = project.hasProperty('mucommanderBundleJRE') ? mucommanderBundleJRE.toBoolean() : false
 }
 
 shadowJar {
@@ -321,51 +323,9 @@ launch4j {
     dontWrapJar = true
     classpath = ['.']
     headerType = "gui"
-    outfile = "mucommander.exe"
-}
-
-task createBundledExe(type: edu.sc.seis.launch4j.tasks.Launch4jLibraryTask) {
-    bundledJre64Bit = true
+    bundledJre64Bit = project.ext.bundleJRE
     bundledJrePath = "jre"
     outfile = "mucommander.exe"
-}
-
-// Windows installer - bundled with JRE
-task nsisBundled(type: Copy, dependsOn: [createBundledExe, createBundlesDir]) {
-    from("$buildDir/launch4j/") {
-        include 'mucommander.exe'
-    }
-    from('jre/win') {
-        into "jre"
-    }
-    from("$buildDir/osgi/") {
-        include '*.jar'
-    }
-    from('package/windows') {
-        include 'mucommander.ico'
-    }
-    from('package/windows') {
-        include 'mucommander-bundled.nsi'
-        filter(ReplaceTokens, tokens: [MU_VERSION: project.version,
-                                       MU_ICON: 'mucommander.ico',
-                                       MU_LICENSE: 'license.txt',
-                                       MU_README: 'readme.txt',
-                                       MU_OUT: 'mucommander-'+project.version+'-setup.exe',
-                                       MU_EXE: 'mucommander.exe',
-                                       MU_JAR: project.tasks.shadowJar.archiveName])
-    }
-    from ('package') {
-        include 'license.txt', 'readme.txt'
-    }
-    from("$buildDir/osgi/app") {
-        include '*.jar'
-        into "app"
-    }
-    from("$buildDir/osgi/bundle") {
-        include '*.jar'
-        into "bundle"
-    }
-    into "$buildDir/tmp/nsis-bundled"
 }
 
 // Windows installer
@@ -373,6 +333,11 @@ task nsis(type: Copy, dependsOn: [createExe, createBundlesDir]) {
     from("$buildDir/launch4j/") {
         include 'mucommander.exe'
     }
+    if (project.ext.bundleJRE) {
+        from('jre/win') {
+            into "jre"
+        }
+    }
     from("$buildDir/osgi/") {
         include '*.jar'
     }
@@ -380,7 +345,7 @@ task nsis(type: Copy, dependsOn: [createExe, createBundlesDir]) {
         include 'mucommander.ico'
     }
     from('package/windows') {
-        include 'mucommander.nsi'
+        include project.ext.bundleJRE ? 'mucommander-bundled.nsi' : 'mucommander.nsi'
         filter(ReplaceTokens, tokens: [MU_VERSION: project.version,
                                        MU_ICON: 'mucommander.ico',
                                        MU_LICENSE: 'license.txt',


### PR DESCRIPTION
By default the generated configuration for NSIS to produce Windows installer does not include JRE.
However, when specifying the aforementioned property, e.g.,
`./gradlew nsis -PmucommanderBundleJRE=true`
the generated configuration includes the JRE in order to produce an installation of a bundled (standalone) application.

This is done only for Windows since on Linux we can specify the JRE as a dependency and on macOS an installed application cannot start without being bundled with JRE as it requires Java 11+.