### PR TITLE
fix rpm packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,14 +187,15 @@ ospackage {
         include '*.jar'
         into '/usr/share/mucommander/app'
     }
-    from ('mucommander-core/src/main/resources/images/mucommander/icon128_24.png') {
-        rename '.*', 'mucommander.png'
-        addParentDirs = false
+    from ('mucommander-core/src/main/resources/images/mucommander') {
+        include 'icon128_24.png'
+        rename 'icon128_24.png', 'mucommander.png'
+        addParentDirs false
         into '/usr/share/pixmaps'
     }
     from ('package/unix') {
         include 'mucommander.desktop'
-        addParentDirs = false
+        addParentDirs false
         into '/usr/share/applications'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'com.athaydes.osgi-run' version '1.6.0'
     id 'java'
     id 'org.ajoberstar.grgit' version '3.1.1'
-    id 'nebula.ospackage' version '7.4.2'
+    id 'nebula.ospackage' version '8.3.0'
     id 'com.github.johnrengelman.shadow' version '5.1.0'
     id 'edu.sc.seis.macAppBundle' version '2.3.0'
     id 'edu.sc.seis.launch4j' version '2.4.6'


### PR DESCRIPTION
Our RPM conflicted with the 'filesystem' package that provides the `/usr/share/pixmaps` folder due to an incorrect setting of 'addParentDirs'.