### PR TITLE
Add nightly builds back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # muCommander
 
-[![Version](http://img.shields.io/badge/version-0.9.5-blue.svg?style=flat)](https://github.com/mucommander/mucommander/releases)
+[![Version](http://img.shields.io/badge/version-0.9.5-blue.svg?style=flat)](https://github.com/mucommander/mucommander/releases/tag/nightly)
 [![License](http://img.shields.io/badge/License-GPL-blue.svg)](http://www.gnu.org/copyleft/gpl.html)
 [![Build Status](https://travis-ci.org/mucommander/mucommander.svg)](https://travis-ci.org/mucommander/mucommander)
 [![Coverity Scan](https://scan.coverity.com/projects/3642/badge.svg)](https://scan.coverity.com/projects/3642)


### PR DESCRIPTION
This PR updates the readme page to point to nightly builds that are produced as described in [this post](https://ahadas.com/nightly-builds-jenkins-github/).