### PR TITLE
Fix FileViewer and FileEditor selection logic when a warning is raised

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorRegistrar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorRegistrar.java
@@ -107,6 +107,7 @@ public class EditorRegistrar {
 
                 // User confirmed the operation
                 editor = factory.createFileEditor();
+                break;
             }
         }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerRegistrar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerRegistrar.java
@@ -104,6 +104,7 @@ public class ViewerRegistrar {
 
                 // User confirmed the operation
                 viewer = (FileViewer) ((FileViewerWrapper) service.createFileViewer()).getViewerComponent();
+                break;
             }
         }
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -52,6 +52,7 @@ Bug fixes:
 - The application can start by a non-admin user after it started by an admin user.
 - The application can start with an inaccessible location at the right panel.
 - Files are transferred properly when the destination folder is not presented in the other panel.
+- Use the correct file viewer/editor when a warning is raised.
 
 Known issues:
 - Mac OS X: "muCommander damaged and cannot be opened" may appear after downloading muCommander from the browser. This


### PR DESCRIPTION
This fixes the FileViewer and FileEditor selection logic when a WarnUserException is raised.

I noticed this issue when trying to view large text files. Instead of displaying the file with the text viewer, the binary viewer was used instead.

I copied the logic to FileEditor as well since they share the same code.