### PR TITLE
Ref #403 - Provide output message on error

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandBrowse.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandBrowse.java
@@ -26,6 +26,8 @@ import com.mucommander.process.ProcessRunner;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author Nicolas Rinaudo
@@ -39,13 +41,13 @@ class CommandBrowse extends UrlOperation {
     }
 
     @Override
-    public void execute(URL url) throws IOException {
+    public CompletionStage<Optional<String>> execute(URL url) throws IOException {
         Command command = CommandManager.getCommandForAlias(CommandManager.URL_OPENER_ALIAS);
         if (command == null)
             throw new UnsupportedOperationException();
 
         AbstractFile target = FileFactory.getFile(url.toString());
-        ProcessRunner.execute(command.getTokens(target), target);
+        return ProcessRunner.executeAsync(command.getTokens(target), target);
     }
 
     /**

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandOpen.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandOpen.java
@@ -24,6 +24,8 @@ import com.mucommander.desktop.LocalFileOperation;
 import com.mucommander.process.ProcessRunner;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author Nicolas Rinaudo
@@ -60,15 +62,15 @@ class CommandOpen extends LocalFileOperation {
     }
 
     @Override
-    public void execute(AbstractFile file) throws IOException {
+    public CompletionStage<Optional<String>> execute(AbstractFile file) throws IOException {
         Command command = CommandManager.getCommandForFile(file, allowDefault);
 
-        // Attemps to find a command that matches the specified target.
+        // Attempts to find a command that matches the specified target.
         if (command == null)
             throw new UnsupportedOperationException();
 
         // If found, executes it.
-        ProcessRunner.execute(command.getTokens(file), file);
+        return ProcessRunner.executeAsync(command.getTokens(file), file);
     }
 
     /**

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandOpenCommandPrompt.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandOpenCommandPrompt.java
@@ -1,6 +1,9 @@
 package com.mucommander.core.desktop;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
 import com.mucommander.command.Command;
 import com.mucommander.command.CommandManager;
 import com.mucommander.commons.file.AbstractFile;
@@ -14,7 +17,7 @@ class CommandOpenCommandPrompt extends LocalFileOperation {
     }
 
     @Override
-    public void execute(AbstractFile file) throws IOException {
+    public CompletionStage<Optional<String>> execute(AbstractFile file) throws IOException {
         Command command = CommandManager.getCommandForAlias(CommandManager.CMD_OPENER_ALIAS);
         if (command == null)
             throw new UnsupportedOperationException();
@@ -22,7 +25,7 @@ class CommandOpenCommandPrompt extends LocalFileOperation {
         if (!file.isDirectory()) {
             file = file.getParent();
         }
-        ProcessRunner.execute(command.getTokens(file), file);
+        return ProcessRunner.executeAsync(command.getTokens(file), file);
     }
 
     @Override

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandOpenInFileManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/CommandOpenInFileManager.java
@@ -24,6 +24,8 @@ import com.mucommander.desktop.LocalFileOperation;
 import com.mucommander.process.ProcessRunner;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author Nicolas Rinaudo
@@ -35,12 +37,12 @@ class CommandOpenInFileManager extends LocalFileOperation {
     }
 
     @Override
-    public void execute(AbstractFile file) throws IOException {
+    public CompletionStage<Optional<String>> execute(AbstractFile file) throws IOException {
         Command command = CommandManager.getCommandForAlias(CommandManager.FILE_MANAGER_ALIAS);
         if (command == null)
             throw new UnsupportedOperationException();
 
-        ProcessRunner.execute(command.getTokens(file), file);
+        return ProcessRunner.executeAsync(command.getTokens(file), file);
     }
 
     @Override

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
@@ -25,7 +25,9 @@ import java.net.URL;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Vector;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import javax.swing.JComponent;
@@ -91,16 +93,16 @@ public class DesktopManager {
     /** AbstractNotifier instance, null if none is available on the current platform */
     private static AbstractNotifier notifier;
 
-    public static void openCommandPrompt(File file) throws IOException, UnsupportedOperationException {
-        executeOperation(OPEN_COMMAND_PROMPT, new Object[] { file });
+    public static CompletionStage<Optional<String>> openCommandPrompt(File file) throws IOException, UnsupportedOperationException {
+        return executeOperation(OPEN_COMMAND_PROMPT, new Object[] { file });
     }
 
-    public static void openCommandPrompt(String file) throws IOException, UnsupportedOperationException {
-        executeOperation(OPEN_COMMAND_PROMPT, new Object[] { file });
+    public static CompletionStage<Optional<String>> openCommandPrompt(String file) throws IOException, UnsupportedOperationException {
+        return executeOperation(OPEN_COMMAND_PROMPT, new Object[] { file });
     }
 
-    public static void openCommandPrompt(AbstractFile file) throws IOException, UnsupportedOperationException {
-        executeOperation(OPEN_COMMAND_PROMPT, new Object[] { file });
+    public static CompletionStage<Optional<String>> openCommandPrompt(AbstractFile file) throws IOException, UnsupportedOperationException {
+        return executeOperation(OPEN_COMMAND_PROMPT, new Object[] { file });
     }
 
 
@@ -344,13 +346,12 @@ public class DesktopManager {
 
     public static boolean isOperationSupported(String type, Object[] target) {return getSupportedOperation(type, target) != null;}
 
-    public static void executeOperation(String type, Object[] target) throws IOException, UnsupportedOperationException {
+    public static CompletionStage<Optional<String>> executeOperation(String type, Object[] target) throws IOException, UnsupportedOperationException {
         DesktopOperation operation = getSupportedOperation(type, target);
 
         if (operation!= null)
-            operation.execute(target);
-        else
-            throw new UnsupportedOperationException();
+            return operation.execute(target);
+        throw new UnsupportedOperationException();
     }
 
     public static String getOperationName(String type) throws UnsupportedOperationException {
@@ -382,11 +383,11 @@ public class DesktopManager {
 
     public static boolean canBrowse(AbstractFile url) {return isOperationSupported(BROWSE, new Object[] {url});}
 
-    public static void browse(URL url) throws IOException, UnsupportedOperationException {executeOperation(BROWSE, new Object[] {url});}
+    public static CompletionStage<Optional<String>> browse(URL url) throws IOException, UnsupportedOperationException {return executeOperation(BROWSE, new Object[] {url});}
 
-    public static void browse(String url) throws IOException, UnsupportedOperationException {executeOperation(BROWSE, new Object[] {url});}
+    public static CompletionStage<Optional<String>> browse(String url) throws IOException, UnsupportedOperationException {return executeOperation(BROWSE, new Object[] {url});}
 
-    public static void browse(AbstractFile url) throws IOException, UnsupportedOperationException {executeOperation(BROWSE, new Object[] {url});}
+    public static CompletionStage<Optional<String>> browse(AbstractFile url) throws IOException, UnsupportedOperationException {return executeOperation(BROWSE, new Object[] {url});}
 
 
 
@@ -400,11 +401,11 @@ public class DesktopManager {
 
     public static boolean canOpen(AbstractFile file) {return isOperationSupported(OPEN, new Object[] {file});}
 
-    public static void open(File file) throws IOException, UnsupportedOperationException {executeOperation(OPEN, new Object[] {file});}
+    public static CompletionStage<Optional<String>> open(File file) throws IOException, UnsupportedOperationException {return executeOperation(OPEN, new Object[] {file});}
 
-    public static void open(String file) throws IOException, UnsupportedOperationException {executeOperation(OPEN, new Object[] {file});}
+    public static CompletionStage<Optional<String>> open(String file) throws IOException, UnsupportedOperationException {return executeOperation(OPEN, new Object[] {file});}
 
-    public static void open(AbstractFile file) throws IOException, UnsupportedOperationException {executeOperation(OPEN, new Object[] {file});}
+    public static CompletionStage<Optional<String>> open(AbstractFile file) throws IOException, UnsupportedOperationException {return executeOperation(OPEN, new Object[] {file});}
 
 
 
@@ -418,11 +419,11 @@ public class DesktopManager {
 
     public static boolean canOpenInFileManager(AbstractFile file) {return isOperationSupported(OPEN_IN_FILE_MANAGER, new Object[] {file});}
 
-    public static void openInFileManager(File file) throws IOException, UnsupportedOperationException {executeOperation(OPEN_IN_FILE_MANAGER, new Object[] {file});}
+    public static CompletionStage<Optional<String>> openInFileManager(File file) throws IOException, UnsupportedOperationException {return executeOperation(OPEN_IN_FILE_MANAGER, new Object[] {file});}
 
-    public static void openInFileManager(String file) throws IOException, UnsupportedOperationException {executeOperation(OPEN_IN_FILE_MANAGER, new Object[] {file});}
+    public static CompletionStage<Optional<String>> openInFileManager(String file) throws IOException, UnsupportedOperationException {return executeOperation(OPEN_IN_FILE_MANAGER, new Object[] {file});}
 
-    public static void openInFileManager(AbstractFile file) throws IOException, UnsupportedOperationException {executeOperation(OPEN_IN_FILE_MANAGER, new Object[] {file});}
+    public static CompletionStage<Optional<String>> openInFileManager(AbstractFile file) throws IOException, UnsupportedOperationException {return executeOperation(OPEN_IN_FILE_MANAGER, new Object[] {file});}
 
     private static String getFileManagerName(DesktopOperation operation) throws UnsupportedOperationException {
         if(operation == null)

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/InternalBrowse.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/InternalBrowse.java
@@ -21,6 +21,9 @@ import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import com.mucommander.desktop.UrlOperation;
 
@@ -72,14 +75,19 @@ class InternalBrowse extends UrlOperation {
     /**
      * Opens the specified URL in the system's default browser.
      * @param  url         URL to browse.
-     * @throws IOException if an error occured.
+     * @return             the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
+     * @throws IOException if an error occurred.
      */
     @Override
-    public void execute(URL url) throws IOException {
+    public CompletionStage<Optional<String>> execute(URL url) throws IOException {
         // If java.awt.Desktop browsing is available, use it.
         if(isAvailable()) {
-            try {getDesktop().browse(url.toURI()); return;}
-            catch(URISyntaxException e) {throw new IOException(e.getMessage());}
+            try {
+                getDesktop().browse(url.toURI());
+                return CompletableFuture.completedFuture(Optional.empty());
+            } catch(URISyntaxException e) {
+                throw new IOException(e.getMessage());
+            }
         }
 
         throw new UnsupportedOperationException();

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/InternalOpen.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/InternalOpen.java
@@ -20,6 +20,9 @@ package com.mucommander.core.desktop;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.desktop.LocalFileOperation;
@@ -71,11 +74,12 @@ class InternalOpen extends LocalFileOperation {
     public boolean isAvailable() {return getDesktop() != null && getDesktop().isSupported(Desktop.Action.OPEN);}
 
     @Override
-    public void execute(AbstractFile file) throws IOException {
+    public CompletionStage<Optional<String>> execute(AbstractFile file) throws IOException {
         if(isAvailable())
             getDesktop().open(new File(file.getAbsolutePath()));
         else
             throw new UnsupportedOperationException();
+        return CompletableFuture.completedFuture(Optional.empty());
     }
     /**
      * Returns the action's label.

--- a/mucommander-core/src/main/java/com/mucommander/job/FileJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/FileJob.java
@@ -28,7 +28,6 @@ import com.mucommander.commons.file.CachedFile;
 import com.mucommander.commons.file.util.FileSet;
 import com.mucommander.job.ui.DialogResult;
 import com.mucommander.job.ui.UserInputHelper;
-import com.mucommander.os.notifier.AbstractNotifier;
 import com.mucommander.os.notifier.NotificationType;
 import com.mucommander.text.Translator;
 import com.mucommander.ui.dialog.QuestionDialog;

--- a/mucommander-core/src/main/java/com/mucommander/job/impl/TempExecJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/impl/TempExecJob.java
@@ -27,6 +27,7 @@ import com.mucommander.commons.file.PermissionAccess;
 import com.mucommander.commons.file.PermissionType;
 import com.mucommander.commons.file.util.FileSet;
 import com.mucommander.core.desktop.DesktopManager;
+import com.mucommander.ui.dialog.InformationDialog;
 import com.mucommander.ui.dialog.file.ProgressDialog;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.quicklist.RecentExecutedFilesQL;
@@ -99,7 +100,7 @@ public class TempExecJob extends TempCopyJob {
 
             // Try to open the file.
             try {
-                DesktopManager.open(currentDestFile);
+                InformationDialog.showErrorDialogIfNeeded(getMainFrame(), DesktopManager.open(currentDestFile));
                 RecentExecutedFilesQL.addFile(file);
             }
             catch(Exception e) {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/AbstractViewerAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/AbstractViewerAction.java
@@ -22,11 +22,9 @@ import java.util.Map;
 import com.mucommander.command.Command;
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.FileOperation;
-import com.mucommander.commons.file.filter.AndFileFilter;
-import com.mucommander.commons.file.filter.AttributeFileFilter;
-import com.mucommander.commons.file.filter.AttributeFileFilter.FileAttribute;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 import com.mucommander.commons.file.filter.FileOperationFilter;
+import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.job.impl.TempOpenWithJob;
 import com.mucommander.process.ProcessRunner;
 import com.mucommander.text.Translator;
@@ -78,9 +76,12 @@ abstract class AbstractViewerAction extends SelectedFileAction {
             if(customCommand != null) {
                 // If it's local, run the custom editor on it.
                 if(file.hasAncestor(LocalFile.class)) {
-                    try {ProcessRunner.execute(customCommand.getTokens(file), file);}
+                    try {
+                        InformationDialog.showErrorDialogIfNeeded(getMainFrame(), ProcessRunner.executeAsync(customCommand.getTokens(file), file));
+                    }
                     catch(Exception e) {
-                        InformationDialog.showErrorDialog(mainFrame);}
+                        InformationDialog.showErrorDialog(mainFrame);
+                    }
                 }
 
                 // If it's distant, copies it locally before running the custom editor on it.

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CommandAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CommandAction.java
@@ -83,10 +83,10 @@ public class CommandAction extends MuAction {
 
         // If we're working with local files, go ahead and runs the command.
         if(selectedFiles.getBaseFolder().getURL().getScheme().equals(LocalFile.SCHEMA) && (selectedFiles.getBaseFolder().hasAncestor(LocalFile.class))) {
-            try {ProcessRunner.execute(command.getTokens(selectedFiles), selectedFiles.getBaseFolder());}
-            catch(Exception e) {
+            try {
+                InformationDialog.showErrorDialogIfNeeded(getMainFrame(), ProcessRunner.executeAsync(command.getTokens(selectedFiles), selectedFiles.getBaseFolder()));
+            } catch(Exception e) {
                 InformationDialog.showErrorDialog(mainFrame);
-
                 LOGGER.debug("Failed to execute command: " + command.getCommand(), e);
             }
         }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenAction.java
@@ -35,6 +35,7 @@ import com.mucommander.conf.MuPreference;
 import com.mucommander.conf.MuPreferences;
 import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.job.impl.TempExecJob;
+import com.mucommander.process.ProcessRunner;
 import com.mucommander.text.Translator;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
@@ -134,9 +135,9 @@ public class OpenAction extends MuAction {
         // Opens local files using their native associations.
         else if(resolvedFile.getURL().getScheme().equals(LocalFile.SCHEMA) && (resolvedFile.hasAncestor(LocalFile.class))) {
             try {
-            	DesktopManager.open(resolvedFile);
-            	RecentExecutedFilesQL.addFile(resolvedFile);
-    		}
+                InformationDialog.showErrorDialogIfNeeded(getMainFrame(), DesktopManager.open(resolvedFile));
+                RecentExecutedFilesQL.addFile(resolvedFile);
+            }
             catch(IOException e) {
                 InformationDialog.showErrorDialog(mainFrame);
             }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenNativelyAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenNativelyAction.java
@@ -67,8 +67,8 @@ public class OpenNativelyAction extends MuAction {
         else {
             // Tries to execute file with native file associations
             try {
-            	DesktopManager.open(selectedFile);
-            	RecentExecutedFilesQL.addFile(selectedFile);
+                InformationDialog.showErrorDialogIfNeeded(getMainFrame(), DesktopManager.open(selectedFile));
+                RecentExecutedFilesQL.addFile(selectedFile);
         	}
             catch(IOException e) {
                 InformationDialog.showErrorDialog(mainFrame);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenURLInBrowserAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenURLInBrowserAction.java
@@ -53,9 +53,9 @@ public class OpenURLInBrowserAction extends MuAction {
     public void performAction() {
         Object url = getValue(URL_PROPERTY_KEY);
 
-        if(url!=null && (url instanceof String)) {
+        if(url instanceof String) {
             try {
-                DesktopManager.browse(new URL((String)url));
+                InformationDialog.showErrorDialogIfNeeded(getMainFrame(), DesktopManager.browse(new URL((String)url)));
             }
             catch(Exception e) {
                 InformationDialog.showErrorDialog(mainFrame);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RevealInDesktopAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RevealInDesktopAction.java
@@ -64,7 +64,7 @@ public class RevealInDesktopAction extends ParentFolderAction {
     @Override
     public void performAction() {
         try {
-            DesktopManager.openInFileManager(mainFrame.getActivePanel().getCurrentFolder());
+            InformationDialog.showErrorDialogIfNeeded(getMainFrame(), DesktopManager.openInFileManager(mainFrame.getActivePanel().getCurrentFolder()));
         }
         catch(Exception e) {
             InformationDialog.showErrorDialog(mainFrame);

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/InformationDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/InformationDialog.java
@@ -27,6 +27,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -100,6 +102,20 @@ public class InformationDialog {
      */
     public static void showErrorDialog(Component parentComponent, String message) {
         showErrorDialog(parentComponent, null, message, null, null);
+    }
+
+    /**
+     * Brings up an error dialog with the specified message and a generic localized title if and only if the
+     * provided asynchronous task provides an output message.
+     *
+     * @param parentComponent determines the <code>Frame</code> in which the dialog is displayed; if <code>null</code>,
+     * or if the parentComponent has no <code>Frame</code>, a default <code>Frame</code> is used
+     * @param asyncTask the asynchronous task that will provide an output message to display in case of error
+     */
+    public static void showErrorDialogIfNeeded(Component parentComponent, CompletionStage<Optional<String>> asyncTask) {
+        asyncTask.thenAccept(
+            outputMessages -> outputMessages.ifPresent(s -> InformationDialog.showErrorDialog(parentComponent, s))
+        );
     }
 
     /**

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopOperation.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopOperation.java
@@ -18,8 +18,8 @@
 package com.mucommander.desktop;
 
 import java.io.IOException;
-
-import com.mucommander.desktop.UrlOperation;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Contract for basic desktop operations.
@@ -76,7 +76,7 @@ public interface DesktopOperation {
      * </p>
      * @return the operation's name.
      */
-    public String getName();
+    String getName();
 
     /**
      * Checks whether the operation is available.
@@ -93,7 +93,7 @@ public interface DesktopOperation {
      * @return <code>true</code> if the operation is available, <code>false</code> otherwise.
      * @see    #canExecute(Object[])
      */
-    public boolean isAvailable();
+    boolean isAvailable();
 
     /**
      * Checks whether an operation is supported for the specified parameters.
@@ -125,7 +125,7 @@ public interface DesktopOperation {
      * @param  target parameters to check.
      * @return        <code>true</code> if the operation can be executed with the specified parameters, <code>false</code> otherwise.
      */
-    public boolean canExecute(Object[] target);
+    boolean canExecute(Object[] target);
 
     /**
      * Executes the operation on the specified parameters.
@@ -134,8 +134,9 @@ public interface DesktopOperation {
      * through {@link #canExecute(Object[])}.
      * </p>
      * @param  target                        parameters on which to execute the operation.
+     * @return                               the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
      * @throws IOException                   if an error occurs.
      * @throws UnsupportedOperationException if the operation is not supported for the specified parameters.
      */
-    public void execute(Object[] target) throws IOException, UnsupportedOperationException;
+    CompletionStage<Optional<String>> execute(Object[] target) throws IOException, UnsupportedOperationException;
 }

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/LocalFileOperation.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/LocalFileOperation.java
@@ -24,6 +24,8 @@ import com.mucommander.commons.file.protocol.local.SpecialWindowsLocation;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * {@link DesktopOperation} implementation meant for actions that involve local files.
@@ -48,10 +50,11 @@ public abstract class LocalFileOperation implements DesktopOperation {
     /**
      * Executes the operation on the specified file.
      * @param  file                          file on which to execute the operation.
+     * @return                               the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
      * @throws IOException                   if an error occurs.
      * @throws UnsupportedOperationException if the operation is not supported.
      */
-    public abstract void execute(AbstractFile file) throws IOException, UnsupportedOperationException;
+    public abstract CompletionStage<Optional<String>> execute(AbstractFile file) throws IOException, UnsupportedOperationException;
 
     /**
      * Checks whether the operation knows how to deal with the specified file.
@@ -97,19 +100,20 @@ public abstract class LocalFileOperation implements DesktopOperation {
      * implementations should ignore it.
      * </p>
      * @param  target                        parameters of the operation.
+     * @return                               the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
      * @throws IOException                   if an error occurs.
      * @throws UnsupportedOperationException if the operation is not supported.
      * @see                                  #execute(AbstractFile)
      * @see                                  #extractTarget(Object[])
      */
-    public void execute(Object[] target) throws IOException, UnsupportedOperationException {
+    public CompletionStage<Optional<String>> execute(Object[] target) throws IOException, UnsupportedOperationException {
         // Makes sure we received the right kind of parameters.
         AbstractFile file = extractTarget(target);
         if(file == null)
             throw new UnsupportedOperationException();
 
         // Execute the operation.
-        execute(file);
+        return execute(file);
     }
 
 

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/UrlOperation.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/UrlOperation.java
@@ -20,6 +20,8 @@ package com.mucommander.desktop;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * {@link DesktopOperation} implementation meant for actions that involve <code>java.net.URL</code>.
@@ -44,10 +46,11 @@ public abstract class UrlOperation implements DesktopOperation {
     /**
      * Executes the operation on the specified URL.
      * @param  url                           URL on which to execute the operation.
+     * @return                               the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
      * @throws IOException                   if an error occurs.
      * @throws UnsupportedOperationException if the operation is not supported.
      */
-    public abstract void execute(URL url) throws IOException;
+    public abstract CompletionStage<Optional<String>> execute(URL url) throws IOException;
 
     /**
      * Checks whether the operation knows how to deal with the specified URL.
@@ -96,17 +99,18 @@ public abstract class UrlOperation implements DesktopOperation {
      * implementations should ignore it.
      * </p>
      * @param  target                        parameters of the operation.
+     * @return                               the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
      * @throws IOException                   if an error occurs.
      * @throws UnsupportedOperationException if the operation is not supported.
      * @see                                  #execute(URL)
      * @see                                  #extractTarget(Object[])
      */
-    public void execute(Object[] target) throws IOException, UnsupportedOperationException {
+    public CompletionStage<Optional<String>> execute(Object[] target) throws IOException, UnsupportedOperationException {
         URL url;
 
         if((url = extractTarget(target)) == null)
             throw new UnsupportedOperationException();
-        execute(url);
+        return execute(url);
     }
 
 

--- a/mucommander-process/src/main/java/com/mucommander/process/AsyncProcessListener.java
+++ b/mucommander-process/src/main/java/com/mucommander/process/AsyncProcessListener.java
@@ -1,0 +1,47 @@
+package com.mucommander.process;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Listener used to provide the output messages to the end-user when an error occurs while executing a task
+ * with the {@link ProcessRunner}.
+ *
+ * @author Nicolas Filotto (nicolas.filotto@gmail.com)
+ */
+class AsyncProcessListener implements ProcessListener {
+
+    /**
+     * The buffer that will contain the output messages provided by the {@link ProcessOutputMonitor}.
+     */
+    private final StringBuilder buffer = new StringBuilder();
+    /**
+     * The {@link CompletableFuture} that will be used as callback to provide the output messages in case
+     * the return value is not {@code 0}.
+     */
+    private final CompletableFuture<Optional<String>> completableFuture = new CompletableFuture<>();
+
+    /**
+     * Gives the {@link CompletionStage} allowing to get the output messages.
+     * @return the corresponding callback to provide the output messages.
+     */
+    CompletionStage<Optional<String>> toCompletionStage() {
+        return completableFuture;
+    }
+
+    @Override
+    public void processDied(int returnValue) {
+        completableFuture.complete(returnValue == 0 ? Optional.empty() : Optional.of(buffer.toString().trim()));
+    }
+
+    @Override
+    public void processOutput(String output) {
+        buffer.append(output);
+    }
+
+    @Override
+    public void processOutput(byte[] buffer, int offset, int length) {
+        // Nothing to do
+    }
+}

--- a/mucommander-process/src/main/java/com/mucommander/process/ProcessRunner.java
+++ b/mucommander-process/src/main/java/com/mucommander/process/ProcessRunner.java
@@ -22,7 +22,9 @@ import com.mucommander.commons.file.FileFactory;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.StringTokenizer;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Used to run process in as safe a manner as possible.
@@ -306,6 +308,21 @@ public class ProcessRunner {
      * @throws IOException      thrown if an error happens while starting the process.
      */
     public static AbstractProcess execute(String[] tokens, AbstractFile currentDirectory) throws IOException {return execute(tokens, currentDirectory, null, null);}
+
+    /**
+     * Executes the specified command in the specified directory asynchronously with the ability to perform an
+     * action in case of an error.
+     * @param  tokens           command to execute.
+     * @param  currentDirectory directory in which to run the command.
+     * @return                  the {@link CompletionStage} allowing to receive asynchronously the output messages in case of error if any.
+     * @see                     #execute(String[],AbstractFile,ProcessListener,String)
+     * @throws IOException      thrown if an error happens while starting the process.
+     */
+    public static CompletionStage<Optional<String>> executeAsync(String[] tokens, AbstractFile currentDirectory) throws IOException {
+        final AsyncProcessListener listener = new AsyncProcessListener();
+        execute(tokens, currentDirectory, listener, null);
+        return listener.toCompletionStage();
+    }
 
     /**
      * Executes the specified command in the specified directory.


### PR DESCRIPTION
Fix for #403

## Motivation

No message is provided to the end-user when an error occurs while opening a file.

## Modifications:

* Change the signature of the methods to return a `CompletionStage<Optional<String>>` allowing to retrieve the output message as callback
* Add a specific `ProcessListener` to provide the output message through a callback
* Show the output message with a `InformationDialog.showErrorDialog` when it is possible