### PR TITLE
Change rendering of editable cell

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
@@ -33,6 +33,7 @@ import java.awt.event.MouseMotionListener;
 import java.util.Iterator;
 import java.util.WeakHashMap;
 
+import javax.swing.BorderFactory;
 import javax.swing.DefaultCellEditor;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
@@ -49,7 +50,6 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
-import com.mucommander.text.SizeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +64,7 @@ import com.mucommander.conf.MuPreferences;
 import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.job.impl.MoveJob;
 import com.mucommander.text.CustomDateFormat;
+import com.mucommander.text.SizeFormat;
 import com.mucommander.ui.action.ActionKeymap;
 import com.mucommander.ui.action.ActionManager;
 import com.mucommander.ui.action.MuAction;
@@ -205,7 +206,7 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
         inputMap.setParent(null);
 
         // Initializes the table.
-        cellRenderer     = new FileTableCellRenderer(this);
+        cellRenderer = new FileTableCellRenderer(this);
         getColumnModel().getColumn(convertColumnIndexToView(Column.NAME.ordinal())).setCellEditor(filenameEditor = new FilenameEditor(new JTextField()));
         getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         setTableHeader(new FileTableHeader(this));
@@ -1532,6 +1533,7 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
         public FilenameEditor(JTextField textField) {
             super(textField);
             this.filenameField = textField;
+            filenameField.setBorder(BorderFactory.createEmptyBorder());
             // Sets the font to the same one that's used for cell rendering (user-defined)
             filenameField.setFont(FileTableCellRenderer.getCellFont());
             filenameField.setFocusTraversalKeysEnabled(false);
@@ -1621,6 +1623,11 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
 
             AbstractFile file = tableModel.getFileAtRow(editingRow);
             AbstractCopyDialog.selectDestinationFilename(file, file.getName(), 0).feedToPathField(filenameField);
+
+            filenameField.setBackground(cellRenderer.getBakgroundOfSelectedFileInInactiveTable());
+            filenameField.setSelectionColor(cellRenderer.getBakgroundOfNormalFileInInactiveTable());
+            filenameField.setForeground(cellRenderer.getForegroundOfSelectedFileInInactiveTable(editingRow, file));
+            filenameField.setSelectedTextColor(cellRenderer.getForegroundOfNormalFileInInactiveTable(editingRow, file));
 
             // Request focus on text field
             filenameField.requestFocus();

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
@@ -169,15 +169,6 @@ public class FileTableCellRenderer implements TableCellRenderer, ThemeListener {
     }
 
     public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int rowIndex, int columnIndex) {
-        Column                column;
-        int                   colorIndex;
-        int                   focusedIndex;
-        int                   selectedIndex;
-        CellLabel             label;
-        AbstractFile          file;
-        boolean               matches;
-        QuickSearch 		  search;
-
         // Need to check that row index is not out of bounds because when the folder
         // has just been changed, the JTable may try to repaint the old folder and
         // ask for a row index greater than the length if the old folder contained more files
@@ -185,13 +176,14 @@ public class FileTableCellRenderer implements TableCellRenderer, ThemeListener {
             return null;
 
         // Sanity check.
-        file = tableModel.getCachedFileAtRow(rowIndex);
+        AbstractFile file = tableModel.getCachedFileAtRow(rowIndex);
         if(file==null) {
             LOGGER.debug("tableModel.getCachedFileAtRow("+ rowIndex +") RETURNED NULL !");
             return null;
         }
 
-        search = this.table.getQuickSearch();
+        QuickSearch search = this.table.getQuickSearch();
+        boolean matches;
         if(!table.hasFocus())
             matches = true;
         else {
@@ -203,12 +195,12 @@ public class FileTableCellRenderer implements TableCellRenderer, ThemeListener {
 
         // Retrieves the various indexes of the colors to apply.
         // Selection only applies when the table is the active one
-        selectedIndex =  (isSelected && ((FileTable)table).isActiveTable()) ? ThemeCache.SELECTED : ThemeCache.NORMAL;
-        focusedIndex  = table.hasFocus() ? ThemeCache.ACTIVE : ThemeCache.INACTIVE;
-        colorIndex    = getColorIndex(rowIndex, file, tableModel);
+        int selectedIndex =  (isSelected && ((FileTable)table).isActiveTable()) ? ThemeCache.SELECTED : ThemeCache.NORMAL;
+        int focusedIndex  = table.hasFocus() ? ThemeCache.ACTIVE : ThemeCache.INACTIVE;
+        int colorIndex    = getColorIndex(rowIndex, file, tableModel);
 
-        column = Column.valueOf(table.convertColumnIndexToModel(columnIndex));
-        label = cellLabels[column.ordinal()];
+        Column column = Column.valueOf(table.convertColumnIndexToModel(columnIndex));
+        CellLabel label = cellLabels[column.ordinal()];
 
         // Extension/icon column: return ImageIcon instance
         if(column == Column.EXTENSION) {

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
@@ -18,6 +18,7 @@
 
 package com.mucommander.ui.main.table;
 
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
 
@@ -101,7 +102,24 @@ public class FileTableCellRenderer implements TableCellRenderer, ThemeListener {
         return ThemeCache.tableFont;
     }
 
-	
+    public Color getBakgroundOfSelectedFileInInactiveTable() {
+        return ThemeCache.backgroundColors[ThemeCache.INACTIVE][ThemeCache.SELECTED];
+    }
+
+    public Color getBakgroundOfNormalFileInInactiveTable() {
+        return ThemeCache.backgroundColors[ThemeCache.INACTIVE][ThemeCache.NORMAL];
+    }
+
+    public Color getForegroundOfSelectedFileInInactiveTable(int row, AbstractFile file) {
+        int colorIndex = getColorIndex(row, file, tableModel);
+        return ThemeCache.foregroundColors[ThemeCache.INACTIVE][ThemeCache.SELECTED][colorIndex];
+    }
+
+    public Color getForegroundOfNormalFileInInactiveTable(int row, AbstractFile file) {
+        int colorIndex = getColorIndex(row, file, tableModel);
+        return ThemeCache.foregroundColors[ThemeCache.INACTIVE][ThemeCache.NORMAL][colorIndex];
+    }
+
     /**
      * Sets CellLabels' font to the current one.
      */

--- a/mucommander-core/src/main/java/com/mucommander/ui/theme/ThemeCache.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/theme/ThemeCache.java
@@ -133,13 +133,11 @@ public class ThemeCache implements ThemeListener {
     }
     
     private static void fireColorChanged(ColorChangedEvent event) {
-        for(ThemeListener listener : listeners.keySet())
-            listener.colorChanged(event);
+        listeners.keySet().forEach(listener -> listener.colorChanged(event));
     }
     
     private static void fireFontChanged(FontChangedEvent event) {
-        for(ThemeListener listener : listeners.keySet())
-            listener.fontChanged(event);
+        listeners.keySet().forEach(listener -> listener.fontChanged(event));
     }
     
 


### PR DESCRIPTION
Set the text area that is used for editing with an empty border and change the background and foreground colors so it would better fit to the theme that is used within the table