### PR TITLE
check JAVA_HOME on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,6 +302,9 @@ launch4j {
     if (project.ext.bundleJRE) {
         bundledJre64Bit = true
         bundledJrePath = "jre"
+    } else {
+        bundledJrePath = '%JAVA_HOME%'
+        bundledJreAsFallback = true
     }
     outfile = "mucommander.exe"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -298,6 +298,7 @@ launch4j {
     dontWrapJar = true
     classpath = ['.']
     headerType = "gui"
+    jreMinVersion = "1.8"
     if (project.ext.bundleJRE) {
         bundledJre64Bit = project.ext.bundleJRE
         bundledJrePath = "jre"

--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,7 @@ launch4j {
     headerType = "gui"
     jreMinVersion = "1.8"
     if (project.ext.bundleJRE) {
-        bundledJre64Bit = project.ext.bundleJRE
+        bundledJre64Bit = true
         bundledJrePath = "jre"
     }
     outfile = "mucommander.exe"

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -43,6 +43,7 @@ Improvements:
 - Added a new icon for the virtual bookmarks file system (bookmark://).
 - Package the 'portable' version packaged as zip archive rather than "tarball".
 - Accelerate system files filtering on macOS.
+- The non-bundled version for Windows looks for a JRE also in JAVA_HOME.
 
 Localization:
 - 


### PR DESCRIPTION
With this change, the non-bundled version for Windows looks for a JRE in JAVA_HOME when JRE registry entries cannot be found. This may be the case with JRE/JDK distributions that don't use an installer.