### PR TITLE
File (Spotlight) comments on macOS

### DIFF
--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -17,7 +17,6 @@ dependencies {
 
 jar {
     from configurations.comprise.collect { it.isDirectory() ? it : zipTree(it).matching {
-        exclude 'com/sun/jna/darwin/**'
         exclude 'com/sun/jna/freebsd-x86/**'
         exclude 'com/sun/jna/freebsd-x86-64/**'
         exclude 'com/sun/jna/linux-arm/**'
@@ -49,6 +48,8 @@ jar {
             'com.mucommander.commons.file.protocol,' +
             'com.mucommander.commons.file.protocol.local,' +
             'com.mucommander.commons.file.util,' +
+            'com.sun.jna,' +
+            'com.sun.jna.platform.mac,' +
             'com.sun.jna.platform.win32',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",

--- a/mucommander-commons-file/src/main/java/com/sun/jna/platform/mac/XAttrUtils.java
+++ b/mucommander-commons-file/src/main/java/com/sun/jna/platform/mac/XAttrUtils.java
@@ -1,0 +1,23 @@
+package com.sun.jna.platform.mac;
+
+import com.sun.jna.Memory;
+
+public class XAttrUtils {
+    public static byte[] read(String path, String name) {
+        long bufferLength = XAttr.INSTANCE.getxattr(path, name, null, 0, 0, 0);
+        Memory valueBuffer = new Memory(bufferLength);
+        valueBuffer.clear();
+        long valueLength = XAttr.INSTANCE.getxattr(path, name, valueBuffer, bufferLength, 0, 0);
+
+        if (valueLength < 0) {
+            return null;
+        }
+        return valueBuffer.getByteArray(0, (int)valueLength);
+    }
+
+    public static void write(String path, String name, byte[] value) {
+        Memory valueBuffer = new Memory(value.length);
+        valueBuffer.write(0, value, 0, value.length);
+        XAttr.INSTANCE.setxattr(path, name, valueBuffer, valueBuffer.size(), 0, 0);
+    }
+}

--- a/mucommander-commons-file/src/main/java/com/sun/jna/platform/mac/XAttrUtils.java
+++ b/mucommander-commons-file/src/main/java/com/sun/jna/platform/mac/XAttrUtils.java
@@ -3,15 +3,20 @@ package com.sun.jna.platform.mac;
 import com.sun.jna.Memory;
 
 public class XAttrUtils {
+    public static final String COMMENT = "com.apple.metadata:kMDItemFinderComment";
+
     public static byte[] read(String path, String name) {
         long bufferLength = XAttr.INSTANCE.getxattr(path, name, null, 0, 0, 0);
+        if (bufferLength <= 0)
+            return null;
+
         Memory valueBuffer = new Memory(bufferLength);
         valueBuffer.clear();
         long valueLength = XAttr.INSTANCE.getxattr(path, name, valueBuffer, bufferLength, 0, 0);
 
-        if (valueLength < 0) {
+        if (valueLength < 0)
             return null;
-        }
+
         return valueBuffer.getByteArray(0, (int)valueLength);
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Vector;
 import java.util.function.Consumer;
 
+import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JTabbedPane;
 
 import org.slf4j.Logger;
@@ -35,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.runtime.JavaVersion;
+import com.mucommander.commons.util.Pair;
 import com.mucommander.desktop.AbstractTrash;
 import com.mucommander.desktop.DefaultDesktopAdapter;
 import com.mucommander.desktop.DesktopAdapter;
@@ -588,5 +591,9 @@ public class DesktopManager {
 
     public static void customizeMainFrame(Window window) {
         desktop.customizeMainFrame(window);
+    }
+
+    public static List<Pair<JLabel, JComponent>> getExtendedFileProperties(AbstractFile file) {
+        return desktop.getExtendedFileProperties(file);
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/file/PropertiesDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/file/PropertiesDialog.java
@@ -24,26 +24,25 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowEvent;
+import java.util.List;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 import com.mucommander.commons.file.util.FileSet;
-import com.mucommander.commons.file.util.OSXFileUtils;
-import com.mucommander.commons.runtime.OsFamily;
-import com.mucommander.commons.runtime.OsVersion;
+import com.mucommander.commons.util.Pair;
 import com.mucommander.commons.util.ui.dialog.DialogToolkit;
 import com.mucommander.commons.util.ui.dialog.FocusDialog;
 import com.mucommander.commons.util.ui.layout.XAlignedComponentPanel;
 import com.mucommander.commons.util.ui.layout.YBoxPanel;
-import com.mucommander.commons.util.ui.text.MultiLineLabel;
+import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.job.FileJobState;
 import com.mucommander.job.impl.PropertiesJob;
 import com.mucommander.text.SizeFormat;
@@ -127,14 +126,9 @@ public class PropertiesDialog extends FocusDialog implements Runnable, ActionLis
         sizePanel.add(new JLabel(dial = new SpinningDial()));
         labelPanel.addRow(Translator.get("size")+":", sizePanel, 6);
 
-        if(OsFamily.MAC_OS_X.isCurrent() && OsVersion.MAC_OS_X_10_4.isCurrentOrHigher()
-        && isSingleFile && singleFile.hasAncestor(LocalFile.class)) {
-            String comment = OSXFileUtils.getSpotlightComment(singleFile);
-            JLabel commentLabel = new JLabel(Translator.get("comment")+":");
-            commentLabel.setAlignmentY(JLabel.TOP_ALIGNMENT);
-            commentLabel.setVerticalAlignment(SwingConstants.TOP);
-
-            labelPanel.addRow(commentLabel, new MultiLineLabel(comment), 6);
+        if (isSingleFile && singleFile.hasAncestor(LocalFile.class)) {
+            List<Pair<JLabel, JComponent>> infos = DesktopManager.getExtendedFileProperties(singleFile);
+            infos.forEach(info -> labelPanel.addRow(info.first, info.second, 6));
         }
 
         updateLabels();

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopAdapter.java
@@ -19,12 +19,17 @@ package com.mucommander.desktop;
 
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.filter.FileFilter;
+import com.mucommander.commons.util.Pair;
 import com.mucommander.os.notifier.AbstractNotifier;
 
 import java.awt.Window;
 import java.awt.event.MouseEvent;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
+import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JTabbedPane;
 
 /**
@@ -165,4 +170,5 @@ public interface DesktopAdapter {
     default Consumer<JTabbedPane> getTabbedPaneCustomizer() { return null; }
     default void postCopy(AbstractFile source, AbstractFile target) {}
     default void customizeMainFrame(Window window) {}
+    default List<Pair<JLabel, JComponent>> getExtendedFileProperties(AbstractFile file) { return Collections.emptyList(); }
 }

--- a/mucommander-os-macos/build.gradle
+++ b/mucommander-os-macos/build.gradle
@@ -21,7 +21,9 @@ dependencies {
     compile project(":mucommander-os-api")
     compile project(":mucommander-process")
     compile project(":mucommander-translator")
+
     compile 'org.slf4j:slf4j-api:1.7.26'
+    compile 'com.googlecode.plist:dd-plist:1.23'
 
     // the java.desktop module that contains macOS-specific extensions
     compileOnly files('libs/java.desktop.jar')

--- a/mucommander-os-macos/build.gradle
+++ b/mucommander-os-macos/build.gradle
@@ -16,6 +16,7 @@ repositories.jcenter()
 compileJava.options.compilerArgs += ['--release', '11']
 
 dependencies {
+    compile project(":mucommander-commons-util")
     compile project(":mucommander-core")
     compile project(":mucommander-os-api")
     compile project(":mucommander-process")

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -20,9 +20,14 @@ package com.mucommander.desktop.macos;
 import java.awt.Window;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
+import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingConstants;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,10 +41,14 @@ import com.mucommander.command.CommandType;
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 import com.mucommander.commons.runtime.OsFamily;
+import com.mucommander.commons.runtime.OsVersion;
+import com.mucommander.commons.util.Pair;
+import com.mucommander.commons.util.ui.text.MultiLineLabel;
 import com.mucommander.desktop.DefaultDesktopAdapter;
 import com.mucommander.desktop.DesktopInitialisationException;
 import com.mucommander.desktop.TrashProvider;
 import com.mucommander.os.notifier.AbstractNotifier;
+import com.mucommander.text.Translator;
 import com.mucommander.ui.macos.OSXIntegration;
 import com.mucommander.ui.macos.TabbedPaneUICustomizer;
 import com.mucommander.ui.notifier.GrowlNotifier;
@@ -132,5 +141,17 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
 
     public void customizeMainFrame(Window window) {
         FullScreenUtilities.setWindowCanFullScreen(window, true);
+    }
+
+    @Override
+    public List<Pair<JLabel, JComponent>> getExtendedFileProperties(AbstractFile file) {
+        if (OsVersion.MAC_OS_X_10_4.isCurrentOrHigher()) {
+            String comment = OSXFileUtils.getSpotlightComment(file);
+            JLabel commentLabel = new JLabel(Translator.get("comment")+":");
+            commentLabel.setAlignmentY(JLabel.TOP_ALIGNMENT);
+            commentLabel.setVerticalAlignment(SwingConstants.TOP);
+            return Collections.singletonList(new Pair<>(commentLabel, new MultiLineLabel(comment)));
+        }
+        return Collections.emptyList();
     }
 }

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXFileUtils.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXFileUtils.java
@@ -38,6 +38,9 @@ import com.sun.jna.platform.mac.XAttrUtils;
 public class OSXFileUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(OSXFileUtils.class);
 
+    /** AppleScript that sets file comment */
+    public static final String SET_COMMENT_APPLESCRIPT = "tell application \"Finder\" to set comment of file {posix file \"%s\"} to \"%s\"";
+
     /**
      * Returns the Spotlight/Finder comment of the given file. The specified file must be a LocalFile,
      * or have a LocalFile as an ancestor.

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXFileUtils.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXFileUtils.java
@@ -16,7 +16,7 @@
  */
 
 
-package com.mucommander.commons.file.util;
+package com.mucommander.desktop.macos;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -61,7 +61,7 @@ public class OSXFileUtils {
      * @return the Spotlight/Finder comment of the specified file
      */
     public static String getSpotlightComment(AbstractFile file) {
-        if(!(OsFamily.MAC_OS_X.isCurrent() && OsVersion.MAC_OS_X_10_4.isCurrentOrHigher()))
+        if(!OsVersion.MAC_OS_X_10_4.isCurrentOrHigher())
             return null;
 
         InputStream pin = null;

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXFileUtils.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXFileUtils.java
@@ -18,19 +18,17 @@
 
 package com.mucommander.desktop.macos;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.io.UnsupportedEncodingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.dd.plist.BinaryPropertyListParser;
+import com.dd.plist.NSString;
+import com.dd.plist.PropertyListFormatException;
 import com.mucommander.commons.file.AbstractFile;
-import com.mucommander.commons.io.StreamUtils;
-import com.mucommander.commons.runtime.OsFamily;
 import com.mucommander.commons.runtime.OsVersion;
+import com.sun.jna.platform.mac.XAttrUtils;
 
 /**
  * This class contains methods for file operations that are specific to Mac OS X.
@@ -39,9 +37,6 @@ import com.mucommander.commons.runtime.OsVersion;
  */
 public class OSXFileUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(OSXFileUtils.class);
-
-    /** Pattern matching the Spotlight comment in the output of the 'mdls' command */
-    private final static Pattern MDLS_COMMENT_PATTERN = Pattern.compile("\".*\"$");
 
     /**
      * Returns the Spotlight/Finder comment of the given file. The specified file must be a LocalFile,
@@ -64,43 +59,17 @@ public class OSXFileUtils {
         if(!OsVersion.MAC_OS_X_10_4.isCurrentOrHigher())
             return null;
 
-        InputStream pin = null;
+        byte[] bytes = XAttrUtils.read(file.getAbsolutePath(), XAttrUtils.COMMENT);
+        if (bytes == null)
+            return null;
+
+        NSString comment;
         try {
-            Process process = Runtime.getRuntime().exec(new String[]{"mdls", "-name", "kMDItemFinderComment", file.getAbsolutePath()});
-            process.waitFor();
-
-            if(process.exitValue()!=0)
-                return null;
-
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            pin = process.getInputStream();
-            StreamUtils.copyStream(pin, bout);
-
-            // Sample output when there is a comment:
-            // kMDItemFinderComment = "This is a spotlight comment"
-            //
-            // Sample output when there is no comment:
-            // kMDItemFinderComment = (null)
-            String output = new String(bout.toByteArray());
-            Matcher matcher = MDLS_COMMENT_PATTERN.matcher(output);
-
-            if(matcher.find()) {
-                // Strip off the quotes surrounding the comment
-                String group = matcher.group();
-                return group.substring(1, group.length()-1);
-            }
-
+            comment = (NSString) BinaryPropertyListParser.parse(bytes);
+        } catch (UnsupportedEncodingException | PropertyListFormatException e) {
+            LOGGER.error("failed to read comment of: " + file.getAbsolutePath());
             return null;
         }
-        catch(Exception e) {
-            LOGGER.info("Caught exception", e);
-
-            return null;
-        }
-        finally {
-            if(pin!=null)
-                try { pin.close(); }
-                catch(IOException e) {}
-        }
+        return comment.getContent();
     }
 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -35,7 +35,7 @@ New features:
 - 
 
 Improvements:
-- 
+- Copying local files on macOS also copies their (Spotlight) comment.
 
 Localization:
 - 


### PR DESCRIPTION
1. Move handling of the comments to the macOS-specific bundle (mucommander-os-macos)
2. Retrieve the comments via JNA rather than invoking the `mdls` command
3. Copy comments as part of copying local files
