### PR TITLE
Search for size

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/search/SearchBuilder.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/search/SearchBuilder.java
@@ -42,5 +42,6 @@ public interface SearchBuilder {
     SearchBuilder matchCaseInsensitive(Map<String, String> properties);
     SearchBuilder matchRegex(Map<String, String> properties);
     SearchBuilder searchText(Map<String, String> properties);
+    SearchBuilder searchSize(Map<String, String> properties);
     SearchJob build();
 }

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/search/SearchFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/search/SearchFile.java
@@ -77,7 +77,7 @@ public class SearchFile extends ProtocolFile implements SearchListener {
     }
 
     @Override
-    public AbstractFile[] ls() throws IOException, UnsupportedFileOperationException {
+    public AbstractFile[] ls() throws IOException {
         if (search == null) {
             return EMPTY_RESULTS;
         }
@@ -173,8 +173,7 @@ public class SearchFile extends ProtocolFile implements SearchListener {
 
     /**
      * Starts a search thread.
-     * @param mainFrame the MainFrame the search is initiated from
-     */
+     **/
     public void start(SearchBuilder builder) {
         lastModified = System.currentTimeMillis();
         pausedToDueMaxResults = null;
@@ -195,6 +194,7 @@ public class SearchFile extends ProtocolFile implements SearchListener {
                 .matchCaseInsensitive(properties)
                 .matchRegex(properties)
                 .searchText(properties)
+                .searchSize(properties)
                 .build();
         search.start();
     }

--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/button/ButtonChoicePanel.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/button/ButtonChoicePanel.java
@@ -88,7 +88,7 @@ public class ButtonChoicePanel extends JPanel implements KeyListener, FocusListe
         }
         // Use GridLayout to lay out buttons on 2-dimensional grid
         else {
-            setLayout(new GridLayout(0, nbCols));
+            setLayout(new GridLayout(0, nbCols, 10,10));
         }
 
         for (JButton button : buttons) {

--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/layout/XAlignedComponentPanel.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/layout/XAlignedComponentPanel.java
@@ -102,8 +102,11 @@ public class XAlignedComponentPanel extends JPanel {
      * @param component JComponent instance, will take all remaining width space
      * @param ySpaceAfter number of pixels to be inserted after this row
      */
-    public void addRow(String label, JComponent component, int ySpaceAfter) {
-        addRow(new JLabel(label), component, ySpaceAfter);
+    public JLabel addRow(String label, JComponent component, int ySpaceAfter) {
+        JLabel l = new JLabel(label);
+        l.setLabelFor(component);
+        addRow(l, component, ySpaceAfter);
+        return l;
     }
 
 

--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/layout/XAlignedComponentPanel.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/layout/XAlignedComponentPanel.java
@@ -104,7 +104,6 @@ public class XAlignedComponentPanel extends JPanel {
      */
     public JLabel addRow(String label, JComponent component, int ySpaceAfter) {
         JLabel l = new JLabel(label);
-        l.setLabelFor(component);
         addRow(l, component, ySpaceAfter);
         return l;
     }

--- a/mucommander-core/src/main/java/com/mucommander/search/SearchBuilder.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchBuilder.java
@@ -278,11 +278,12 @@ public class SearchBuilder implements com.mucommander.commons.file.protocol.sear
             Predicate<AbstractFile> isNotSymlink = isSymlink.negate();
             predicate = predicate.and(isNotSymlink);
         }
-        if (searchText != null)
-            predicate = predicate.and(createFileContentPredicate());
-
         if (searchSize != null)
             predicate =  predicate.and(createFileSizePredicate());
+
+        // text should be the last predicate because it is the most expensive
+        if (searchText != null)
+            predicate = predicate.and(createFileContentPredicate());
 
         return predicate;
     }

--- a/mucommander-core/src/main/java/com/mucommander/search/SizeRelation.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SizeRelation.java
@@ -20,28 +20,27 @@ package com.mucommander.search;
  * @author Gerolf Scherr
  */
 public enum SizeRelation {
-    eq(0,"=") {
+    eq("=") {
         @Override
         public boolean matches(long sz, long limit, SizeUnit unit) {
             return sz == limit * unit.factor;
         }
     },
-    lt(1,"<"){
+    lt("<"){
         @Override
         public boolean matches(long sz, long limit, SizeUnit unit) {
             return sz < limit * unit.factor;
         }
     },
-    gt(2,">"){
+    gt(">"){
         @Override
         public boolean matches(long sz, long limit, SizeUnit unit) {
             return sz > limit * unit.factor;
         }
     };
 
-    final int index;
     final String title;
-    SizeRelation(int index, String title) { this.index = index; this.title = title; }
+    SizeRelation(String title) { this.title = title; }
 
     // title for combo box display
     public String toString() {

--- a/mucommander-core/src/main/java/com/mucommander/search/SizeRelation.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SizeRelation.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.search;
+
+/**
+ * @author Gerolf Scherr
+ */
+public enum SizeRelation {
+    eq(0,"=") {
+        @Override
+        public boolean matches(long sz, long limit, SizeUnit unit) {
+            return sz == limit * unit.factor;
+        }
+    },
+    lt(1,"<"){
+        @Override
+        public boolean matches(long sz, long limit, SizeUnit unit) {
+            return sz < limit * unit.factor;
+        }
+    },
+    gt(2,">"){
+        @Override
+        public boolean matches(long sz, long limit, SizeUnit unit) {
+            return sz > limit * unit.factor;
+        }
+    };
+
+    final int index;
+    final String title;
+    SizeRelation(int index, String title) { this.index = index; this.title = title; }
+
+    // title for combo box display
+    public String toString() {
+        return title;
+    }
+
+    public final static SizeRelation[] VALUES = values();
+
+    abstract public boolean matches(long sz, long limit, SizeUnit searchSizeUnit);
+
+}

--- a/mucommander-core/src/main/java/com/mucommander/search/SizeUnit.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SizeUnit.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.search;
+
+/**
+ * @author Gerolf Scherr
+ */
+public enum SizeUnit {
+    bytes(0,1), kB(1,1024), MB(2,1024*1024), GB(3,1024l*1024*1024);
+    final int index;
+    final long factor;
+    SizeUnit(int index, long factor) {
+        this.index = index; this.factor = factor;
+    }
+    public final static SizeUnit[] VALUES = values();
+
+}

--- a/mucommander-core/src/main/java/com/mucommander/search/SizeUnit.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SizeUnit.java
@@ -20,11 +20,10 @@ package com.mucommander.search;
  * @author Gerolf Scherr
  */
 public enum SizeUnit {
-    bytes(0,1), kB(1,1024), MB(2,1024*1024), GB(3,1024l*1024*1024);
-    final int index;
+    bytes(1), kB(1024), MB(1024*1024), GB(1024l*1024*1024);
     final long factor;
-    SizeUnit(int index, long factor) {
-        this.index = index; this.factor = factor;
+    SizeUnit(long factor) {
+        this.factor = factor;
     }
     public final static SizeUnit[] VALUES = values();
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/text/EnhancedTextField.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/text/EnhancedTextField.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mucommander.ui.text;
+
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+
+
+/**
+ * @author Gerolf Scherr
+ */
+public class EnhancedTextField extends JTextField {
+
+    public EnhancedTextField(int columns, boolean selectAllOnFocus) {
+        super(columns);
+        init(selectAllOnFocus);
+    }
+
+    public EnhancedTextField(String s, boolean selectAllOnFocus) {
+        super(s);
+        init(selectAllOnFocus);
+    }
+
+    private void init(boolean selectAllOnFocus) {
+        if (selectAllOnFocus) addFocusListener(SelectAllOnFocusListener.get());
+    }
+
+}
+

--- a/mucommander-core/src/main/java/com/mucommander/ui/text/SelectAllOnFocusListener.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/text/SelectAllOnFocusListener.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of muCommander, http://www.mucommander.com
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.mucommander.ui.text;
+
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import javax.swing.text.JTextComponent;
+
+
+/**
+ * @author Gerolf Scherr
+ */
+public class SelectAllOnFocusListener implements FocusListener {
+
+    private final static class InstanceHolder {
+        final static SelectAllOnFocusListener me = new SelectAllOnFocusListener();
+    }
+
+    public static SelectAllOnFocusListener get() {
+        return InstanceHolder.me;
+    }
+
+    private SelectAllOnFocusListener() { }
+
+    @Override
+    public void focusGained(FocusEvent e) {
+        Object o = e.getSource();
+        if (o instanceof JTextComponent) ((JTextComponent)o).selectAll();
+    }
+
+    @Override
+    public void focusLost(FocusEvent e) {
+    }
+}

--- a/mucommander-translator/src/main/resources/dictionary.properties
+++ b/mucommander-translator/src/main/resources/dictionary.properties
@@ -484,8 +484,12 @@ search_dialog.case_sensitive = $[file_selection_dialog.case_sensitive]
 search_dialog.matches_regexp = $[file_selection_dialog.matches_regexp]
 search_dialog.wildcards = (* = any string, ? = any character, \\ = escape for literals: *?)
 search_dialog.search_text  = Containing text
-search_dialog.search_memonic=t
+search_dialog.size=Size
 search_dialog.size_error= Size must be a number or empty!
+search_dialog.size_unit.bytes = bytes
+search_dialog.size_unit.kB = kB
+search_dialog.size_unit.MB = MB
+search_dialog.size_unit.GB = GB
 search_dialog.text_case_sensitive = $[file_selection_dialog.case_sensitive]
 search_dialog.text_matches_regexp = $[file_selection_dialog.matches_regexp]
 server_connect_dialog.server_type = Connection type

--- a/mucommander-translator/src/main/resources/dictionary.properties
+++ b/mucommander-translator/src/main/resources/dictionary.properties
@@ -484,6 +484,8 @@ search_dialog.case_sensitive = $[file_selection_dialog.case_sensitive]
 search_dialog.matches_regexp = $[file_selection_dialog.matches_regexp]
 search_dialog.wildcards = (* = any string, ? = any character, \\ = escape for literals: *?)
 search_dialog.search_text  = Containing text
+search_dialog.search_memonic=t
+search_dialog.size_error= Size must be a number or empty!
 search_dialog.text_case_sensitive = $[file_selection_dialog.case_sensitive]
 search_dialog.text_matches_regexp = $[file_selection_dialog.matches_regexp]
 server_connect_dialog.server_type = Connection type

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
@@ -94,7 +94,7 @@ class TextEditorImpl implements ThemeListener {
 			/**
 			 * Mouse events bubble up until finding a component with a relative listener.
 			 * That's why in case we get an event that needs to initiate its default behavior,
-			 * we just bubble it up to the parent component of the JTextArea.
+			 * we just bubble it up to the parent component of the JTextArea.  
 			 */
 			public void mouseWheelMoved(MouseWheelEvent e) {
 				boolean isCtrlPressed = (e.getModifiers() & KeyEvent.CTRL_MASK)!=0;
@@ -131,10 +131,10 @@ class TextEditorImpl implements ThemeListener {
 
 
 	void findNext() {
-		if (StringUtils.isNullOrEmpty(searchString))
-			find();
-		else
-			doSearch(textArea.getSelectionEnd(), true);
+	    if (StringUtils.isNullOrEmpty(searchString))
+	        find();
+	    else
+	        doSearch(textArea.getSelectionEnd(), true);
 	}
 
 	void findPrevious() {
@@ -247,21 +247,21 @@ class TextEditorImpl implements ThemeListener {
 	 */
 	public void colorChanged(ColorChangedEvent event) {
 		switch(event.getColorId()) {
-			case Theme.EDITOR_FOREGROUND_COLOR:
-				textArea.setForeground(event.getColor());
-				break;
+		case Theme.EDITOR_FOREGROUND_COLOR:
+			textArea.setForeground(event.getColor());
+			break;
 
-			case Theme.EDITOR_BACKGROUND_COLOR:
-				textArea.setBackground(event.getColor());
-				break;
+		case Theme.EDITOR_BACKGROUND_COLOR:
+			textArea.setBackground(event.getColor());
+			break;
 
-			case Theme.EDITOR_SELECTED_FOREGROUND_COLOR:
-				textArea.setSelectedTextColor(event.getColor());
-				break;
+		case Theme.EDITOR_SELECTED_FOREGROUND_COLOR:
+			textArea.setSelectedTextColor(event.getColor());
+			break;
 
-			case Theme.EDITOR_SELECTED_BACKGROUND_COLOR:
-				textArea.setSelectionColor(event.getColor());
-				break;
+		case Theme.EDITOR_SELECTED_BACKGROUND_COLOR:
+			textArea.setSelectionColor(event.getColor());
+			break;
 		}
 	}
 

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
@@ -58,11 +58,16 @@ class TextEditorImpl implements ThemeListener {
 	/** Indicates whether there is a line separator in the original file */
 	private boolean lineSeparatorExists;
 
+	private boolean isEditable;
+
+	private String textLC;
+
 	////////////////////
 	// Initialization //
 	////////////////////
 
 	public TextEditorImpl(boolean isEditable) {
+		this.isEditable = isEditable;
 		// Initialize text area
 		initTextArea(isEditable);
 
@@ -141,8 +146,15 @@ class TextEditorImpl implements ThemeListener {
 		doSearch(textArea.getSelectionStart() - 1, false);
 	}
 
+
+
 	private String getTextLC() {
-		return textArea.getText().toLowerCase();
+		if (isEditable) {
+			return textArea.getText().toLowerCase();
+		} else {
+			if (textLC == null) textLC = textArea.getText().toLowerCase();
+			return textLC;
+		}
 	}
 
 	private void doSearch(int startPos, boolean forward) {

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
@@ -58,16 +58,11 @@ class TextEditorImpl implements ThemeListener {
 	/** Indicates whether there is a line separator in the original file */
 	private boolean lineSeparatorExists;
 
-	private boolean isEditable;
-
-	private String textLC;
-
 	////////////////////
 	// Initialization //
 	////////////////////
 
 	public TextEditorImpl(boolean isEditable) {
-		this.isEditable = isEditable;
 		// Initialize text area
 		initTextArea(isEditable);
 
@@ -99,7 +94,7 @@ class TextEditorImpl implements ThemeListener {
 			/**
 			 * Mouse events bubble up until finding a component with a relative listener.
 			 * That's why in case we get an event that needs to initiate its default behavior,
-			 * we just bubble it up to the parent component of the JTextArea.  
+			 * we just bubble it up to the parent component of the JTextArea.
 			 */
 			public void mouseWheelMoved(MouseWheelEvent e) {
 				boolean isCtrlPressed = (e.getModifiers() & KeyEvent.CTRL_MASK)!=0;
@@ -136,25 +131,18 @@ class TextEditorImpl implements ThemeListener {
 
 
 	void findNext() {
-	    if (StringUtils.isNullOrEmpty(searchString))
-	        find();
-	    else
-	        doSearch(textArea.getSelectionEnd(), true);
+		if (StringUtils.isNullOrEmpty(searchString))
+			find();
+		else
+			doSearch(textArea.getSelectionEnd(), true);
 	}
 
 	void findPrevious() {
 		doSearch(textArea.getSelectionStart() - 1, false);
 	}
 
-
-
 	private String getTextLC() {
-		if (isEditable) {
-			return textArea.getText().toLowerCase();
-		} else {
-			if (textLC == null) textLC = textArea.getText().toLowerCase();
-			return textLC;
-		}
+		return textArea.getText().toLowerCase();
 	}
 
 	private void doSearch(int startPos, boolean forward) {
@@ -259,21 +247,21 @@ class TextEditorImpl implements ThemeListener {
 	 */
 	public void colorChanged(ColorChangedEvent event) {
 		switch(event.getColorId()) {
-		case Theme.EDITOR_FOREGROUND_COLOR:
-			textArea.setForeground(event.getColor());
-			break;
+			case Theme.EDITOR_FOREGROUND_COLOR:
+				textArea.setForeground(event.getColor());
+				break;
 
-		case Theme.EDITOR_BACKGROUND_COLOR:
-			textArea.setBackground(event.getColor());
-			break;
+			case Theme.EDITOR_BACKGROUND_COLOR:
+				textArea.setBackground(event.getColor());
+				break;
 
-		case Theme.EDITOR_SELECTED_FOREGROUND_COLOR:
-			textArea.setSelectedTextColor(event.getColor());
-			break;
+			case Theme.EDITOR_SELECTED_FOREGROUND_COLOR:
+				textArea.setSelectedTextColor(event.getColor());
+				break;
 
-		case Theme.EDITOR_SELECTED_BACKGROUND_COLOR:
-			textArea.setSelectionColor(event.getColor());
-			break;
+			case Theme.EDITOR_SELECTED_BACKGROUND_COLOR:
+				textArea.setSelectionColor(event.getColor());
+				break;
 		}
 	}
 


### PR DESCRIPTION
+ Search for File Size (greater, less, equals) with Units (bytes, kB, MB, GB)

+ Small tweaks for the Search dialog which should enhance productivity:
- '*' as default file name, select-all-on-focus enabled. 
- mnemonic (default:alt-t) for search text.
- as a result the user (me) can search using fewer keystrokes: If I want to search for file name I can just start typing, but if I want to search for file content (text) I type alt-t and enter the search text.

TODO: I am not too proud of the layout in the dialog.
