### PR TITLE
Fix copying to non-default destination folder

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/util/PathUtils.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/util/PathUtils.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Objects;
 
 /**
  * This class contains static helper methods that operate on file paths.
@@ -226,33 +227,28 @@ public class PathUtils {
         }
 
         // No point in going any further if the URL cannot be resolved into a file
-        AbstractFile destFile = null;
-        if (parent != null && destURL.equals(parent.getURL())) {
-            destFile = parent;
-        } else {
-            try {
-                destFile = FileFactory.getFile(destURL, parent);
-            } catch (IOException e) {
-                LOGGER.debug("failed to retrieve file", e);
-            }
-        }
-        if(destFile ==null) {
+        AbstractFile destFile = FileFactory.getFile(destURL);
+        if (destFile == null) {
             LOGGER.info("could not resolve a file for {}", destURL);
             return null;
         }
 
         // Test if the destination file exists
         boolean destFileExists = destFile.exists();
-        if(destFileExists) {
+        if (destFileExists) {
             // Note: path to archives must end with a trailing separator character to refer to the archive as a folder,
             //  if they don't, they'll refer to the archive as a file.
             if(destFile.isDirectory() || (destPath.endsWith(destFile.getSeparator()) && destFile.isBrowsable()))
                 return new ResolvedDestination(destFile, DestinationType.EXISTING_FOLDER, destFile);
         }
 
+        if (Objects.equals(parent, destFile.getParent())) {
+            destFile.setParent(parent);
+        }
+
         // Test if the destination's parent exists, if not the path is not a valid destination
         AbstractFile destParent = destFile.getParent();
-        if(destParent==null || !destParent.exists())
+        if (destParent == null || !destParent.exists())
             return null;
 
         return new ResolvedDestination(destFile, destFileExists?DestinationType.EXISTING_FILE:DestinationType.NEW_FILE, destParent);

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -51,6 +51,7 @@ Bug fixes:
 - File-search returns matches in the root folder of the search when search-subfolders is disabled.
 - The application can start by a non-admin user after it started by an admin user.
 - The application can start with an inaccessible location at the right panel.
+- Files are transferred properly when the destination folder is not presented in the other panel.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This


### PR DESCRIPTION
By default, the destination folder for copy/move file(s) is set to the current folder in the other panel.
Due to changes that were introduced to support copying to Google Drive, the parent folder of the copied files was set to the current folder in the other panel even when specifying a different destination folder.
Now, this doesn't happen when files are copied to a destination folder that is different than the one presented in the other panel.