### PR TITLE
Better XFCE support

### DIFF
--- a/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/Activator.java
+++ b/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/Activator.java
@@ -33,6 +33,7 @@ import com.mucommander.desktop.linux.kde.ConfiguredKde5DesktopAdapter;
 import com.mucommander.desktop.linux.kde.GuessedKde3DesktopAdapter;
 import com.mucommander.desktop.linux.kde.GuessedKde4DesktopAdapter;
 import com.mucommander.desktop.linux.kde.GuessedKde5DesktopAdapter;
+import com.mucommander.desktop.linux.xfce.ConfiguredXfceDesktopAdapter;
 import com.mucommander.desktop.linux.xfce.GuessedXfceDesktopAdapter;
 import com.mucommander.osgi.OperatingSystemService;
 
@@ -54,6 +55,7 @@ public class Activator implements BundleActivator  {
                         new GuessedKde4DesktopAdapter(),
                         new GuessedKde5DesktopAdapter(),
                         new GuessedGnomeDesktopAdapter(),
+                        new ConfiguredXfceDesktopAdapter(),
                         new ConfiguredKde3DesktopAdapter(),
                         new ConfiguredKde4DesktopAdapter(),
                         new ConfiguredKde5DesktopAdapter(),

--- a/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/xfce/ConfiguredXfceDesktopAdapter.java
+++ b/mucommander-os-linux/src/main/java/com/mucommander/desktop/linux/xfce/ConfiguredXfceDesktopAdapter.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.mucommander.desktop.linux.xfce;
+
+import com.mucommander.process.ProcessRunner;
+
+/**
+ * 'Configured' desktop adapter for Xfce. This check content of
+ * <code>XDG_CURRENT_DESKTOP</code> system variable.
+ * 
+ * @author Vadim Kalinnikov
+ */
+public class ConfiguredXfceDesktopAdapter extends XfceDesktopAdapter {
+	public String toString() {return "Xfce Desktop";}
+
+    @Override
+    public boolean isAvailable() {
+        String var = System.getenv("XDG_CURRENT_DESKTOP");
+        if (var != null) {
+            var = var.toLowerCase();
+            return "xfce".equals(var) || "xfce4".equals(var);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
I have added ConfiguredXfceDesktopAdapter. It uses $XDG_CURRENT_DESKTOP environment variable and tested on Xubuntu 20.04.