### PR TITLE
Improve the detection of mouse clicks on the file table headers

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableHeader.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableHeader.java
@@ -38,9 +38,24 @@ public class FileTableHeader extends JTableHeader {
     public FileTableHeader(FileTable table) {
         super(table.getColumnModel());
 
-        addMouseListener(new MouseAdapter() {
+        MouseAdapter mouseAdapter = new MouseAdapter() {
+            private transient short counter;
             @Override
-            public void mouseClicked(MouseEvent e) {
+            public void mousePressed(MouseEvent e) {
+                counter = 0;
+            }
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                ++counter;
+            }
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                // if we get more than 3 mouseDragged events since the mousePressed event,
+                // we will not process the mouseReleased event here. Otherwise, we treat
+                // the mouseReleased event as mouseClicked event
+                if (counter > 3)
+                    return;
+
                 table.requestFocus();
 
                 // One of the table headers was left-clicked, sort the table by the clicked column's criterion
@@ -81,7 +96,9 @@ public class FileTableHeader extends JTableHeader {
                     popupMenu.setVisible(true);
                 }
             }
-        });
+        };
+        addMouseListener(mouseAdapter);
+        addMouseMotionListener(mouseAdapter);
     }
 
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableHeader.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableHeader.java
@@ -17,28 +17,71 @@
 
 package com.mucommander.ui.main.table;
 
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JSeparator;
+import javax.swing.table.JTableHeader;
+
 import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.ui.action.ActionManager;
 import com.mucommander.ui.action.impl.ToggleAutoSizeAction;
 import com.mucommander.ui.main.MainFrame;
 
-import javax.swing.*;
-import javax.swing.table.JTableHeader;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-
 /**
  * @author Maxence Bernard
  */
-public class FileTableHeader extends JTableHeader implements MouseListener {
-
-    private FileTable table;
+public class FileTableHeader extends JTableHeader {
 
     public FileTableHeader(FileTable table) {
         super(table.getColumnModel());
 
-        this.table = table;
-        addMouseListener(this);
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                table.requestFocus();
+
+                // One of the table headers was left-clicked, sort the table by the clicked column's criterion
+                if (DesktopManager.isLeftMouseButton(e)) {
+                    Column col = Column.valueOf(table.convertColumnIndexToModel(getColumnModel().getColumnIndexAtX(e.getX())));
+                    // If the table was already sorted by this criteria, reverse order
+                    if (table.getSortInfo().getCriterion()==col)
+                        table.reverseSortOrder();
+                    else
+                        table.sortBy(col);
+                }
+                // One of the table headers was right-clicked, popup a menu that offers to hide the column
+                else if (DesktopManager.isRightMouseButton(e)) {
+                    JPopupMenu popupMenu = new JPopupMenu();
+                    MainFrame mainFrame = table.getFolderPanel().getMainFrame();
+
+                    for(Column c : Column.values()) {
+                        if(c==Column.NAME)
+                            continue;
+
+                        JCheckBoxMenuItem checkboxMenuItem = new JCheckBoxMenuItem(ActionManager.getActionInstance(c.getToggleColumnActionId(), mainFrame));
+
+                        checkboxMenuItem.setSelected(table.isColumnEnabled(c));
+                        checkboxMenuItem.setEnabled(table.isColumnDisplayable(c));
+                        // Override the action's label to a shorter one
+                        checkboxMenuItem.setText(c.getLabel());
+
+                        popupMenu.add(checkboxMenuItem);
+                    }
+
+                    popupMenu.add(new JSeparator());
+
+                    JCheckBoxMenuItem checkboxMenuItem = new JCheckBoxMenuItem(ActionManager.getActionInstance(ToggleAutoSizeAction.Descriptor.ACTION_ID, mainFrame));
+                    checkboxMenuItem.setSelected(mainFrame.isAutoSizeColumnsEnabled());
+                    popupMenu.add(checkboxMenuItem);
+
+                    popupMenu.show(FileTableHeader.this, e.getX(), e.getY());
+                    popupMenu.setVisible(true);
+                }
+            }
+        });
     }
 
 
@@ -49,66 +92,5 @@ public class FileTableHeader extends JTableHeader implements MouseListener {
     @Override
     public boolean getReorderingAllowed() {
         return true;
-    }
-
-    
-    //////////////////////////////////
-    // MouseListener implementation //
-    //////////////////////////////////
-
-    public void mouseClicked(MouseEvent e) {
-        Column col = Column.valueOf(table.convertColumnIndexToModel(getColumnModel().getColumnIndexAtX(e.getX())));
-
-        table.requestFocus();
-
-        // One of the table headers was left-clicked, sort the table by the clicked column's criterion
-        if(DesktopManager.isLeftMouseButton(e)) {
-            // If the table was already sorted by this criteria, reverse order
-            if (table.getSortInfo().getCriterion()==col)
-                table.reverseSortOrder();
-            else
-                table.sortBy(col);
-        }
-        // One of the table headers was right-clicked, popup a menu that offers to hide the column
-        else if(DesktopManager.isRightMouseButton(e)) {
-            JPopupMenu popupMenu = new JPopupMenu();
-            MainFrame mainFrame = table.getFolderPanel().getMainFrame();
-
-            JCheckBoxMenuItem checkboxMenuItem;
-            for(Column c : Column.values()) {
-                if(c==Column.NAME)
-                    continue;
-
-                checkboxMenuItem = new JCheckBoxMenuItem(ActionManager.getActionInstance(c.getToggleColumnActionId(), mainFrame));
-
-                checkboxMenuItem.setSelected(table.isColumnEnabled(c));
-                checkboxMenuItem.setEnabled(table.isColumnDisplayable(c));
-                // Override the action's label to a shorter one
-                checkboxMenuItem.setText(c.getLabel());
-
-                popupMenu.add(checkboxMenuItem);
-            }
-
-            popupMenu.add(new JSeparator());
-
-            checkboxMenuItem = new JCheckBoxMenuItem(ActionManager.getActionInstance(ToggleAutoSizeAction.Descriptor.ACTION_ID, mainFrame));
-            checkboxMenuItem.setSelected(mainFrame.isAutoSizeColumnsEnabled());
-            popupMenu.add(checkboxMenuItem);
-
-            popupMenu.show(this, e.getX(), e.getY());
-            popupMenu.setVisible(true);
-        }
-    }
-
-    public void mousePressed(MouseEvent e) {
-    }
-
-    public void mouseReleased(MouseEvent e) {
-    }
-
-    public void mouseEntered(MouseEvent e) {
-    }
-
-    public void mouseExited(MouseEvent e) {
     }
 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -35,7 +35,7 @@ New features:
 -
 
 Improvements:
--
+- Mouse clicks on the headers of a file table (e.g., NAME, SIZE, DATE) are better detected.
 
 Localization:
 - Updated Russian translation


### PR DESCRIPTION
On macOS, some of the mouse clicks on the headers of the file tables are not recognized. The reason appears to be the high sensitivity of mouseDragged events. This PR attempts to improve the detection of those mouse clicks by reacting on mouseReleased events instead of mouseClicked events and compensating for the high sensitivity of mouseDragged events.