### PR TITLE
Improve detection of GNOME

### DIFF
--- a/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/gnome/ConfiguredGnomeDesktopAdapter.java
+++ b/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/gnome/ConfiguredGnomeDesktopAdapter.java
@@ -23,15 +23,13 @@ import com.mucommander.process.ProcessRunner;
  * @author Nicolas Rinaudo
  */
 public class ConfiguredGnomeDesktopAdapter extends GnomeDesktopAdapter {
-    private static final String ENV_VAR = "GNOME_DESKTOP_SESSION_ID";
 
     public String toString() {return "Gnome Desktop";}
 
     @Override
     public boolean isAvailable() {
-        String var = System.getenv(ENV_VAR);
-
-        return var != null && !var.trim().equals("");
+        String var = System.getenv("GNOME_DESKTOP_SESSION_ID");
+        return var != null && !var.trim().isEmpty();
     }
 
     @Override

--- a/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/gnome/ConfiguredGnomeDesktopAdapter.java
+++ b/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/gnome/ConfiguredGnomeDesktopAdapter.java
@@ -28,7 +28,20 @@ public class ConfiguredGnomeDesktopAdapter extends GnomeDesktopAdapter {
 
     @Override
     public boolean isAvailable() {
-        String var = System.getenv("GNOME_DESKTOP_SESSION_ID");
+        String var = System.getenv("DESKTOP_SESSION");
+        if ("gnome".equalsIgnoreCase(var))
+            return true;
+
+        var = System.getenv("XDG_CURRENT_DESKTOP");
+        if (var != null) {
+            var = var.toLowerCase();
+            if (var.contains("gnome"))
+                return true;
+            if (var.contains("unity"))
+                return true;
+        }
+
+        var = System.getenv("GNOME_DESKTOP_SESSION_ID");
         return var != null && !var.trim().isEmpty();
     }
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -44,6 +44,7 @@ Improvements:
 - Package the 'portable' version packaged as zip archive rather than "tarball".
 - Accelerate system files filtering on macOS.
 - The non-bundled version for Windows looks for a JRE also in JAVA_HOME.
+- New versions of the GNOME desktop environment in which GNOME_DESKTOP_SESSION_ID is not set are now detected.
 
 Localization:
 - 


### PR DESCRIPTION
As it appears on Fedora 32, the current logic for detection of the GNOME desktop environment breaks on recent versions of GNOME since the deprecated environment variable GNOME_DESKTOP_SESSION_ID was removed and neither `gvfs-open` nor `gnome-open` exists.

This PR enhances the current detection logic with checking of the environment variables DESKTOP_SESSION and XDG_CURRENT_DESKTOP.