### PR TITLE
System files filtering on macOS

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/MacOsSystemFolder.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/MacOsSystemFolder.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.mucommander.commons.file.util.PathUtils;
 import com.mucommander.commons.runtime.OsFamily;
 
 /**
@@ -88,6 +89,8 @@ public enum MacOsSystemFolder {
 	 * @return true if the given file is a system file on macOS, otherwise false.
 	 */
 	public static boolean isSystemFile(AbstractFile file) {
-	    return paths.contains(file.getAbsolutePath());
+	    String path = file.getAbsolutePath();
+	    path = PathUtils.removeTrailingSeparator(path);
+	    return paths.contains(path);
 	}
 }

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/MacOsSystemFolder.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/MacOsSystemFolder.java
@@ -16,6 +16,11 @@
  */
 package com.mucommander.commons.file;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.mucommander.commons.runtime.OsFamily;
 
 /**
  * Top-level Mac OS X system folders hidden by Finder. For more info about those files:
@@ -65,15 +70,24 @@ public enum MacOsSystemFolder {
 
     /** file path */
 	String path;
+	/** Set of the paths declared above */
+	static Set<String> paths;
+
+	static {
+	    if (OsFamily.MAC_OS_X.isCurrent())
+	        paths = Stream.of(values()).map(f -> f.path).collect(Collectors.toSet());
+	}
 
 	MacOsSystemFolder(String path) {
 		this.path = path;
 	}
 
+	/**
+	 * Check if the given file is a system file on macOS.
+	 * @param file the file to check
+	 * @return true if the given file is a system file on macOS, otherwise false.
+	 */
 	public static boolean isSystemFile(AbstractFile file) {
-		for (MacOsSystemFolder folder : values())
-			if (folder.path.equals(file.getAbsolutePath()))
-				return true;
-		return false;
+	    return paths.contains(file.getAbsolutePath());
 	}
 }

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/filter/AbstractFileFilter.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/filter/AbstractFileFilter.java
@@ -17,10 +17,10 @@
 
 package com.mucommander.commons.file.filter;
 
