### PR TITLE
skip method of InputStream should return 0 when EOF is reached

### DIFF
--- a/mucommander-commons-io/src/main/java/com/mucommander/commons/io/RandomAccessInputStream.java
+++ b/mucommander-commons-io/src/main/java/com/mucommander/commons/io/RandomAccessInputStream.java
@@ -95,10 +95,10 @@ public abstract class RandomAccessInputStream extends InputStream implements Ran
      * plus the number of bytes to skip doesn't exceed the length of this stream as returned by {@link #getLength()}.
      * If it does, all the remaining bytes will be skipped so that the offset of this stream will be positioned to
      * {@link #getLength()}.
-     * Returns <code>-1</code> if the offset is already positioned to the end of the stream when this method is called.
+     * Returns <code>0</code> if the offset is already positioned to the end of the stream when this method is called.
      *
      * @param n number of bytes to skip
-     * @return the number of bytes that have effectively been skipped, -1 if the offset is already positioned to the
+     * @return the number of bytes that have effectively been skipped, 0 if the offset is already positioned to the
      * end of the stream when this method is called
      * @throws IOException if something went wrong
      */
@@ -110,9 +110,9 @@ public abstract class RandomAccessInputStream extends InputStream implements Ran
         long offset = getOffset();
         long length = getLength();
 
-        // Return -1 if the offset is already at the end of the stream
+        // Return 0 if the offset is already at the end of the stream
         if(offset>=length)
-            return -1;
+            return 0;
 
         // Makes sure not to go beyond the end of the stream
         long newOffset = offset + n;

--- a/mucommander-commons-io/src/main/java/com/mucommander/commons/io/StreamUtils.java
+++ b/mucommander-commons-io/src/main/java/com/mucommander/commons/io/StreamUtils.java
@@ -362,7 +362,7 @@ public class StreamUtils {
 
         do {
             long nbSkipped = in.skip(n);
-            if(nbSkipped<0)
+            if(nbSkipped==0)
                 throw new EOFException();
 
             n -= nbSkipped;


### PR DESCRIPTION
As the commit message says, the skip method of an InputStream should return 0 when EOF is reached. I hit a bug while running the nightly where muCommander would get stuck when trying to open some tar files. The issue ended up being that commons-compress depends on this behaviour and due to -1 being returned it would get stuck in an endless loop