### PR TITLE
ftp: throw exception when changing directory failed

### DIFF
--- a/mucommander-protocol-ftp/src/main/java/com/mucommander/commons/file/protocol/ftp/FTPFile.java
+++ b/mucommander-protocol-ftp/src/main/java/com/mucommander/commons/file/protocol/ftp/FTPFile.java
@@ -243,8 +243,10 @@ public class FTPFile extends ProtocolFile implements ConnectionHandlerFactory {
             // http://issues.apache.org/jira/browse/NET-10
 
             connHandler.ftpClient.changeWorkingDirectory(absPath);
-            files = connHandler.ftpClient.listFiles();
+            // Throw an IOException if server replied with an error
+            connHandler.checkServerReply();
 
+            files = connHandler.ftpClient.listFiles();
             // Throw an IOException if server replied with an error
             connHandler.checkServerReply();
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -44,6 +44,7 @@ Improvements:
 - The portable version stores preferences files in the installation directory.
 - It is now possible to change the modification date of multiple search results.
 - Prevention of ZipSlip (https://snyk.io/research/zip-slip-vulnerability).
+- An informative error dialog is displayed when failing to change directory while browsing an ftp server.
 
 Localization:
 - Russian translation updated.


### PR DESCRIPTION
As an example, this can happen when trying to cwd to a directory where you do not have permissions. An informative error dialog is now displayed, providing feedback to the user. muCommander also now realizes that the operation failed and no longer updates the path.