### PR TITLE
store preferences in installation directory when in portable mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,7 +411,8 @@ task portable(dependsOn: [createExe, createBundlesDir], type: Zip) {
     from ('package') { include 'license.txt', 'readme.txt' }
     def tempDir = File.createTempDir()
     tempDir.deleteOnExit()
-    from ({ new File(temporaryDir, 'felix-cache').mkdirs(); temporaryDir }) {
+    from ({ new File(temporaryDir, '.portable').createNewFile(); new File(temporaryDir, 'felix-cache').mkdirs(); temporaryDir }) {
+        include '.portable'
         include 'felix-cache'
         dirMode 0777
     }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -41,6 +41,7 @@ Improvements:
 - Tar archives with headers in the pax format are now supported.
 - The free space indicator in the status bar is updated right after relevant events like switching to the application.
 - Symbolic links are unpacked from tar archives.
+- The portable version stores preferences files in the installation directory.
 
 Localization:
 - Updated Russian translation

--- a/src/main/java/com/mucommander/main/muCommander.java
+++ b/src/main/java/com/mucommander/main/muCommander.java
@@ -291,18 +291,26 @@ public class muCommander
         muCommander.copySystemProperties(configProps);
 
         File preferencesFolder;
-        if (configuration.preferences == null) {
-            try {
-                preferencesFolder = UserPreferencesDir.getDefaultPreferencesFolder();
-            } catch(RuntimeException e) {
-                System.err.println("Failed to retrieve default preferences folder: " + e.getMessage());
-                return;
-            }
-        } else {
+        if (configuration.preferences != null) {
             try {
                 preferencesFolder = UserPreferencesDir.getPreferencesFolder(configuration.preferences);
             } catch(RuntimeException e) {
                 System.err.println("Failed to retrieve specified preferences folder: " + configuration.preferences);
+                return;
+            }
+        } else if (new File(codeParentFolder, ".portable").exists()) {
+            String portableDir = new File(codeParentFolder, ".mucommander").getAbsolutePath();
+            try {
+                preferencesFolder = UserPreferencesDir.getPreferencesFolder(portableDir);
+            } catch(RuntimeException e) {
+                System.err.println("Failed to retrieve portable preferences folder: " + portableDir);
+                return;
+            }
+        } else {
+            try {
+                preferencesFolder = UserPreferencesDir.getDefaultPreferencesFolder();
+            } catch(RuntimeException e) {
+                System.err.println("Failed to retrieve default preferences folder: " + e.getMessage());
                 return;
             }
         }


### PR DESCRIPTION
This affects the portable distribution (by default).

In order to detect whether the application should start in portable mode, an empty file with the name `.portable` is used. This file has to reside in the installation directory.

I chose the name and location of the portable preferences directory based on the information available on the wiki [1]. Considering there is a conf folder now, `conf/mucommander` sounds like a good option as well (although I also like the first option of having the preferences directory as top-level in the installation directory instead of inside a folder that is shipped with the distribution).

This PR changes the previous behaviour so it may be useful for some users (if anyone likes to use the portable distribution with global settings) to note that they can delete the `.portable` file from the installation directory in order to revert to the previous behaviour. If you think this would be useful, I could maybe add a line about in the readme.txt.

[1] https://github.com/mucommander/mucommander/wiki/Preference-Files