### PR TITLE
ensure the felix-cache folder is created on Linux

### DIFF
--- a/package/unix/postinst
+++ b/package/unix/postinst
@@ -1,3 +1,4 @@
 #! /bin/sh
 ln -s /usr/share/mucommander/mucommander.sh /usr/bin/mucommander
+mkdir -p /usr/share/mucommander/felix-cache
 chmod 777 /usr/share/mucommander/felix-cache


### PR DESCRIPTION
This prevents the installation to fail due to the lack of /usr/share/mucommander/felix-cache (fix #332)