### PR TITLE
Fix path of created folders in Google Drive

### DIFF
--- a/mucommander-protocol-gdrive/src/main/java/com/mucommander/commons/file/protocol/gdrive/GoogleDriveFile.java
+++ b/mucommander-protocol-gdrive/src/main/java/com/mucommander/commons/file/protocol/gdrive/GoogleDriveFile.java
@@ -222,6 +222,10 @@ public class GoogleDriveFile extends ProtocolFile implements ConnectionHandlerFa
         try(GoogleDriveConnHandler connHandler = getConnHandler()) {
             File fileMetadata = new File();
             String filename = getURL().getFilename();
+            AbstractFile parent = getParent();
+            if (parent instanceof GoogleDriveMonitoredFile)
+                parent = ((GoogleDriveMonitoredFile) parent).getUnderlyingFile();
+            fileMetadata.setParents(Collections.singletonList(((GoogleDriveFile) parent).getId()));
             fileMetadata.setName(filename);
             fileMetadata.setMimeType(FOLDER_MIME_TYPE);
             file = connHandler.getConnection().files().create(fileMetadata)

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -48,6 +48,7 @@ Localization:
 Bug fixes:
 - Fix broken links to: 'Online documentation', 'Report a bug' and 'Make a donation'
 - If 'open -a Finder $f' is found in commands.xml, it is replaced with 'open -R $f' to preserve the behavior of 'Reveal in Finder' action
+- Make folder operation creates the folder within the correct path rather than always within the root folder of Google Drive.
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
Previously they were always created within the root folder, now they are created within the right path