### PR TITLE
Avoid reusing instaces of SearchFile

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/ModificationDateBasedMonitoredFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/ModificationDateBasedMonitoredFile.java
@@ -37,7 +37,8 @@ public class ModificationDateBasedMonitoredFile extends MonitoredFile {
     public boolean isChanged(boolean periodicCheck) {
         // Note that date will be 0 if the folder is no longer available, and thus yield a refresh: this is exactly
         // what we want (the folder will be changed to a 'workable' folder).
-        boolean modificationDateChanged = originalModificationDate != getDate();
+        long currentModificationDate = getDate();
+        boolean modificationDateChanged = originalModificationDate != currentModificationDate;
         LOGGER.debug("isChanged = {}", modificationDateChanged);
         return modificationDateChanged;
     }

--- a/mucommander-core/src/main/java/com/mucommander/core/LocationChanger.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/LocationChanger.java
@@ -179,8 +179,7 @@ public class LocationChanger {
 			case SearchFile.SCHEMA:
 			    if (folder instanceof SearchFile)
 			        ((SearchFile) folder).stop();
-			    else
-			        folder = FileFactory.getFile(folderURL);
+			    folder = FileFactory.getFile(folderURL);
 			    thread = new SearchUpdaterThread(folderURL, changeLockedTab, mainFrame, folderPanel, locationManager, this);
 			    break;
 			default:


### PR DESCRIPTION
Each instance of `SearchFile` holds a search and its modification time and that makes it non-reusable, e.g., within different tabs. This PR introduces two changes:
1. When refreshing a tab that displays a file search, a new instance of `SearchFile` is created instead of reusing the existing instance
2. The file protocol for file searches is set not to use a `FilePool` for caching the instances of `SearchFile` so each tab would get a different instance