### PR TITLE
Enable replacing the bundled JRE on macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,6 +296,13 @@ task copyInfoToAppOutputDir(type: Copy) {
     include "readme.txt"
     into "${->project.buildDir}/${->project.macAppBundle.appOutputDir}/"
 }
+copyInfoToAppOutputDir.doLast {
+    copy {
+        from "package/osx"
+        include "replace_jre.sh"
+        into "${->project.buildDir}/${->project.macAppBundle.appOutputDir}/${->project.macAppBundle.appName}.app/Contents/"
+    }
+}
 createDmg.dependsOn copyInfoToAppOutputDir
 
 launch4j {

--- a/package/osx/replace_jre.sh
+++ b/package/osx/replace_jre.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+clear
+echo "Have muCommander use your OS wide JavaAppletPlugin"
+echo ==================================================
+echo
+echo "Pre-requisites check:"
+
+simlink? () {
+test "$(readlink "${1}")";
+}
+
+info_plist=/Library/Internet\ Plug-Ins/JavaAppletPlugin.plugin/Contents/info.plist
+
+if simlink? "${info_plist}"; then echo "  ✓ compatible Java JRE found 👍"; else echo "No compatible Java JRE found 😞 - aborting." && echo && exit; fi
+
+if [ ! -d "/Applications/muCommander.app" ]; then echo "No muCommander app found in your Applications folder 😞 - aborting." && exit; else echo "  ✓ muCommander app found in /Applications 👍"; fi
+echo --------------------------------------------------
+echo
+echo "This script will remove the Java JRE bundled into your muCommander app and"
+echo "instead link to your OS wide JRE install, then launch the modified app."
+echo
+read -p "Proceed now (y|n)? " -n 1 -r
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+echo
+rm -Rf /Applications/muCommander.app/Contents/PlugIns/macOS/Contents/Home/jre
+echo "  ✓ removed the Java bundle in the muCommander app 👍"
+
+cp -a "$info_plist" /Applications/muCommander.app/Contents/PlugIns/macOS/Contents
+ln -s "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home" /Applications/muCommander.app/Contents/PlugIns/macOS/Contents/Home/jre
+echo "  ✓ placed SymLinks to your OS wide Java Plugin into your muCommander app 👍"
+echo
+echo "..launching the modified muCommander app now!"
+open -n "/Applications/muCommander.app"
+else echo
+fi
+echo
+echo "This window will automatically close in 4 seconds..."
+sleep 4
+osascript -e 'tell app "Terminal"' -e 'close (every window whose name contains ".command")' -e 'if number of windows = 0 then quit' -e 'end tell' & exit;

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -39,6 +39,7 @@ Improvements:
 - File-search dialog is loaded with the previously selected search options instead of the default search options.
 - The wildcard characters '*' and '?' can be used within filenames in file-search.
 - Revert the bundled JRE on macOS to version 11.0.4 that appear to be more stable than 11.0.7.
+- Add the replace_jre.sh script that replaces the bundled JRE with the one of JavaAppletPlugin on macOS/Mac OS X.
 
 Localization:
 - Korean translation updated.
@@ -65,6 +66,8 @@ Known issues:
 - Version 5.0 of RAR is not supported. Such archives would appear empty.
 - Issues with browsing Documents/Desktop/Downloads on macOS may be solved by resetting Security and Privacy settings.
   See https://github.com/mucommander/mucommander/wiki/Reset-Security-&-Privacy-Settings-on-macOS for more details.
+- Mac OS X: muCommander may not be able to start on version <= 10.10 (OS X Yosemite) due to incompatibility of the bundled JRE.
+  This can be solved by installing Java 8 and running '/Applications/muCommander.app/Contents/replace_jre.sh'.
 
 License
 -------


### PR DESCRIPTION
Recent versions of Java do not work on relatively old versions of Mac OS X.
This patch adds a script that replaces the bundled JRE with the one of
JavaAppletPlugin to ease running new versions of muCommander on such
versions of Mac OS X.