### PR TITLE
Added Desktop folder to Drive menu, use system icons for Drive menu

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
@@ -396,7 +396,7 @@ public class LocalFile extends ProtocolFile {
         try {
             AbstractFile desktop = homeFolder.getDirectChild("Desktop");
             if (desktop.exists() && desktop.isDirectory() && desktop.canRead()) {
-                volumesV.add(FileFactory.getFile(desktop.getAbsolutePath()));
+                volumesV.add(desktop);
             }
         } catch (IOException e) {
             LOGGER.debug("Thrown exception while getting Desktop folder", e);

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -306,6 +307,8 @@ public class LocalFile extends ProtocolFile {
         if (!(homeFolder == null || volumesV.contains(homeFolder)))
             volumesV.add(homeFolder);
 
+        addDesktopEntry(volumesV, homeFolder);
+
         AbstractFile volumes[] = new AbstractFile[volumesV.size()];
         volumesV.toArray(volumes);
 
@@ -377,6 +380,22 @@ public class LocalFile extends ProtocolFile {
             String warning =
                     "Error parsing" + (OsFamily.FREEBSD.isCurrent() ? "/sbin/mount -p output" : "/proc/mounts entries");
             LOGGER.warn(warning, e);
+        }
+    }
+
+    /**
+     * Adds Desktop to the given volumes entries if home directory is defined and Desktop folder
+     * is present and is writable (~/Desktop)
+     * @param volumesV the <code>Vector</code> to add mount points to
+     * @param homeFolder  a home folder, can be null
+     */
+    private static void addDesktopEntry(Vector<AbstractFile> volumesV, AbstractFile homeFolder) {
+        if (homeFolder == null) {
+            return;
+        }
+        File desktop = Paths.get(homeFolder.getAbsolutePath(), "Desktop").toFile();
+        if (desktop.exists() && desktop.canWrite() && desktop.isDirectory()) {
+            volumesV.add(FileFactory.getFile(desktop.getAbsolutePath()));
         }
     }
 

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
@@ -393,9 +393,13 @@ public class LocalFile extends ProtocolFile {
         if (homeFolder == null) {
             return;
         }
-        File desktop = Paths.get(homeFolder.getAbsolutePath(), "Desktop").toFile();
-        if (desktop.exists() && desktop.canWrite() && desktop.isDirectory()) {
-            volumesV.add(FileFactory.getFile(desktop.getAbsolutePath()));
+        try {
+            AbstractFile desktop = homeFolder.getDirectChild("Desktop");
+            if (desktop.exists() && desktop.isDirectory() && desktop.canRead()) {
+                volumesV.add(FileFactory.getFile(desktop.getAbsolutePath()));
+            }
+        } catch (IOException e) {
+            LOGGER.debug("Thrown exception while getting Desktop folder", e);
         }
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/DrivePopupButton.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/DrivePopupButton.java
@@ -221,10 +221,8 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
 
             }
             setText(newLabel);
-            // Set the folder icon slightly disobeying system icons policy for the current folder
-            Icon icon = FileIcons.hasProperSystemIcons() ?
-                    FileIcons.getSystemFileIcon(currentFolder) : FileIcons.getFileIcon(currentFolder);
-            setIcon(icon);
+            // Set the folder icon based on the current system icons policy
+            setIcon(FileIcons.getFileIcon(currentFolder));
             break;
 
         case BookmarkProtocolProvider.BOOKMARK:
@@ -251,6 +249,7 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
         default:
             // Remote file, use the protocol's name
             setText(protocol.toUpperCase());
+            // Set the folder icon based on the current system icons policy
             setIcon(FileIcons.getFileIcon(currentFolder));
         }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/DrivePopupButton.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/DrivePopupButton.java
@@ -221,12 +221,10 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
 
             }
             setText(newLabel);
-            { // local ctx for icon
             // Set the folder icon slightly disobeying system icons policy for the current folder
             Icon icon = FileIcons.hasProperSystemIcons() ?
                     FileIcons.getSystemFileIcon(currentFolder) : FileIcons.getFileIcon(currentFolder);
             setIcon(icon);
-            }
             break;
 
         case BookmarkProtocolProvider.BOOKMARK:
@@ -253,12 +251,7 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
         default:
             // Remote file, use the protocol's name
             setText(protocol.toUpperCase());
-            { // local ctx for icon
-            // Set the folder icon slightly disobeying system icons policy for the current folder
-            Icon icon = FileIcons.hasProperSystemIcons() ?
-                    FileIcons.getSystemFileIcon(currentFolder) : FileIcons.getFileIcon(currentFolder);
-            setIcon(icon);
-            }
+            setIcon(FileIcons.getFileIcon(currentFolder));
         }
 
     }

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/DrivePopupButton.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/DrivePopupButton.java
@@ -221,8 +221,12 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
 
             }
             setText(newLabel);
-            // Set the folder icon based on the current system icons policy
-            setIcon(FileIcons.getFileIcon(currentFolder));
+            { // local ctx for icon
+            // Set the folder icon slightly disobeying system icons policy for the current folder
+            Icon icon = FileIcons.hasProperSystemIcons() ?
+                    FileIcons.getSystemFileIcon(currentFolder) : FileIcons.getFileIcon(currentFolder);
+            setIcon(icon);
+            }
             break;
 
         case BookmarkProtocolProvider.BOOKMARK:
@@ -249,8 +253,12 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
         default:
             // Remote file, use the protocol's name
             setText(protocol.toUpperCase());
-            // Set the folder icon based on the current system icons policy
-            setIcon(FileIcons.getFileIcon(currentFolder));
+            { // local ctx for icon
+            // Set the folder icon slightly disobeying system icons policy for the current folder
+            Icon icon = FileIcons.hasProperSystemIcons() ?
+                    FileIcons.getSystemFileIcon(currentFolder) : FileIcons.getFileIcon(currentFolder);
+            setIcon(icon);
+            }
         }
 
     }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -33,6 +33,7 @@ What's new since v1.0.0 ?
 
 New features:
 - Added an option to overwrite files only if size differs
+- Display Desktop folder in drive menu (just under home folder)
 
 Improvements:
 - Added a keyboard shortcut (ALT+DELETE) to Open Trash
@@ -40,6 +41,7 @@ Improvements:
 - Contextual menu is shown for file search results
 - Local file search results can now be revealed in the native Desktop's file manager
 - Added back the 'Go to forums' action that now points to the GitHub discussions page
+- Use system icons (if available) for the current folder in Drive button
 
 Localization:
 - Korean translation updated.

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -41,7 +41,6 @@ Improvements:
 - Contextual menu is shown for file search results
 - Local file search results can now be revealed in the native Desktop's file manager
 - Added back the 'Go to forums' action that now points to the GitHub discussions page
-- Use system icons (if available) for the current folder in Drive button
 
 Localization:
 - Korean translation updated.


### PR DESCRIPTION
PR contains:

- Added Desktop folder to Drive menu (just under user home directory)
- Use system icons for current folder in Drive button - slightly ignoring preferences settings in this case. System icons (if available) are already being used for Drive menu, so I for the current folder they should be used, too. The preference settings as to whether to use system icons (never, apps, always) is more for table view, where people may find system icons to messy or making the UI too busy.