### PR TITLE
Bring the license back to the license dialog

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/RuntimeConstants.java
+++ b/mucommander-core/src/main/java/com/mucommander/RuntimeConstants.java
@@ -36,8 +36,6 @@ public class RuntimeConstants {
 	
     // - Constant paths ------------------------------------------------------------------------------------------------
     // -----------------------------------------------------------------------------------------------------------------
-    /** Path to the muCommander dictionary. */
-    public static final String DICTIONARY_FILE = "/dictionary.txt";
     /** Path to the themes directory. */
     public static final String THEMES_PATH     = "/themes";
     /** Path to the muCommander license file. */

--- a/mucommander-core/src/main/resources/license.txt
+++ b/mucommander-core/src/main/resources/license.txt
@@ -1,0 +1,1 @@
+../../../../package/license.txt

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -41,7 +41,7 @@ Localization:
 - 
 
 Bug fixes:
-- 
+- The license is presented in the license dialog.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This


### PR DESCRIPTION
The `license.txt` file was not packaged with the `mucommander-core` bundle and therefore was inaccessible by the license dialog.