### PR TITLE
Eliminate a race that hinders automatic refresh

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/core/FolderChangeMonitor.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/FolderChangeMonitor.java
@@ -61,9 +61,6 @@ public class FolderChangeMonitor implements Runnable, WindowListener, LocationLi
     /** True when the current folder is currently being changed */
     private boolean folderChanging;
 
-    /** Current folder's date */
-    private long currentFolderDate;
-
     /** Number of milliseconds to wait before next folder check */
     private long waitBeforeCheckTime;
 	
@@ -136,9 +133,6 @@ public class FolderChangeMonitor implements Runnable, WindowListener, LocationLi
         // Listen to folder changes to know when a folder is being / has been changed
         folderPanel.getLocationManager().addLocationListener(this);
 
-        AbstractFile currentFolder = folderPanel.getCurrentFolder();
-        this.currentFolderDate = currentFolder.getDate();
-
         // Folder contents is up-to-date let's wait before checking it for changes
         this.lastCheckTimestamp = System.currentTimeMillis();
         this.waitBeforeCheckTime = waitAfterRefresh;
@@ -204,12 +198,8 @@ public class FolderChangeMonitor implements Runnable, WindowListener, LocationLi
     /**
      * Forces this monitor to update current folder information. This method should be called when a folder has been
      * manually refreshed, so that this monitor doesn't detect changes and try to refresh the table again.
-     *
-     * @param folder the new current folder
      */
-    private void updateFolderInfo(AbstractFile folder) {
-        this.currentFolderDate = folder.getDate();
-
+    private void updateFolderInfo() {
         // Reset time average
         totalCheckTime = 0;
         nbSamples = 0;
@@ -257,7 +247,7 @@ public class FolderChangeMonitor implements Runnable, WindowListener, LocationLi
         totalCheckTime += System.currentTimeMillis()-timeStamp;
         nbSamples++;
 
-        if (date == currentFolderDate)
+        if (date == folderPanel.getLocationManager().getCurrentFolderDate())
             return false;
 
         LOGGER.debug(this+" ("+currentFolder.getName()+") Detected changes in current folder, refreshing table!");
@@ -274,7 +264,7 @@ public class FolderChangeMonitor implements Runnable, WindowListener, LocationLi
 
     public void locationChanged(LocationEvent locationEvent) {
         // Update new current folder info
-        updateFolderInfo(locationEvent.getFolderPanel().getCurrentFolder());
+        updateFolderInfo();
 
         folderChanging = false;
     }

--- a/mucommander-core/src/main/java/com/mucommander/ui/event/LocationManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/event/LocationManager.java
@@ -45,6 +45,9 @@ public class LocationManager {
     /** Current location presented in the FolderPanel */
     private AbstractFile currentFolder;
 
+    /** Current folder's modification date */
+    private long currentFolderDate;
+
     /** Filters out unwanted files when listing folder contents */
 	private ConfigurableFolderFilter configurableFolderFilter = new ConfigurableFolderFilter();
 
@@ -72,7 +75,8 @@ public class LocationManager {
      * @param folder the {@link AbstractFile} that is going to be presented in the {@link FolderPanel}
      */
     public void setCurrentFolder(AbstractFile folder, AbstractFile fileToSelect, boolean changeLockedTab) {
-    	LOGGER.trace("calling ls()");
+        LOGGER.trace("calling ls()");
+        currentFolderDate = folder.getDate();
     	AbstractFile[] children;
     	try {
     	    children = folder.ls(configurableFolderFilter);
@@ -104,6 +108,19 @@ public class LocationManager {
      */
     public AbstractFile getCurrentFolder() {
     	return currentFolder;
+    }
+
+    /**
+     * Return the modification date of {@link LocationManager#currentFolder}
+     * as it appeared right before listing its children.
+     * Note that it may return the modification date prior to the lasts
+     * listing in case the file as been modified after calling {@link AbstractFile#getDate()}
+     * and before calling {@link AbstractFile#ls()}.
+     *
+     * @return the modification date of the currently presented folder.
+     */
+    public long getCurrentFolderDate() {
+        return currentFolderDate;
     }
 
     public FolderChangeMonitor getFolderChangeMonitor() {

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -44,6 +44,7 @@ Localization:
 Bug fixes:
 - The license is presented in the license dialog.
 - Added back missing quote characters in various dialogs (e.g., doesnt -> doesn't)
+- Eliminate a race that may have caused currently presented folders not to refresh automatically.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This


### PR DESCRIPTION
There was a potential race that may have caused changes in currently
presented folders to get unnoticed by the automatic refreshs mechanism:
1. The location of a folder panel is changed
2. The children of the presented folder are listed
3. The children of the presented folder are changed
4. The modification date of the presented folders is queried
5. Consequently, the presented folder wouldn't get refreshed and so
   the changes in step 4 wouldn't have been reflected in the UI.

This is solved by querying the folder's modification date prior to
listing its children. This may result in a redundant refresh later
on, which is better than the possibily of the UI not catching up
with changes to the currently presented folder.