### PR TITLE
Drop non-required bundles in OS-dependent packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,9 @@ ospackage {
         include '*.jar'
         exclude 'osgiaas*'
         exclude 'jline*'
+        exclude 'mucommander-os-macos*'
+        exclude 'mucommander-os-openvms*'
+        exclude 'mucommander-os-win*'
         into '/usr/share/mucommander/bundle'
     }
     from ("$buildDir/osgi/app") {

--- a/build.gradle
+++ b/build.gradle
@@ -353,6 +353,9 @@ task nsis(type: Copy, dependsOn: [createExe, createBundlesDir]) {
         include '*.jar'
         exclude 'osgiaas*'
         exclude 'jline*'
+        exclude 'mucommander-os-linux*'
+        exclude 'mucommander-os-macos*'
+        exclude 'mucommander-os-openvms*'
         into "bundle"
     }
     into "$buildDir/tmp/nsis"

--- a/build.gradle
+++ b/build.gradle
@@ -279,6 +279,9 @@ copyToResourcesJava.doLast {
         include 'bundle/**'
         exclude 'bundle/osgiaas*'
         exclude 'bundle/jline*'
+        exclude 'bundle/mucommander-os-linux*'
+        exclude 'bundle/mucommander-os-openvms*'
+        exclude 'bundle/mucommander-os-win*'
         into project.file("${->project.buildDir}/${->project.macAppBundle.appOutputDir}/${->project.macAppBundle.appName}.app/Contents/${->project.macAppBundle.jarSubdir}")
     }
 }


### PR DESCRIPTION
This is a step toward minimizing the packaging size of muCommander.
This PR removes OS-specific bundles that are irrelevant to the target OS.