### PR TITLE
Fix the creation of Felix cache directory

### DIFF
--- a/package/readme.txt
+++ b/package/readme.txt
@@ -48,6 +48,7 @@ Localization:
 
 Bug fixes:
 - File-search returns matches in the root folder of the search when search-subfolders is disabled.
+- The application no longer fails to start by a non-admin user after it starts by an admin user.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -41,6 +41,7 @@ Improvements:
 - Set initial look and feel to "GTK+" on Linux as it better handles scaling for HiDPI.
 - Non-browsable initial locations that are specified by command line arguments are selected on startup.
 - Store user-files in '$XDG_CONFIG_HOME/mucommander' if environment variable XDG_CONFIG_HOME is set on Linux.
+- Create Felix cache directory within the system's temporary folder instead of within the installation folder.
 
 Localization:
 - Korean translation updated.

--- a/src/main/java/com/mucommander/main/muCommander.java
+++ b/src/main/java/com/mucommander/main/muCommander.java
@@ -279,7 +279,7 @@ public class muCommander
         final String appDir = configProps.get("mucommander.app.dir");
         configProps.computeIfAbsent("felix.auto.start.2", key -> "file:" + new File(appDir, "mucommander-core-0.9.7.jar").getAbsolutePath());
 
-        Path cacheDir = Paths.get(System.getProperty("java.io.tmpdir"), "mucommander-felix-cache");
+        Path cacheDir = Paths.get(System.getProperty("java.io.tmpdir"), "mucommander-felix-cache-"+System.getProperty("user.name"));
         configProps.put(Constants.FRAMEWORK_STORAGE, cacheDir.toFile().getAbsolutePath());
 
         // Copy framework properties from the system properties.

--- a/src/main/java/com/mucommander/main/muCommander.java
+++ b/src/main/java/com/mucommander/main/muCommander.java
@@ -278,7 +278,9 @@ public class muCommander
 
         final String appDir = configProps.get("mucommander.app.dir");
         configProps.computeIfAbsent("felix.auto.start.2", key -> "file:" + new File(appDir, "mucommander-core-0.9.7.jar").getAbsolutePath());
-        configProps.computeIfAbsent(Constants.FRAMEWORK_STORAGE, key -> new File(codeParentFolder, "felix-cache").getAbsolutePath());
+
+        Path cacheDir = Paths.get(System.getProperty("java.io.tmpdir"), "mucommander-felix-cache");
+        configProps.put(Constants.FRAMEWORK_STORAGE, cacheDir.toFile().getAbsolutePath());
 
         // Copy framework properties from the system properties.
         muCommander.copySystemProperties(configProps);


### PR DESCRIPTION
Move the Felix cache directory to be within the operating system's temporary folder and create a different cache directory per-user