+import java.util.stream.Stream;
+
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.util.FileSet;
-
-import java.util.Vector;
 
 
 /**
@@ -76,18 +76,9 @@ public abstract class AbstractFileFilter implements FileFilter {
     }
 
     public AbstractFile[] filter(AbstractFile files[]) {
-        Vector<AbstractFile> filteredFilesV = new Vector<AbstractFile>();
-        int nbFiles = files.length;
-        AbstractFile file;
-        for(int i=0; i<nbFiles; i++) {
-            file = files[i];
-            if(match(file))
-                filteredFilesV.add(file);
-        }
-
-        AbstractFile filteredFiles[] = new AbstractFile[filteredFilesV.size()];
-        filteredFilesV.toArray(filteredFiles);
-        return filteredFiles;
+        return Stream.of(files)
+                .filter(this::match)
+                .toArray(AbstractFile[]::new);
     }
 
     public void filter(FileSet files) {

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/PreferencesDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/PreferencesDialog.java
@@ -176,12 +176,12 @@ public abstract class PreferencesDialog extends FocusDialog implements ActionLis
     }
 
     /**
-     * Notifies all panels that changes are about to be commited.
+     * Notifies all panels that changes are about to be committed.
      * <p>
      * This gives preference panels a chance to display warning or errors before changes are
      * committed.
      * </p>
-     * @return <code>true</code> if all preference panels are ok with commiting the changes, <code>false</code> otherwise.
+     * @return <code>true</code> if all preference panels are ok with committing the changes, <code>false</code> otherwise.
      */
     public boolean checkCommit() {
         // Ask pref panels to commit changes

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/GeneralPreferencesDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/GeneralPreferencesDialog.java
@@ -122,20 +122,6 @@ public class GeneralPreferencesDialog extends PreferencesDialog {
     // - Misc. ------------------------------------------------------------------
     // --------------------------------------------------------------------------
     /**
-     * Commits the changes and writes the configuration file if necessary.
-     */
-    @Override
-    public void commit() {
-        super.commit();
-        try {
-            MuConfigurations.savePreferences();
-        }
-        catch(Exception e) {
-            InformationDialog.showErrorDialog(this);
-        }
-    }
-
-    /**
      * Releases the singleton.
      */
     @Override

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/ConfigurableFolderFilter.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/ConfigurableFolderFilter.java
@@ -17,15 +17,17 @@
 
 package com.mucommander.ui.main;
 
+import java.util.function.Consumer;
+
 import com.mucommander.commons.conf.ConfigurationEvent;
 import com.mucommander.commons.conf.ConfigurationListener;
 import com.mucommander.commons.file.filter.AndFileFilter;
 import com.mucommander.commons.file.filter.AttributeFileFilter;
 import com.mucommander.commons.file.filter.AttributeFileFilter.FileAttribute;
+import com.mucommander.commons.file.filter.FileFilter;
 import com.mucommander.conf.MuConfigurations;
 import com.mucommander.conf.MuPreference;
 import com.mucommander.conf.MuPreferences;
-import com.mucommander.commons.file.filter.FileFilter;
 import com.mucommander.ui.main.tree.FoldersTreePanel;
 
 /**
@@ -75,29 +77,24 @@ public class ConfigurableFolderFilter extends AndFileFilter implements Configura
      * Adds or removes filters based on configuration changes.
      */
     public void configurationChanged(ConfigurationEvent event) {
-        String var = event.getVariable();
-
+        FileFilter fileFilter = null;
+        switch(event.getVariable()) {
         // Show or hide hidden files
-        if (var.equals(MuPreferences.SHOW_HIDDEN_FILES)) {
-            if(event.getBooleanValue())
-                removeFileFilter(hiddenFileFilter);
-            else
-                addFileFilter(hiddenFileFilter);
+        case MuPreferences.SHOW_HIDDEN_FILES:
+            fileFilter = hiddenFileFilter;
+            break;
+            // Show or hide .DS_Store files (macOS option)
+        case MuPreferences.SHOW_DS_STORE_FILES:
+            fileFilter = dsFileFilter;
+            break;
+            // Show or hide system folders (macOS option)
+        case MuPreferences.SHOW_SYSTEM_FOLDERS:
+            fileFilter = systemFileFilter;
+            break;
         }
-        // Show or hide .DS_Store files (Mac OS X option)
-        else if (var.equals(MuPreferences.SHOW_DS_STORE_FILES)) {
-            if(event.getBooleanValue())
-                removeFileFilter(dsFileFilter);
-            else
-                addFileFilter(dsFileFilter);
+        if (fileFilter != null) {
+            Consumer<FileFilter> func = event.getBooleanValue() ? this::removeFileFilter : this::addFileFilter;
+            func.accept(fileFilter);
         }
-        // Show or hide system folders (Mac OS X option)
-        else if (var.equals(MuPreferences.SHOW_SYSTEM_FOLDERS)) {
-            if(event.getBooleanValue())
-                removeFileFilter(systemFileFilter);
-            else
-                addFileFilter(systemFileFilter);
-        }
-
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/Column.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/Column.java
@@ -17,9 +17,9 @@
 
 package com.mucommander.ui.main.table;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.mucommander.commons.file.util.FileComparator;
 import com.mucommander.text.Translator;
@@ -40,7 +40,7 @@ public enum Column {
     GROUP(true, false, FileComparator.GROUP_CRITERION, "ToggleGroupColumn", "SortByGroup");
 
     private static final Map<Integer, Column> ORDINAL_TO_ENUM_MAPPING = new HashMap<Integer, Column>(){{
-        Arrays.stream(Column.values()).forEach(column -> put(column.ordinal(), column));
+        Stream.of(Column.values()).forEach(column -> put(column.ordinal(), column));
     }};
 
     /** Standard minimum column width */

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -49,6 +49,7 @@ Bug fixes:
 - The license is presented in the license dialog.
 - Added back missing quote characters in various dialogs (e.g., doesnt -> doesn't).
 - The up-to-date perferences are reflected in the file tables on every change.
+- System files are filtered out when the 'Show system files' preference is deselected on macOS.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -47,7 +47,8 @@ Localization:
 
 Bug fixes:
 - The license is presented in the license dialog.
-- Added back missing quote characters in various dialogs (e.g., doesnt -> doesn't)
+- Added back missing quote characters in various dialogs (e.g., doesnt -> doesn't).
+- The up-to-date perferences are reflected in the file tables on every change.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -40,6 +40,7 @@ Improvements:
 - Exclude OSGi-cli from packaging, avoiding the creation of .osgiaas_cli_history file on shutdown.
 - Added a new icon for the virtual bookmarks file system (bookmark://).
 - Package the 'portable' version packaged as zip archive rather than "tarball".
+- Accelerate system files filtering on macOS.
 
 Localization:
 - 


### PR DESCRIPTION
This PR improves several aspects related to system files filtering on macOS:
1. Fix the filtering so system files, e.g., `/etc`, will actually be filtered out in the UI
2. Fix an issue that caused the `Show system files` preference (and as a matter of fact also other preferences that should be reflected in the UI) to not being applied when preferences are changed more than once.
3. Reduce the filtering time by minimizing the number of times AbstractFile#getAbsolutePath is called.