### PR TITLE
Improvements related to pasting files from clipboard

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PasteClipboardFilesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PasteClipboardFilesAction.java
@@ -51,11 +51,7 @@ public class PasteClipboardFilesAction extends MuAction {
 
     public PasteClipboardFilesAction(MainFrame mainFrame, Map<String,Object> properties) {
         super(mainFrame, properties);
-
-        // Allows this action to be dynamically enabled when the clipboard contains files, and disabled otherwise.
-        // ClipboardNotifier does not work under Mac OS X (tested under Tiger with Java 1.5.0_06)
-        if(!OsFamily.MAC_OS.isCurrent())
-            new ClipboardNotifier(this);
+        new ClipboardNotifier(this);
     }
 
     @Override

--- a/mucommander-core/src/main/java/com/mucommander/ui/dnd/ClipboardNotifier.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dnd/ClipboardNotifier.java
@@ -61,7 +61,7 @@ public class ClipboardNotifier implements FlavorListener {
      */
     private void toggleActionState() {
         try {
-            action.setEnabled(ClipboardSupport.getClipboard().isDataFlavorAvailable(DataFlavor.javaFileListFlavor));
+            action.setEnabled(isPasteClipboardFilesActionEnabled());
         }
         catch(Exception e) {
             // Works around "java.lang.IllegalStateException: cannot open system clipboard" thrown when the clipboard
@@ -69,6 +69,14 @@ public class ClipboardNotifier implements FlavorListener {
 
             LOGGER.debug("Caught an exception while querying the clipboard for files", e);
         }
+    }
+
+    /**
+     * Checks whether the {@link PasteClipboardFilesAction} should be enabled based on the clipboard state
+     * @return true if PasteClipboardFilesAction should be enabled, false otherwise
+     */
+    public static boolean isPasteClipboardFilesActionEnabled() {
+        return ClipboardSupport.getClipboard().isDataFlavorAvailable(DataFlavor.javaFileListFlavor);
     }
 
     ///////////////////////////////////

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/menu/TablePopupMenu.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/menu/TablePopupMenu.java
@@ -22,6 +22,7 @@ import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.protocol.search.SearchFile;
 import com.mucommander.commons.file.util.FileSet;
 import com.mucommander.core.desktop.DesktopManager;
+import com.mucommander.ui.dnd.ClipboardNotifier;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.popup.MuActionsPopupMenu;
 
@@ -80,15 +81,23 @@ public class TablePopupMenu extends MuActionsPopupMenu {
             add(new JSeparator());
         }
 
+        boolean copyOrPasteActionAdded = false;
         // 'Copy name(s)' and 'Copy path(s)' are displayed only if a single file was clicked or files are marked
         if (clickedFile != null || markedFiles.size() > 0) {
             addAction(com.mucommander.ui.action.impl.CopyFilesToClipboardAction.Descriptor.ACTION_ID);
             addAction(com.mucommander.ui.action.impl.CopyFileNamesAction.Descriptor.ACTION_ID);
             addAction(com.mucommander.ui.action.impl.CopyFileBaseNamesAction.Descriptor.ACTION_ID);
             addAction(com.mucommander.ui.action.impl.CopyFilePathsAction.Descriptor.ACTION_ID);
-
-            add(new JSeparator());
+            copyOrPasteActionAdded = true;
         }
+
+        if (ClipboardNotifier.isPasteClipboardFilesActionEnabled()) {
+            addAction(com.mucommander.ui.action.impl.PasteClipboardFilesAction.Descriptor.ACTION_ID);
+            copyOrPasteActionAdded = true;
+        }
+
+        if (copyOrPasteActionAdded)
+            add(new JSeparator());
 
         // Those following items are displayed in all cases
         addAction(com.mucommander.ui.action.impl.MarkAllAction.Descriptor.ACTION_ID);

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -45,6 +45,7 @@ Improvements:
 - Speed up collecting file-system roots when Windows network shares disconnect
 - Added an option to use system icons (if available) for Folders in Drive button
 - Sort criterion/column and sort order are presented on files tables when using a non-native look and feel on macOS
+- Added the 'Paste file(s)' action, when enabled, to the context menu of file tables.
 
 Localization:
 - Korean translation updated.


### PR DESCRIPTION
1. Add the 'paste file(s)' action to the context menu of file tables
2. Use ClipboardNotifier also on macOS as it now seems to work well