### PR TITLE
WIP: Basic SMBv2 support through jcifs-ng library

### DIFF
--- a/mucommander-protocol-smb/build.gradle
+++ b/mucommander-protocol-smb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api project(':mucommander-protocol-api')
     api project(':mucommander-translator')
 
-    implementation 'eu.agno3.jcifs:jcifs-ng:2.1.6'
+    implementation 'eu.agno3.jcifs:jcifs-ng:2.1.7'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-protocol-smb/build.gradle
+++ b/mucommander-protocol-smb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api project(':mucommander-protocol-api')
     api project(':mucommander-translator')
 
-    implementation 'jcifs:jcifs:1.3.17'
+    implementation 'eu.agno3.jcifs:jcifs-ng:2.1.6'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
+++ b/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
@@ -24,6 +24,7 @@ import com.mucommander.commons.file.protocol.FileProtocols;
 import com.mucommander.commons.file.protocol.ProtocolFile;
 import com.mucommander.commons.io.RandomAccessInputStream;
 import com.mucommander.commons.io.RandomAccessOutputStream;
+import jcifs.context.SingletonContext;
 import jcifs.smb.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,7 +158,8 @@ import java.util.Collections;
         // The reason for doing this rather than using the SmbFile(String) constructor is that SmbFile uses java.net.URL
         // for the URL parsing which is unable to properly parse urls where the password contains a '@' character,
         // such as smb://user:p@ssword@host/path . 
-        return new SmbFile(url.toString(false), new NtlmPasswordAuthentication(domain, login, credentials.getPassword()));
+        // @todo update deprecated constructor call for jcifs-ng
+        return new SmbFile(url.toString(false), SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthentication(SingletonContext.getInstance(), domain, login, credentials.getPassword())));
     }
 
 
@@ -200,7 +202,8 @@ import java.util.Collections;
      * @param period time period during which attributes values are cached, in milliseconds
      */
     public static void setAttributeCachingPeriod(long period) {
-        jcifs.Config.setProperty("jcifs.smb.client.attrExpirationPeriod", ""+period);
+        // @todo convert for jcifs-ng
+        //  jcifs.Config.setProperty("jcifs.smb.client.attrExpirationPeriod", ""+period);
     }
 
 

--- a/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
+++ b/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
@@ -205,8 +205,7 @@ import java.util.Collections;
      * @param period time period during which attributes values are cached, in milliseconds
      */
     public static void setAttributeCachingPeriod(long period) {
-        // @todo convert for jcifs-ng
-        //  jcifs.Config.setProperty("jcifs.smb.client.attrExpirationPeriod", ""+period);
+        System.setProperty("jcifs.smb.client.attrExpirationPeriod", ""+period);
     }
 
 

--- a/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
+++ b/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
@@ -24,6 +24,8 @@ import com.mucommander.commons.file.protocol.FileProtocols;
 import com.mucommander.commons.file.protocol.ProtocolFile;
 import com.mucommander.commons.io.RandomAccessInputStream;
 import com.mucommander.commons.io.RandomAccessOutputStream;
+
+import jcifs.CIFSContext;
 import jcifs.context.SingletonContext;
 import jcifs.smb.*;
 import org.slf4j.Logger;
@@ -159,7 +161,8 @@ import java.util.Collections;
         // for the URL parsing which is unable to properly parse urls where the password contains a '@' character,
         // such as smb://user:p@ssword@host/path . 
         // @todo update deprecated constructor call for jcifs-ng
-        return new SmbFile(url.toString(false), SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthentication(SingletonContext.getInstance(), domain, login, credentials.getPassword())));
+        CIFSContext context = SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthentication(SingletonContext.getInstance(), domain, login, credentials.getPassword()));
+        return new SmbFile(url.toString(false), context);
     }
 
 

--- a/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
+++ b/mucommander-protocol-smb/src/main/java/com/mucommander/commons/file/protocol/smb/SMBFile.java
@@ -160,8 +160,8 @@ import java.util.Collections;
         // The reason for doing this rather than using the SmbFile(String) constructor is that SmbFile uses java.net.URL
         // for the URL parsing which is unable to properly parse urls where the password contains a '@' character,
         // such as smb://user:p@ssword@host/path . 
-        // @todo update deprecated constructor call for jcifs-ng
-        CIFSContext context = SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthentication(SingletonContext.getInstance(), domain, login, credentials.getPassword()));
+        CIFSContext context = SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthenticator(
+                domain, login, credentials.getPassword()));
         return new SmbFile(url.toString(false), context);
     }
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -32,7 +32,7 @@ What's new since v1.0.1 ?
 -----------------------
 
 New features:
--
+- Add support for SMBv2
 
 Improvements:
 -


### PR DESCRIPTION
This should eventually resolve issue #101

The `jcifs-ng` library (https://github.com/AgNO3/jcifs-ng) which supports SMBv2+ protocol is almost a drop-in replacement for the original `jcifs`.

The PR is not final yet, as I have very little knowledge of SMB internals and there are some parts that needs further rewrite in the `mucommander-protocol-smb` module (marked with `@todo`). Any help from the community is more than welcome. 

In my environment (connecting to a Synology DiskStation running DSM 7.0) I can access the files, copy, move etc. but the main observation so far is that it's significantly slower than previously when connecting using SMBv1