### PR TITLE
Package the portable version as a zip archive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,7 +347,7 @@ task nsis(type: Copy, dependsOn: [createExe, createBundlesDir]) {
 }
 
 // Portable packaging
-task portable(dependsOn: [createExe, createBundlesDir], type: Tar) {
+task portable(dependsOn: [createExe, createBundlesDir], type: Zip) {
     from ("$buildDir/launch4j") {
         include 'mucommander.exe'
     }
@@ -375,8 +375,6 @@ task portable(dependsOn: [createExe, createBundlesDir], type: Tar) {
     }
 
     classifier = 'portable'
-    extension = 'tar.gz'
-    compression = Compression.GZIP
     version = project.version+'-'+project.ext.release
 }
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -38,6 +38,7 @@ Improvements:
 - Copy file's (Spotlight) comment and user tags when copying local files on macOS.
 - Exclude OSGi-cli from packaging, avoiding the creation of .osgiaas_cli_history file on shutdown.
 - Added a new icon for the virtual bookmarks file system (bookmark://).
+- Package the 'portable' version packaged as zip archive rather than "tarball".
 
 Localization:
 - 


### PR DESCRIPTION
Since it is easier to extract zip archives than "tarballs" on some operating systems.