### PR TITLE
Fix to let Reveal In XYZ work on search and parent folder #591

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ParentFolderAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ParentFolderAction.java
@@ -37,7 +37,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public abstract class ParentFolderAction extends MuAction implements ActivePanelListener, LocationListener {
 
-    public ParentFolderAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ParentFolderAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         // Listen to active table change events
@@ -65,10 +65,7 @@ public abstract class ParentFolderAction extends MuAction implements ActivePanel
 
     private void toggleEnabledStateAdapter() {
         AbstractFile currentFolder = mainFrame.getActivePanel().getCurrentFolder();
-        if (currentFolder.getURL().getScheme().equals(SearchFile.SCHEMA))
-            setEnabled(false);
-        else
-            toggleEnabledState();
+        toggleEnabledState();
     }
 
     /////////////////////////////////
@@ -78,10 +75,10 @@ public abstract class ParentFolderAction extends MuAction implements ActivePanel
     public void activePanelChanged(FolderPanel folderPanel) {
         toggleEnabledStateAdapter();
     }
-    
+
     /**********************************
-	 * LocationListener Implementation
-	 **********************************/
+     * LocationListener Implementation
+     **********************************/
 
     public void locationChanged(LocationEvent e) {
         toggleEnabledStateAdapter();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RevealInDesktopAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RevealInDesktopAction.java
@@ -29,6 +29,7 @@ import javax.swing.KeyStroke;
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.archive.AbstractArchiveEntryFile;
 import com.mucommander.commons.file.protocol.local.LocalFile;
+import com.mucommander.commons.file.protocol.search.SearchFile;
 import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.text.Translator;
 import com.mucommander.ui.action.AbstractActionDescriptor;
@@ -55,21 +56,25 @@ public class RevealInDesktopAction extends ParentFolderAction {
     @Override
     protected void toggleEnabledState() {
         AbstractFile currentFolder = mainFrame.getActivePanel().getCurrentFolder();
+        AbstractFile selectedFile = mainFrame.getActiveTable().getSelectedFile();
         setEnabled(currentFolder.getURL().getScheme().equals(LocalFile.SCHEMA)
                 && !currentFolder.isArchive()
-                && !currentFolder.hasAncestor(AbstractArchiveEntryFile.class));
+                && !currentFolder.hasAncestor(AbstractArchiveEntryFile.class)
+                || currentFolder.getURL().getScheme().equals(SearchFile.SCHEMA)
+                && selectedFile != null
+                && selectedFile.getURL().getScheme().equals(LocalFile.SCHEMA));
     }
 
     @Override
     public void performAction() {
+        AbstractFile currentFolder = mainFrame.getActivePanel().getCurrentFolder();
         AbstractFile selectedFile = mainFrame.getActiveTable().getSelectedFile();
-        if (selectedFile != null) {
-            try {
-                CompletionStage<Optional<String>> completionStage = openInFileManager(selectedFile);
-                InformationDialog.showErrorDialogIfNeeded(getMainFrame(), completionStage);
-            } catch (Exception e) {
-                InformationDialog.showErrorDialog(mainFrame);
-            }
+        try {
+            CompletionStage<Optional<String>> completionStage =
+                    openInFileManager(selectedFile != null ? selectedFile : currentFolder);
+            InformationDialog.showErrorDialogIfNeeded(getMainFrame(), completionStage);
+        } catch (Exception e) {
+            InformationDialog.showErrorDialog(mainFrame);
         }
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/menu/TablePopupMenu.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/menu/TablePopupMenu.java
@@ -98,8 +98,9 @@ public class TablePopupMenu extends MuActionsPopupMenu {
         add(new JSeparator());
 
         addAction(com.mucommander.ui.action.impl.RefreshAction.Descriptor.ACTION_ID);
-        // 'Reveal in desktop' displayed only if clicked file is a local file and the OS is capable of doing this
-        if (DesktopManager.canOpenInFileManager(currentFolder)) {
+        // 'Reveal in desktop' displayed only if clicked file is a local file and the OS is capable of doing this,
+        // if clicked file is null, then it was clicked either on background (current folder) or on '..'
+        if (DesktopManager.canOpenInFileManager(clickedFile != null ? clickedFile : currentFolder)) {
             addAction(com.mucommander.ui.action.impl.RevealInDesktopAction.Descriptor.ACTION_ID);
         }
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -42,7 +42,7 @@ Localization:
 - Korean translation updated.
 
 Bug fixes:
-- 
+- "Reveal in" now available and works in search results and when clicking on parent folder
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
Fix addressing bug #591 to Reveal In XYZ work when:
- in search results
- clicked on '..'

Tested on macOS **only**