### PR TITLE
Gradle warnings

### DIFF
--- a/apache-bzip2/build.gradle
+++ b/apache-bzip2/build.gradle
@@ -10,7 +10,7 @@ jar {
         'Import-Package': '*',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'biz.aQute.bnd.builder'
+    apply plugin: 'java-library'
     compileJava.options.compilerArgs += ['--release', '8']
     compileJava.options.encoding = 'UTF-8'
     compileTestJava.options.encoding = 'UTF-8'
@@ -43,8 +44,8 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.felix:org.apache.felix.main:6.0.3'
-    compile 'com.beust:jcommander:1.78'
+    implementation 'org.apache.felix:org.apache.felix.main:6.0.3'
+    implementation 'com.beust:jcommander:1.78'
 
     osgiRuntime project('mucommander-core')
     osgiRuntime project('mucommander-command')

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ allprojects {
 subprojects {
     apply plugin: 'biz.aQute.bnd.builder'
     compileJava.options.compilerArgs += ['--release', '8']
+    compileJava.options.encoding = 'UTF-8'
+    compileTestJava.options.encoding = 'UTF-8'
 }
 
 compileJava.options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ launch4j {
     icon = "$projectDir/package/windows/mucommander.ico"
     mainClassName = "com.mucommander.main.muCommander"
     copyConfigurable = project.tasks.shadowJar.outputs.files
-    jar = "${project.tasks.shadowJar.archiveFileName}"
+    jar = "${project.tasks.shadowJar.archiveFileName.get()}"
     dontWrapJar = true
     classpath = ['.']
     headerType = "gui"
@@ -363,7 +363,7 @@ task nsis(type: Copy, dependsOn: [createExe, createBundlesDir]) {
                                        MU_README: 'readme.txt',
                                        MU_OUT: 'mucommander-'+project.version+'-'+project.ext.release+'-setup.exe',
                                        MU_EXE: 'mucommander.exe',
-                                       MU_JAR: project.tasks.shadowJar.archiveFileName])
+                                       MU_JAR: project.tasks.shadowJar.archiveFileName.get()])
     }
     from ('package') {
         include 'license.txt', 'readme.txt'

--- a/build.gradle
+++ b/build.gradle
@@ -149,14 +149,14 @@ ext {
     bundleJRE = project.hasProperty('mucommanderBundleJRE') ? mucommanderBundleJRE.toBoolean() : false
 }
 
-shadowJar.classifier = null
+shadowJar.archiveClassifier = null
 
 jar {
     manifest {
         attributes("Main-Class": "com.mucommander.main.muCommander",
                    "Specification-Title": "muCommander",
                    "Specification-Vendor": "Arik Hadas",
-                   "Specification-Version": version,
+                   "Specification-Version": archiveVersion,
                    "Implementation-Title": "muCommander",
                    "Implementation-Vendor": "Arik Hadas",
                    "Implementation-Version": revision.substring(0, 7),
@@ -323,7 +323,7 @@ launch4j {
     icon = "$projectDir/package/windows/mucommander.ico"
     mainClassName = "com.mucommander.main.muCommander"
     copyConfigurable = project.tasks.shadowJar.outputs.files
-    jar = "${project.tasks.shadowJar.archiveName}"
+    jar = "${project.tasks.shadowJar.archiveFileName}"
     dontWrapJar = true
     classpath = ['.']
     headerType = "gui"
@@ -362,7 +362,7 @@ task nsis(type: Copy, dependsOn: [createExe, createBundlesDir]) {
                                        MU_README: 'readme.txt',
                                        MU_OUT: 'mucommander-'+project.version+'-'+project.ext.release+'-setup.exe',
                                        MU_EXE: 'mucommander.exe',
-                                       MU_JAR: project.tasks.shadowJar.archiveName])
+                                       MU_JAR: project.tasks.shadowJar.archiveFileName])
     }
     from ('package') {
         include 'license.txt', 'readme.txt'
@@ -399,7 +399,7 @@ task portable(dependsOn: [createExe, createBundlesDir], type: Zip) {
     from ('package/unix/mucommander.sh') {
         filter(ReplaceTokens, tokens: [MU_VERSION: project.version])
     }
-    into "muCommander-$version"
+    into "muCommander-$archiveVersion"
     from ("$buildDir/osgi/bundle") {
         include '*.jar'
         exclude 'osgiaas*'
@@ -411,8 +411,8 @@ task portable(dependsOn: [createExe, createBundlesDir], type: Zip) {
         into 'app'
     }
 
-    classifier = 'portable'
-    version = project.version+'-'+project.ext.release
+    archiveClassifier = 'portable'
+    archiveVersion = project.version+'-'+project.ext.release
 }
 
 // Unix packaging
@@ -441,9 +441,9 @@ task tgz(dependsOn: createBundlesDir, type: Tar) {
         into 'app'
     }
 
-    extension = 'tar.gz'
+    archiveExtension = 'tar.gz'
     compression = Compression.GZIP
-    version = project.version+'-'+project.ext.release
+    archiveVersion = project.version+'-'+project.ext.release
 }
 
 task(afterEclipseImport).doLast {

--- a/mucommander-archiver/build.gradle
+++ b/mucommander-archiver/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':mucommander-format-tar')
     compile project(':mucommander-format-zip')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-archiver/build.gradle
+++ b/mucommander-archiver/build.gradle
@@ -2,9 +2,9 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-format-tar')
-    compile project(':mucommander-format-zip')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-format-tar')
+    api project(':mucommander-format-zip')
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-archiver/build.gradle
+++ b/mucommander-archiver/build.gradle
@@ -17,7 +17,7 @@ jar {
         'Export-Package': 'com.mucommander.commons.file.archiver',
         'Specification-Title': 'muCommander',
         'Specification-Vendor': 'Arik Hadas',
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-command/build.gradle
+++ b/mucommander-command/build.gradle
@@ -29,7 +29,7 @@ jar {
         'Import-Package': '*',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-command/build.gradle
+++ b/mucommander-command/build.gradle
@@ -13,9 +13,9 @@ plugins {
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-file")
-    compile project(":mucommander-preferences")
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    api project(":mucommander-commons-file")
+    api project(":mucommander-preferences")
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-commons-collections/build.gradle
+++ b/mucommander-commons-collections/build.gradle
@@ -14,7 +14,7 @@ jar {
          'Export-Package': 'com.mucommander.commons.collections',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-commons-collections/build.gradle
+++ b/mucommander-commons-collections/build.gradle
@@ -3,7 +3,7 @@ repositories.jcenter()
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.26'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-commons-collections/build.gradle
+++ b/mucommander-commons-collections/build.gradle
@@ -1,7 +1,7 @@
 repositories.jcenter()
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-commons-conf/build.gradle
+++ b/mucommander-commons-conf/build.gradle
@@ -3,7 +3,7 @@ repositories.jcenter()
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.26'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-commons-conf/build.gradle
+++ b/mucommander-commons-conf/build.gradle
@@ -14,7 +14,7 @@ jar {
          'Export-Package': 'com.mucommander.commons.conf',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-commons-conf/build.gradle
+++ b/mucommander-commons-conf/build.gradle
@@ -1,7 +1,7 @@
 repositories.jcenter()
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.osgi:osgi.core:7.0.0'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation 'junit:junit:4.12'
 }
 
 jar {

--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -52,7 +52,7 @@ jar {
             'com.sun.jna.platform.win32',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -1,15 +1,15 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-io')
-    compile project(':mucommander-commons-runtime')
-    compile project(':mucommander-commons-util')
+    api project(':mucommander-commons-io')
+    api project(':mucommander-commons-runtime')
+    api project(':mucommander-commons-util')
 
     comprise 'net.java.dev.jna:jna:5.5.0'
     comprise 'net.java.dev.jna:jna-platform:5.5.0'
-    compile 'org.slf4j:slf4j-api:1.7.26'
-    compile 'commons-collections:commons-collections:3.2.2'
-    compile 'org.osgi:osgi.core:7.0.0'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'commons-collections:commons-collections:3.2.2'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation 'junit:junit:4.12'

--- a/mucommander-commons-io/build.gradle
+++ b/mucommander-commons-io/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.26'
     comprise 'com.ibm.icu:icu4j:59.2'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-commons-io/build.gradle
+++ b/mucommander-commons-io/build.gradle
@@ -1,7 +1,7 @@
 repositories.jcenter()
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
     comprise 'com.ibm.icu:icu4j:59.2'
 
     testImplementation 'org.testng:testng:6.11'

--- a/mucommander-commons-io/build.gradle
+++ b/mucommander-commons-io/build.gradle
@@ -26,7 +26,7 @@ jar {
                 'com.mucommander.commons.io.security',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-commons-runtime/build.gradle
+++ b/mucommander-commons-runtime/build.gradle
@@ -2,7 +2,7 @@ repositories.jcenter()
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.26'
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-commons-runtime/build.gradle
+++ b/mucommander-commons-runtime/build.gradle
@@ -1,7 +1,7 @@
 repositories.jcenter()
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
     testImplementation 'org.testng:testng:6.11'
 }
 

--- a/mucommander-commons-runtime/build.gradle
+++ b/mucommander-commons-runtime/build.gradle
@@ -13,7 +13,7 @@ jar {
          'Export-Package': 'com.mucommander.commons.runtime',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-commons-util/build.gradle
+++ b/mucommander-commons-util/build.gradle
@@ -15,7 +15,7 @@ jar {
          'Export-Package': "com.mucommander.*",
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-commons-util/build.gradle
+++ b/mucommander-commons-util/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile project(":mucommander-commons-runtime")
     compile 'org.slf4j:slf4j-api:1.7.26'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-commons-util/build.gradle
+++ b/mucommander-commons-util/build.gradle
@@ -1,8 +1,8 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-runtime")
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    api project(":mucommander-commons-runtime")
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -17,11 +17,12 @@ dependencies {
     compileOnly project(':mucommander-os-api')
     compileOnly project(':mucommander-viewer-api')
 
-    compile 'ch.qos.logback:logback-core:1.2.3'
-    compile 'ch.qos.logback:logback-classic:1.2.3'
-    compile 'org.jmdns:jmdns:3.5.5'
-    compile 'org.slf4j:slf4j-api:1.7.26'
-    compile 'org.osgi:osgi.core:7.0.0'
+    implementation 'ch.qos.logback:logback-core:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'org.jmdns:jmdns:3.5.5'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation 'commons-collections:commons-collections:3.2.2'
     comprise 'org.unix4j:unix4j-command:0.5'
 
     testImplementation 'org.testng:testng:6.11'

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -44,7 +44,7 @@ jar {
         'Bundle-DocURL': 'https://www.mucommander.com',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -24,12 +24,12 @@ dependencies {
     compile 'org.osgi:osgi.core:7.0.0'
     comprise 'org.unix4j:unix4j-command:0.5'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile 'junit:junit:4.12'
-    testCompile project(':mucommander-commons-file')
-    testCompile project(':mucommander-commons-conf')
-    testCompile project(':mucommander-commons-collections')
-    testCompile project(':mucommander-commons-io')
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation 'junit:junit:4.12'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation project(':mucommander-commons-conf')
+    testImplementation project(':mucommander-commons-collections')
+    testImplementation project(':mucommander-commons-io')
 }
 
 jar {

--- a/mucommander-encoding/build.gradle
+++ b/mucommander-encoding/build.gradle
@@ -1,9 +1,9 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-util")
-    compile project(":mucommander-preferences")
-    compile project(":mucommander-translator")
+    api project(":mucommander-commons-util")
+    api project(":mucommander-preferences")
+    api project(":mucommander-translator")
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-encoding/build.gradle
+++ b/mucommander-encoding/build.gradle
@@ -18,7 +18,7 @@ jar {
         'Import-Package': '*',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-ar/build.gradle
+++ b/mucommander-format-ar/build.gradle
@@ -16,7 +16,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.ar.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-ar/build.gradle
+++ b/mucommander-format-ar/build.gradle
@@ -2,7 +2,10 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-ar/build.gradle
+++ b/mucommander-format-ar/build.gradle
@@ -4,7 +4,7 @@ repositories.jcenter()
 dependencies {
     compile project(':mucommander-commons-file')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-bzip2/build.gradle
+++ b/mucommander-format-bzip2/build.gradle
@@ -2,8 +2,11 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':apache-bzip2')
+    api project(':mucommander-commons-file')
+    api project(':apache-bzip2')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-bzip2/build.gradle
+++ b/mucommander-format-bzip2/build.gradle
@@ -17,7 +17,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.bzip2.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-bzip2/build.gradle
+++ b/mucommander-format-bzip2/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':mucommander-commons-file')
     compile project(':apache-bzip2')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-gzip/build.gradle
+++ b/mucommander-format-gzip/build.gradle
@@ -4,7 +4,7 @@ repositories.jcenter()
 dependencies {
     compile project(':mucommander-commons-file')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-gzip/build.gradle
+++ b/mucommander-format-gzip/build.gradle
@@ -16,7 +16,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.gzip.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-gzip/build.gradle
+++ b/mucommander-format-gzip/build.gradle
@@ -2,7 +2,9 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-iso/build.gradle
+++ b/mucommander-format-iso/build.gradle
@@ -2,7 +2,10 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-iso/build.gradle
+++ b/mucommander-format-iso/build.gradle
@@ -4,7 +4,7 @@ repositories.jcenter()
 dependencies {
     compile project(':mucommander-commons-file')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-iso/build.gradle
+++ b/mucommander-format-iso/build.gradle
@@ -16,7 +16,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.iso.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-libguestfs/build.gradle
+++ b/mucommander-format-libguestfs/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile 'org.osgi:osgi.core:7.0.0'
-    compile files('libs/libguestfs.jar')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation files('libs/libguestfs.jar')
 }
 
 repositories.jcenter()

--- a/mucommander-format-libguestfs/build.gradle
+++ b/mucommander-format-libguestfs/build.gradle
@@ -15,7 +15,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.libguestfs.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-lst/build.gradle
+++ b/mucommander-format-lst/build.gradle
@@ -16,7 +16,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.lst.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-lst/build.gradle
+++ b/mucommander-format-lst/build.gradle
@@ -2,7 +2,10 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-lst/build.gradle
+++ b/mucommander-format-lst/build.gradle
@@ -4,7 +4,7 @@ repositories.jcenter()
 dependencies {
     compile project(':mucommander-commons-file')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-rar/build.gradle
+++ b/mucommander-format-rar/build.gradle
@@ -24,7 +24,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.rar.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-rar/build.gradle
+++ b/mucommander-format-rar/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile 'org.apache.commons:commons-vfs2:2.3'
     compile 'com.github.junrar:junrar:4.0.0'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 // In this section you declare where to find the dependencies of your project

--- a/mucommander-format-rar/build.gradle
+++ b/mucommander-format-rar/build.gradle
@@ -3,10 +3,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile 'org.osgi:osgi.core:7.0.0'
-    compile 'org.apache.commons:commons-vfs2:2.3'
-    compile 'com.github.junrar:junrar:4.0.0'
+    api project(':mucommander-commons-file')
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation 'org.apache.commons:commons-vfs2:2.3'
+    implementation 'com.github.junrar:junrar:4.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-sevenzip/build.gradle
+++ b/mucommander-format-sevenzip/build.gradle
@@ -2,7 +2,10 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-sevenzip/build.gradle
+++ b/mucommander-format-sevenzip/build.gradle
@@ -4,7 +4,7 @@ repositories.jcenter()
 dependencies {
     compile project(':mucommander-commons-file')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-sevenzip/build.gradle
+++ b/mucommander-format-sevenzip/build.gradle
@@ -16,7 +16,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.archive.sevenzip.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-tar/build.gradle
+++ b/mucommander-format-tar/build.gradle
@@ -2,8 +2,11 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':apache-bzip2')
+    api project(':mucommander-commons-file')
+    api project(':apache-bzip2')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-format-tar/build.gradle
+++ b/mucommander-format-tar/build.gradle
@@ -18,7 +18,7 @@ jar {
             'com.mucommander.commons.file.archive.tar.provider',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-format-tar/build.gradle
+++ b/mucommander-format-tar/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':mucommander-commons-file')
     compile project(':apache-bzip2')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 jar {

--- a/mucommander-format-zip/build.gradle
+++ b/mucommander-format-zip/build.gradle
@@ -2,7 +2,10 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation project(':mucommander-commons-file')

--- a/mucommander-format-zip/build.gradle
+++ b/mucommander-format-zip/build.gradle
@@ -4,9 +4,9 @@ repositories.jcenter()
 dependencies {
     compile project(':mucommander-commons-file')
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 jar {

--- a/mucommander-format-zip/build.gradle
+++ b/mucommander-format-zip/build.gradle
@@ -19,7 +19,7 @@ jar {
             'com.mucommander.commons.file.archive.zip.provider',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-api/build.gradle
+++ b/mucommander-os-api/build.gradle
@@ -13,11 +13,11 @@ plugins {
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-file")
-    compile project(":mucommander-command")
-    compile project(":mucommander-process")
-    compile project(":mucommander-translator")
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    api project(":mucommander-commons-file")
+    api project(":mucommander-command")
+    api project(":mucommander-process")
+    api project(":mucommander-translator")
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-os-api/build.gradle
+++ b/mucommander-os-api/build.gradle
@@ -35,7 +35,7 @@ jar {
          'Import-Package': '*',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-linux/build.gradle
+++ b/mucommander-os-linux/build.gradle
@@ -32,7 +32,7 @@
           'Import-Package': '*',
           'Specification-Title': "muCommander",
           'Specification-Vendor': "Arik Hadas",
-          'Specification-Version': version,
+          'Specification-Version': archiveVersion,
           'Implementation-Title': "muCommander",
           'Implementation-Vendor': "Arik Hadas",
           'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-linux/build.gradle
+++ b/mucommander-os-linux/build.gradle
@@ -13,10 +13,11 @@
  repositories.jcenter()
  
  dependencies {
-     compile project(":mucommander-core")
-     compile project(":mucommander-os-api")
-     compile project(":mucommander-process")
-     compile 'org.slf4j:slf4j-api:1.7.26'
+     api project(":mucommander-core")
+     api project(":mucommander-os-api")
+     api project(":mucommander-process")
+     implementation 'org.slf4j:slf4j-api:1.7.26'
+     implementation 'org.osgi:osgi.core:7.0.0'
  
      // Use JUnit test framework
      testImplementation 'junit:junit:4.12'

--- a/mucommander-os-macos-java8/build.gradle
+++ b/mucommander-os-macos-java8/build.gradle
@@ -58,7 +58,7 @@ jar {
          'Import-Package': '!com.sun.jna.*,*',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-macos-java8/build.gradle
+++ b/mucommander-os-macos-java8/build.gradle
@@ -17,15 +17,16 @@ repositories.jcenter()
 
 
 dependencies {
-    compile project(":mucommander-commons-util")
-    compile project(":mucommander-core")
-    compile project(":mucommander-os-api")
-    compile project(":mucommander-process")
-    compile project(":mucommander-translator")
+    api project(":mucommander-commons-util")
+    api project(":mucommander-core")
+    api project(":mucommander-os-api")
+    api project(":mucommander-process")
+    api project(":mucommander-translator")
 
     comprise 'net.java.dev.jna:jna-platform:5.5.0'
-    compile 'org.slf4j:slf4j-api:1.7.26'
-    compile 'com.googlecode.plist:dd-plist:1.23'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'com.googlecode.plist:dd-plist:1.23'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     // Apple's Java extensions
     compileOnly files('libs/java-extension.jar')

--- a/mucommander-os-macos/build.gradle
+++ b/mucommander-os-macos/build.gradle
@@ -18,15 +18,16 @@ repositories.jcenter()
 compileJava.options.compilerArgs += ['--release', '11']
 
 dependencies {
-    compile project(":mucommander-commons-util")
-    compile project(":mucommander-core")
-    compile project(":mucommander-os-api")
-    compile project(":mucommander-process")
-    compile project(":mucommander-translator")
+    api project(":mucommander-commons-util")
+    api project(":mucommander-core")
+    api project(":mucommander-os-api")
+    api project(":mucommander-process")
+    api project(":mucommander-translator")
 
     comprise 'net.java.dev.jna:jna-platform:5.5.0'
-    compile 'org.slf4j:slf4j-api:1.7.26'
-    compile 'com.googlecode.plist:dd-plist:1.23'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'com.googlecode.plist:dd-plist:1.23'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     // the java.desktop module that contains macOS-specific extensions
     compileOnly files('libs/java.desktop.jar')

--- a/mucommander-os-macos/build.gradle
+++ b/mucommander-os-macos/build.gradle
@@ -59,7 +59,7 @@ jar {
          'Import-Package': '!com.sun.jna.*,*',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-openvms/build.gradle
+++ b/mucommander-os-openvms/build.gradle
@@ -13,10 +13,11 @@
  repositories.jcenter()
  
  dependencies {
-     compile project(":mucommander-core")
-     compile project(":mucommander-commons-runtime")
-     compile project(":mucommander-os-api")
-     compile 'org.slf4j:slf4j-api:1.7.26'
+     api project(":mucommander-core")
+     api project(":mucommander-commons-runtime")
+     api project(":mucommander-os-api")
+     implementation 'org.slf4j:slf4j-api:1.7.26'
+     implementation 'org.osgi:osgi.core:7.0.0'
  
      // Use JUnit test framework
      testImplementation 'junit:junit:4.12'

--- a/mucommander-os-openvms/build.gradle
+++ b/mucommander-os-openvms/build.gradle
@@ -32,7 +32,7 @@
           'Import-Package': '*',
           'Specification-Title': "muCommander",
           'Specification-Vendor': "Arik Hadas",
-          'Specification-Version': version,
+          'Specification-Version': archiveVersion,
           'Implementation-Title': "muCommander",
           'Implementation-Vendor': "Arik Hadas",
           'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-win/build.gradle
+++ b/mucommander-os-win/build.gradle
@@ -31,7 +31,7 @@ jar {
          'Import-Package': '*',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-os-win/build.gradle
+++ b/mucommander-os-win/build.gradle
@@ -25,21 +25,6 @@ dependencies {
 }
  
 jar {
-
-    from configurations.comprise.collect { it.isDirectory() ? it : zipTree(it).matching {
-        exclude 'com/sun/jna/aix*/**'
-        exclude 'com/sun/jna/freebsd*/**'
-        exclude 'com/sun/jna/linux*/**'
-        exclude 'com/sun/jna/openbsd*/**'
-        exclude 'com/sun/jna/sunos*/**'
-        exclude 'com/sun/jna/win*/**'
-        exclude 'META-INF/**'
-        exclude 'com/sun/jna/platform/linux/**'
-        exclude 'com/sun/jna/platform/unix/**'
-        exclude 'com/sun/jna/platform/win32/**'
-        exclude 'com/sun/jna/platform/wince/**'
-    } }
-
     bnd ('Bundle-Name': 'muCommander-os-win',
          'Bundle-Vendor': 'muCommander',
          'Bundle-Description': 'Windows specifics',

--- a/mucommander-os-win/build.gradle
+++ b/mucommander-os-win/build.gradle
@@ -13,15 +13,33 @@ plugins {
 repositories.jcenter()
  
 dependencies {
-    compile project(":mucommander-core")
-    compile project(":mucommander-os-api")
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    api project(":mucommander-core")
+    api project(":mucommander-os-api")
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
+
+    comprise 'net.java.dev.jna:jna-platform:5.5.0'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 }
  
 jar {
+
+    from configurations.comprise.collect { it.isDirectory() ? it : zipTree(it).matching {
+        exclude 'com/sun/jna/aix*/**'
+        exclude 'com/sun/jna/freebsd*/**'
+        exclude 'com/sun/jna/linux*/**'
+        exclude 'com/sun/jna/openbsd*/**'
+        exclude 'com/sun/jna/sunos*/**'
+        exclude 'com/sun/jna/win*/**'
+        exclude 'META-INF/**'
+        exclude 'com/sun/jna/platform/linux/**'
+        exclude 'com/sun/jna/platform/unix/**'
+        exclude 'com/sun/jna/platform/win32/**'
+        exclude 'com/sun/jna/platform/wince/**'
+    } }
+
     bnd ('Bundle-Name': 'muCommander-os-win',
          'Bundle-Vendor': 'muCommander',
          'Bundle-Description': 'Windows specifics',

--- a/mucommander-preferences/build.gradle
+++ b/mucommander-preferences/build.gradle
@@ -18,7 +18,7 @@ jar {
          'Export-Package': 'com.mucommander.conf,com.mucommander.io.backup',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-preferences/build.gradle
+++ b/mucommander-preferences/build.gradle
@@ -1,9 +1,12 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-conf")
-    compile project(":mucommander-commons-file")
-    compile project(":mucommander-commons-io")
+    api project(":mucommander-commons-conf")
+    api project(":mucommander-commons-file")
+    api project(":mucommander-commons-io")
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-process/build.gradle
+++ b/mucommander-process/build.gradle
@@ -29,7 +29,7 @@ jar {
         'Import-Package': '*',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-process/build.gradle
+++ b/mucommander-process/build.gradle
@@ -13,8 +13,8 @@ plugins {
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-file")
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    api project(":mucommander-commons-file")
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-protocol-api/build.gradle
+++ b/mucommander-protocol-api/build.gradle
@@ -16,7 +16,7 @@ jar {
          'Export-Package': 'com.mucommander.protocol.ui',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-api/build.gradle
+++ b/mucommander-protocol-api/build.gradle
@@ -1,8 +1,8 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-commons-file")
-    compile project(":mucommander-commons-util")
+    api project(":mucommander-commons-file")
+    api project(":mucommander-commons-util")
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-protocol-ftp/build.gradle
+++ b/mucommander-protocol-ftp/build.gradle
@@ -1,9 +1,11 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-encoding')
-    compile project(':mucommander-translator')
-    compile 'commons-net:commons-net:3.6'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-encoding')
+    api project(':mucommander-translator')
+    implementation 'commons-net:commons-net:3.6'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'junit:junit:4.12'
 

--- a/mucommander-protocol-ftp/build.gradle
+++ b/mucommander-protocol-ftp/build.gradle
@@ -7,9 +7,9 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-ftp/build.gradle
+++ b/mucommander-protocol-ftp/build.gradle
@@ -23,7 +23,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.ftp.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-gdrive/build.gradle
+++ b/mucommander-protocol-gdrive/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 repositories.mavenCentral()

--- a/mucommander-protocol-gdrive/build.gradle
+++ b/mucommander-protocol-gdrive/build.gradle
@@ -24,7 +24,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.gdrive.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-gdrive/build.gradle
+++ b/mucommander-protocol-gdrive/build.gradle
@@ -1,11 +1,13 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-encoding')
-    compile project(':mucommander-translator')
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev110-1.23.0'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-encoding')
+    api project(':mucommander-translator')
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev110-1.23.0'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'junit:junit:4.12'
 

--- a/mucommander-protocol-hadoop/build.gradle
+++ b/mucommander-protocol-hadoop/build.gradle
@@ -1,10 +1,11 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'org.apache.hadoop:hadoop-core:0.20.2'
-    compile 'org.osgi:osgi.core:7.0.0'
-    compile 'commons-logging:commons-logging:1.2'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'org.apache.hadoop:hadoop-core:0.20.2'
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     // Use JUnit test framework
     testImplementation 'org.testng:testng:6.11'

--- a/mucommander-protocol-hadoop/build.gradle
+++ b/mucommander-protocol-hadoop/build.gradle
@@ -23,7 +23,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.hadoop.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-hadoop/build.gradle
+++ b/mucommander-protocol-hadoop/build.gradle
@@ -7,9 +7,9 @@ dependencies {
     compile 'commons-logging:commons-logging:1.2'
 
     // Use JUnit test framework
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-http/build.gradle
+++ b/mucommander-protocol-http/build.gradle
@@ -1,8 +1,9 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'org.osgi:osgi.core:7.0.0'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation project(':mucommander-commons-file')

--- a/mucommander-protocol-http/build.gradle
+++ b/mucommander-protocol-http/build.gradle
@@ -20,7 +20,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.http.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-http/build.gradle
+++ b/mucommander-protocol-http/build.gradle
@@ -4,9 +4,9 @@ dependencies {
     compile project(':mucommander-translator')
     compile 'org.osgi:osgi.core:7.0.0'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-nfs/build.gradle
+++ b/mucommander-protocol-nfs/build.gradle
@@ -25,7 +25,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.nfs.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-nfs/build.gradle
+++ b/mucommander-protocol-nfs/build.gradle
@@ -4,8 +4,7 @@ dependencies {
     api project(':mucommander-translator')
 
     implementation 'org.osgi:osgi.core:7.0.0'
-
-    compileOnly 'com.sun:yanfs:1.3'
+    implementation 'com.sun:yanfs:1.3'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
@@ -18,7 +17,6 @@ dependencies {
 repositories.jcenter()
 
 jar {
-   from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
    bnd ('Bundle-Name': 'muCommander-nfs',
         'Bundle-Vendor': 'muCommander',
         'Bundle-Description': 'Library with configuration tools',

--- a/mucommander-protocol-nfs/build.gradle
+++ b/mucommander-protocol-nfs/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     compileOnly 'com.sun:yanfs:1.3'
 

--- a/mucommander-protocol-nfs/build.gradle
+++ b/mucommander-protocol-nfs/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-nfs/build.gradle
+++ b/mucommander-protocol-nfs/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 repositories.jcenter()
 
 jar {
-   from { configurations.compileOnly.collect { it.isDirectory() ? it : zipTree(it) } }
+   from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
    bnd ('Bundle-Name': 'muCommander-nfs',
         'Bundle-Vendor': 'muCommander',
         'Bundle-Description': 'Library with configuration tools',

--- a/mucommander-protocol-ovirt/build.gradle
+++ b/mucommander-protocol-ovirt/build.gradle
@@ -21,7 +21,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.ovirt.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-ovirt/build.gradle
+++ b/mucommander-protocol-ovirt/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     compile 'org.ovirt.engine.api:sdk:4.2.1'
     compile 'org.osgi:osgi.core:7.0.0'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-ovirt/build.gradle
+++ b/mucommander-protocol-ovirt/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-commons-util')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'org.ovirt.engine.api:sdk:4.2.1'
-    compile 'org.osgi:osgi.core:7.0.0'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-commons-util')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'org.ovirt.engine.api:sdk:4.2.1'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)

--- a/mucommander-protocol-registry/build.gradle
+++ b/mucommander-protocol-registry/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     compile 'org.osgi:osgi.core:7.0.0'
     compile 'com.googlecode.json-simple:json-simple:1.1.1'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-registry/build.gradle
+++ b/mucommander-protocol-registry/build.gradle
@@ -24,7 +24,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.registry.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-registry/build.gradle
+++ b/mucommander-protocol-registry/build.gradle
@@ -1,13 +1,13 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-commons-util')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-format-tar')
-    compile project(':mucommander-process')
-    compile project(':mucommander-translator')
-    compile 'org.ovirt.engine.api:sdk:4.2.1'
-    compile 'org.osgi:osgi.core:7.0.0'
-    compile 'com.googlecode.json-simple:json-simple:1.1.1'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-commons-util')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-format-tar')
+    api project(':mucommander-process')
+    api project(':mucommander-translator')
+    implementation 'org.ovirt.engine.api:sdk:4.2.1'
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)

--- a/mucommander-protocol-s3/build.gradle
+++ b/mucommander-protocol-s3/build.gradle
@@ -26,7 +26,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.s3.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-s3/build.gradle
+++ b/mucommander-protocol-s3/build.gradle
@@ -1,13 +1,15 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'net.java.dev.jets3t:jets3t:0.9.4'
-    compile 'commons-logging:commons-logging:1.2'
-    compile 'javax.xml:jaxrpc-api:1.1'
-    compile 'javax.jms:jms:1.1'
-    compile 'org.glassfish:javax.xml.soap:10.0-b28'
-    compile files('libs/mail.osgi-1.4.jar')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'net.java.dev.jets3t:jets3t:0.9.4'
+    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'javax.xml:jaxrpc-api:1.1'
+    implementation 'javax.jms:jms:1.1'
+    implementation 'org.glassfish:javax.xml.soap:10.0-b28'
+    implementation files('libs/mail.osgi-1.4.jar')
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation project(':mucommander-commons-file')

--- a/mucommander-protocol-s3/build.gradle
+++ b/mucommander-protocol-s3/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     compile 'org.glassfish:javax.xml.soap:10.0-b28'
     compile files('libs/mail.osgi-1.4.jar')
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-sftp/build.gradle
+++ b/mucommander-protocol-sftp/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     compile 'com.jcraft:jzlib:1.1.3'
     compile 'org.osgi:osgi.core:7.0.0'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-sftp/build.gradle
+++ b/mucommander-protocol-sftp/build.gradle
@@ -21,7 +21,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.sftp.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-sftp/build.gradle
+++ b/mucommander-protocol-sftp/build.gradle
@@ -1,10 +1,11 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'com.jcraft:jsch:0.1.55'
-    compile 'com.jcraft:jzlib:1.1.3'
-    compile 'org.osgi:osgi.core:7.0.0'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'com.jcraft:jsch:0.1.55'
+    implementation 'com.jcraft:jzlib:1.1.3'
+    implementation 'org.osgi:osgi.core:7.0.0'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)

--- a/mucommander-protocol-smb/build.gradle
+++ b/mucommander-protocol-smb/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'jcifs:jcifs:1.3.17'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'jcifs:jcifs:1.3.17'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-protocol-smb/build.gradle
+++ b/mucommander-protocol-smb/build.gradle
@@ -23,7 +23,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.smb.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-smb/build.gradle
+++ b/mucommander-protocol-smb/build.gradle
@@ -7,9 +7,9 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile project(':mucommander-commons-file')
-    testCompile files(project(':mucommander-commons-file').sourceSets.test.output)
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation project(':mucommander-commons-file')
+    testImplementation files(project(':mucommander-commons-file').sourceSets.test.output)
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-vsphere/build.gradle
+++ b/mucommander-protocol-vsphere/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile project(':mucommander-translator')
     compile 'javax.xml.ws:jaxws-api:2.2.12'
 
-    runtime 'javax.jws:javax.jws-api:1.1'
+    runtimeOnly 'javax.jws:javax.jws-api:1.1'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-protocol-vsphere/build.gradle
+++ b/mucommander-protocol-vsphere/build.gradle
@@ -1,16 +1,18 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-protocol-api')
-    compile project(':mucommander-translator')
-    compile 'javax.xml.ws:jaxws-api:2.2.12'
+    api project(':mucommander-commons-file')
+    api project(':mucommander-protocol-api')
+    api project(':mucommander-translator')
+    implementation 'javax.xml.ws:jaxws-api:2.2.12'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     runtimeOnly 'javax.jws:javax.jws-api:1.1'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
-    compile project(':mucommander-commons-file')
+    api project(':mucommander-commons-file')
     testImplementation 'org.testng:testng:6.11'
-    compile files('libs/vim25.jar')
+    implementation files('libs/vim25.jar')
 }
 
 repositories.jcenter()

--- a/mucommander-protocol-vsphere/build.gradle
+++ b/mucommander-protocol-vsphere/build.gradle
@@ -24,7 +24,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.commons.file.protocol.vsphere.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-protocol-vsphere/build.gradle
+++ b/mucommander-protocol-vsphere/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
     compile project(':mucommander-commons-file')
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
     compile files('libs/vim25.jar')
 }
 

--- a/mucommander-translator/build.gradle
+++ b/mucommander-translator/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     compile project(":mucommander-preferences")
     compile 'org.slf4j:slf4j-api:1.7.26'
 
-    testCompile 'org.testng:testng:6.11'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'org.testng:testng:6.11'
+    testImplementation 'junit:junit:4.12'
 }
 
 jar {

--- a/mucommander-translator/build.gradle
+++ b/mucommander-translator/build.gradle
@@ -1,8 +1,10 @@
 repositories.jcenter()
 
 dependencies {
-    compile project(":mucommander-preferences")
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    api project(":mucommander-preferences")
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
     testImplementation 'junit:junit:4.12'

--- a/mucommander-translator/build.gradle
+++ b/mucommander-translator/build.gradle
@@ -17,7 +17,7 @@ jar {
          'Export-Package': 'com.mucommander.text',
          'Specification-Title': "muCommander",
          'Specification-Vendor': "Arik Hadas",
-         'Specification-Version': version,
+         'Specification-Version': archiveVersion,
          'Implementation-Title': "muCommander",
          'Implementation-Vendor': "Arik Hadas",
          'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-viewer-api/build.gradle
+++ b/mucommander-viewer-api/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':mucommander-commons-file')
     compile project(':mucommander-commons-util')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 repositories.jcenter()

--- a/mucommander-viewer-api/build.gradle
+++ b/mucommander-viewer-api/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-commons-util')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-commons-util')
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-viewer-api/build.gradle
+++ b/mucommander-viewer-api/build.gradle
@@ -15,7 +15,7 @@ jar {
         'Export-Package': 'com.mucommander.viewer',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-viewer-binary/build.gradle
+++ b/mucommander-viewer-binary/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile 'org.exbin.deltahex:deltahex-swing:0.1.2'
     compile 'org.exbin.deltahex:deltahex-swing:0.1.2'
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 repositories.jcenter()

--- a/mucommander-viewer-binary/build.gradle
+++ b/mucommander-viewer-binary/build.gradle
@@ -23,7 +23,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.viewer.binary.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Miroslav Hajda",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Miroslav Hajda",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-viewer-binary/build.gradle
+++ b/mucommander-viewer-binary/build.gradle
@@ -1,13 +1,14 @@
 dependencies {
-    compile project(':mucommander-core')
-    compile project(':mucommander-viewer-api')
-    compile project(':mucommander-preferences')
-    compile project(':mucommander-translator')
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-commons-util')
+    api project(':mucommander-core')
+    api project(':mucommander-viewer-api')
+    api project(':mucommander-preferences')
+    api project(':mucommander-translator')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-commons-util')
 
-    compile 'org.exbin.deltahex:deltahex-swing:0.1.2'
-    compile 'org.exbin.deltahex:deltahex-swing:0.1.2'
+    implementation 'org.exbin.deltahex:deltahex-swing:0.1.2'
+    implementation 'org.exbin.deltahex:deltahex-swing:0.1.2'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-viewer-image/build.gradle
+++ b/mucommander-viewer-image/build.gradle
@@ -1,8 +1,11 @@
 dependencies {
-    compile project(':mucommander-core')
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-viewer-api')
-    compile project(':mucommander-translator')
+    api project(':mucommander-core')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-viewer-api')
+    api project(':mucommander-translator')
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-viewer-image/build.gradle
+++ b/mucommander-viewer-image/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile project(':mucommander-viewer-api')
     compile project(':mucommander-translator')
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 repositories.jcenter()

--- a/mucommander-viewer-image/build.gradle
+++ b/mucommander-viewer-image/build.gradle
@@ -18,7 +18,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.viewer.image.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-viewer-pdf/build.gradle
+++ b/mucommander-viewer-pdf/build.gradle
@@ -55,7 +55,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.viewer.pdf.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Impxlementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-viewer-pdf/build.gradle
+++ b/mucommander-viewer-pdf/build.gradle
@@ -34,7 +34,7 @@ repositories {
     }
     maven {
         // for jai.core and dai.codec
-        url 'http://maven.icm.edu.pl/artifactory/repo'
+        url 'https://maven.ceon.pl/artifactory/repo/'
     }
     mavenCentral()
 }

--- a/mucommander-viewer-pdf/build.gradle
+++ b/mucommander-viewer-pdf/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
-    compile project(':mucommander-core')
-    compile project(':mucommander-viewer-api')
-    compile project(':mucommander-translator')
+    api project(':mucommander-core')
+    api project(':mucommander-viewer-api')
+    api project(':mucommander-translator')
+
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     comprise group: 'com.levigo.jbig2', name: 'levigo-jbig2-imageio', version: '2.0'
     comprise group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.57'

--- a/mucommander-viewer-pdf/build.gradle
+++ b/mucommander-viewer-pdf/build.gradle
@@ -43,6 +43,7 @@ repositories {
 
 jar {
    from configurations.comprise.collect { it.isDirectory() ? it : zipTree(it)}
+   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
    bnd ('Bundle-Name': 'muCommander-viewer-pdf',
         'Bundle-Vendor': 'muCommander',
         'Bundle-Description': 'Library for viewing PDF files',

--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':mucommander-encoding')
     compile project(":mucommander-preferences")
 
-    testCompile 'org.testng:testng:6.11'
+    testImplementation 'org.testng:testng:6.11'
 }
 
 repositories.jcenter()

--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -20,7 +20,7 @@ jar {
         'Bundle-Activator': 'com.mucommander.viewer.text.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",
-        'Specification-Version': version,
+        'Specification-Version': archiveVersion,
         'Implementation-Title': "muCommander",
         'Implementation-Vendor': "Arik Hadas",
         'Implementation-Version': revision.substring(0, 7),

--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -1,10 +1,13 @@
 dependencies {
-    compile project(':mucommander-core')
-    compile project(':mucommander-commons-file')
-    compile project(':mucommander-viewer-api')
-    compile project(':mucommander-translator')
-    compile project(':mucommander-encoding')
-    compile project(":mucommander-preferences")
+    api project(':mucommander-core')
+    api project(':mucommander-commons-file')
+    api project(':mucommander-viewer-api')
+    api project(':mucommander-translator')
+    api project(':mucommander-encoding')
+    api project(":mucommander-preferences")
+
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.osgi:osgi.core:7.0.0'
 
     testImplementation 'org.testng:testng:6.11'
 }


### PR DESCRIPTION
Should (at least partially) resolve #416 

In some cases I needed to change the build configuration of certain modules a bit, so I hope I didn't broke anything and it would be great if somebody with greater experience with the project could doublecheck those. 

Fixed (hopefully) all gradle warnings coming from mucommander's gradle files.

Checked using `gradlew clean runOsgi --warning-mode all` and several other tasks for packaging, I guess there might be additional tasks that I didn't execute which might be somehow sensitive to the changes. 

There are few more warnings remaining that are coming from several plugins (and might or might not be resolved by upgrading given plugin):

https://plugins.gradle.org/plugin/edu.sc.seis.macAppBundle
```
> Configure project :
The AbstractArchiveTask.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the destinationDirectory property instead. See https://docs.gradle.org/6.3/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:destinationDir for more details.
        at org.gradle.api.tasks.bundling.AbstractArchiveTask.setDestinationDir(AbstractArchiveTask.java:199)
        at org.gradle.api.tasks.bundling.Zip_Decorated.setDestinationDir(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.gradle.api.tasks.bundling.Zip_Decorated.setProperty(Unknown Source)
        at edu.sc.seis.macAppBundle.MacAppBundlePlugin$_createAppZipTask_closure70.doCall(MacAppBundlePlugin.groovy:256)
        ...

The AbstractArchiveTask.archiveName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveFileName property instead. See https://docs.gradle.org/6.3/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveName for more details.
        at org.gradle.api.tasks.bundling.AbstractArchiveTask.setArchiveName(AbstractArchiveTask.java:126)
        at org.gradle.api.tasks.bundling.Zip_Decorated.setArchiveName(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.gradle.api.tasks.bundling.Zip_Decorated.setProperty(Unknown Source)
        at edu.sc.seis.macAppBundle.MacAppBundlePlugin$_createAppZipTask_closure70.doCall(MacAppBundlePlugin.groovy:265)
        ...
```

https://plugins.gradle.org/plugin/biz.aQute.bnd.builder

```
> Task :mucommander-protocol-nfs:jar
The AbstractArchiveTask.baseName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveBaseName property instead. See https://docs.gradle.org/6.3/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:baseName for more details.
        at org.gradle.api.tasks.bundling.AbstractArchiveTask.getBaseName(AbstractArchiveTask.java:223)
        at org.gradle.api.tasks.bundling.Jar_Decorated.getBaseName(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at groovy.lang.MetaBeanProperty.getProperty(MetaBeanProperty.java:59)
        at groovy.lang.Closure.getProperty(Closure.java:292)
        at groovy.lang.Closure.getPropertyTryThese(Closure.java:313)
        at groovy.lang.Closure.getPropertyOwnerFirst(Closure.java:307)
        at groovy.lang.Closure.getProperty(Closure.java:296)
        at aQute.bnd.gradle.BundleTaskConvention$_buildBundle_closure5$_closure6.doCall(BundleTaskConvention.groovy:282)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
        at groovy.lang.Closure.call(Closure.java:405)
        at groovy.lang.Closure.call(Closure.java:421)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at aQute.bnd.gradle.BundleTaskConvention$_buildBundle_closure5.doCall(BundleTaskConvention.groovy:199)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
        at groovy.lang.Closure.call(Closure.java:405)
        at groovy.lang.Closure.call(Closure.java:421)
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:71)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:154)
        at org.gradle.util.ConfigureUtil.configureSelf(ConfigureUtil.java:130)
        at org.gradle.api.internal.AbstractTask.configure(AbstractTask.java:597)
        at org.gradle.api.internal.AbstractTask.configure(AbstractTask.java:99)
        at org.gradle.util.Configurable$configure.call(Unknown Source)
        at aQute.bnd.gradle.BundleTaskConvention.buildBundle(BundleTaskConvention.groovy:194)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at org.gradle.internal.extensibility.DefaultConvention$ExtensionsDynamicObject.tryInvokeMethod(DefaultConvention.java:308)
        at org.gradle.internal.extensibility.MixInClosurePropertiesAsMethodsDynamicObject.tryInvokeMethod(MixInClosurePropertiesAsMethodsDynamicObject.java:34)
        at org.gradle.api.tasks.bundling.Jar_Decorated.invokeMethod(Unknown Source)
        at aQute.bnd.gradle.BndBuilderPlugin$_apply_closure1$_closure2$_closure6.doCall(BndBuilderPlugin.groovy:59)
        ...
```

https://plugins.gradle.org/plugin/com.athaydes.osgi-run

```
> Task :createBundlesDir
Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: "mucommander-preferences-0.9.7.jar". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths. Consult the upgrading guide for further information: https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated
	at org.gradle.api.internal.file.copy.DuplicateHandlingCopyActionDecorator.lambda$execute$0(DuplicateHandlingCopyActionDecorator.java:54)
	at org.gradle.api.internal.file.copy.CopyFileVisitorImpl.processFile(CopyFileVisitorImpl.java:64)
	at org.gradle.api.internal.file.copy.CopyFileVisitorImpl.visitFile(CopyFileVisitorImpl.java:48)
	at org.gradle.api.internal.file.collections.DirectoryFileTree.processSingleFile(DirectoryFileTree.java:138)
	at org.gradle.api.internal.file.collections.DirectoryFileTree.visitFrom(DirectoryFileTree.java:125)
	at org.gradle.api.internal.file.collections.DirectoryFileTree.visit(DirectoryFileTree.java:112)
	at org.gradle.api.internal.file.collections.FileTreeAdapter.visit(FileTreeAdapter.java:94)
	at org.gradle.api.internal.file.CompositeFileTree.visit(CompositeFileTree.java:101)
	at org.gradle.api.internal.file.copy.CopySpecActionImpl.execute(CopySpecActionImpl.java:40)
	at org.gradle.api.internal.file.copy.CopySpecActionImpl.execute(CopySpecActionImpl.java:24)
	at org.gradle.api.internal.file.copy.DefaultCopySpec$DefaultCopySpecResolver.walk(DefaultCopySpec.java:702)
	at org.gradle.api.internal.file.copy.DefaultCopySpec.walk(DefaultCopySpec.java:497)
	at org.gradle.api.internal.file.copy.DelegatingCopySpecInternal.walk(DelegatingCopySpecInternal.java:282)
	at org.gradle.api.internal.file.copy.CopySpecBackedCopyActionProcessingStream.process(CopySpecBackedCopyActionProcessingStream.java:39)
	at org.gradle.api.internal.file.copy.DuplicateHandlingCopyActionDecorator.lambda$execute$1(DuplicateHandlingCopyActionDecorator.java:43)
	at org.gradle.api.internal.file.copy.NormalizingCopyActionDecorator.lambda$execute$1(NormalizingCopyActionDecorator.java:60)
	at org.gradle.api.internal.file.copy.FileCopyAction.execute(FileCopyAction.java:38)
	at org.gradle.api.internal.file.copy.NormalizingCopyActionDecorator.execute(NormalizingCopyActionDecorator.java:59)
	at org.gradle.api.internal.file.copy.DuplicateHandlingCopyActionDecorator.execute(DuplicateHandlingCopyActionDecorator.java:43)
	at org.gradle.api.internal.file.copy.CopyActionExecuter.execute(CopyActionExecuter.java:40)
	at org.gradle.api.internal.file.copy.FileCopier.doCopy(FileCopier.java:80)
	at org.gradle.api.internal.file.copy.FileCopier.copy(FileCopier.java:65)
	at org.gradle.api.internal.file.DefaultFileOperations.copy(DefaultFileOperations.java:207)
	at org.gradle.api.internal.project.DefaultProject.copy(DefaultProject.java:1100)
	at org.gradle.api.internal.project.DefaultProject.copy(DefaultProject.java:1095)
	at org.gradle.api.Project$copy$8.call(Unknown Source)
	at com.athaydes.gradle.osgi.CreateBundlesDir.copyBundles(CreateBundlesDir.groovy:85)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.athaydes.gradle.osgi.CreateBundlesDir.createOsgiRuntime(CreateBundlesDir.groovy:68)
	...
```