### PR TITLE
text-viewer: calculate line numbers panel width after file is loaded

### DIFF
--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
@@ -88,6 +88,7 @@ class TextEditor extends FileEditor implements DocumentListener, EncodingListene
     		@Override
     		protected void showLineNumbers(boolean show) {
                 TextEditor.this.setRowHeaderView(show ? TextEditor.this.lineNumbersPanel : null);
+                setLineNumbers(show);
     	    }
     		
             @Override

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
@@ -57,6 +57,8 @@ import com.mucommander.ui.viewer.FileFrame;
 class TextEditor extends FileEditor implements DocumentListener, EncodingListener {
 	private static final Logger LOGGER = LoggerFactory.getLogger(TextEditor.class);
 
+    private TextLineNumbersPanel lineNumbersPanel;
+
     /** Menu bar */
     // Menus //
     private JMenu editMenu;
@@ -85,9 +87,14 @@ class TextEditor extends FileEditor implements DocumentListener, EncodingListene
     		
     		@Override
     		protected void showLineNumbers(boolean show) {
-    			TextEditor.this.setRowHeaderView(show ? new TextLineNumbersPanel(textEditorImpl.getTextArea()) : null);
+                TextEditor.this.setRowHeaderView(show ? TextEditor.this.lineNumbersPanel : null);
     	    }
     		
+            @Override
+            protected void initLineNumbersPanel() {
+                lineNumbersPanel = new TextLineNumbersPanel(textEditorImpl.getTextArea());
+            }
+
     		@Override
     		protected void initMenuBarItems() {
     			// Edit menu
@@ -200,7 +207,8 @@ class TextEditor extends FileEditor implements DocumentListener, EncodingListene
 
     @Override
     public void show(AbstractFile file) throws IOException {
-    	textViewerDelegate.startEditing(file, this);
+        textViewerDelegate.startEditing(file, this);
+        lineNumbersPanel.setPreferredWidth();
     }
     
     /////////////////////////////////////

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextLineNumbersPanel.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextLineNumbersPanel.java
@@ -150,7 +150,7 @@ public class TextLineNumbersPanel extends JPanel implements CaretListener, Docum
 	protected void setPreferredWidth() {
 		Element root = component.getDocument().getDefaultRootElement();
 		int lines = root.getElementCount();
-		int digits = Math.max(String.valueOf(lines).length(), minimumDisplayDigits);
+		int digits = Math.max(String.valueOf(lines).length() + 2, minimumDisplayDigits);
 
 		//  Update sizes when number of digits in the line number changes
 		if (lastDigits != digits) {

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextLineNumbersPanel.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextLineNumbersPanel.java
@@ -147,7 +147,7 @@ public class TextLineNumbersPanel extends JPanel implements CaretListener, Docum
 	/**
 	 *  Calculate the width needed to display the maximum line number
 	 */
-	private void setPreferredWidth() {
+	protected void setPreferredWidth() {
 		Element root = component.getDocument().getDefaultRootElement();
 		int lines = root.getElementCount();
 		int digits = Math.max(String.valueOf(lines).length(), minimumDisplayDigits);

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
@@ -66,6 +66,8 @@ public class TextViewer extends FileViewer implements EncodingListener {
 
     private static boolean lineNumbers = MuSnapshot.getSnapshot().getVariable(TextViewerSnapshot.TEXT_FILE_PRESENTER_LINE_NUMBERS, TextViewerSnapshot.DEFAULT_LINE_NUMBERS);
 
+    private TextLineNumbersPanel lineNumbersPanel;
+
     /** Menu items */
     // Menus //
     private JMenu editMenu;
@@ -90,7 +92,9 @@ public class TextViewer extends FileViewer implements EncodingListener {
 
         setComponentToPresent(textEditorImpl.getTextArea());
 
+        initLineNumbersPanel();
         showLineNumbers(lineNumbers);
+
         textEditorImpl.wrap(lineWrap);
 
         initMenuBarItems();
@@ -220,13 +224,17 @@ public class TextViewer extends FileViewer implements EncodingListener {
     }
 
     protected void showLineNumbers(boolean show) {
-        setRowHeaderView(show ? new TextLineNumbersPanel(textEditorImpl.getTextArea()) : null);
+        setRowHeaderView(show ? lineNumbersPanel : null);
         setLineNumbers(show);
     }
 
     protected void wrapLines(boolean wrap) {
         textEditorImpl.wrap(wrap);
         setLineWrap(wrap);
+    }
+
+    protected void initLineNumbersPanel() {
+        lineNumbersPanel = new TextLineNumbersPanel(textEditorImpl.getTextArea());
     }
 
     protected void initMenuBarItems() {
@@ -259,6 +267,7 @@ public class TextViewer extends FileViewer implements EncodingListener {
     @Override
     public void show(AbstractFile file) throws IOException {
         startEditing(file, null);
+        lineNumbersPanel.setPreferredWidth();
     }
 
     ///////////////////////////////////


### PR DESCRIPTION
With the current implementation, the initial display of a text file always has a width proportional to minimumDisplayDigits. The resulting visual issue is especially visible when opening files with lines in excess of 10000. With this commit, the width is calculated after the file is loaded and as a result it is set appropriately.
 
I have also added a second commit that increases the padding of the line numbers in the panel for better display, let me know how you feel about it.

EDIT: Added separate commit with fix for remembering panel visibility status.