### PR TITLE
Improve rendering of editable filename cell

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
@@ -1531,7 +1531,6 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
         public FilenameEditor(JTextField textField) {
             super(textField);
             this.filenameField = textField;
-            filenameField.setBorder(BorderFactory.createEmptyBorder());
             // Sets the font to the same one that's used for cell rendering (user-defined)
             filenameField.setFont(FileTableCellRenderer.getCellFont());
             filenameField.setFocusTraversalKeysEnabled(false);
@@ -1622,10 +1621,7 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
             AbstractFile file = tableModel.getFileAtRow(editingRow);
             AbstractCopyDialog.selectDestinationFilename(file, file.getName(), 0).feedToPathField(filenameField);
 
-            filenameField.setBackground(cellRenderer.getBakgroundOfSelectedFileInInactiveTable());
-            filenameField.setSelectionColor(cellRenderer.getBakgroundOfNormalFileInInactiveTable());
-            filenameField.setForeground(cellRenderer.getForegroundOfSelectedFileInInactiveTable(editingRow, file));
-            filenameField.setSelectedTextColor(cellRenderer.getForegroundOfNormalFileInInactiveTable(editingRow, file));
+            filenameField.setBorder(BorderFactory.createLineBorder(cellRenderer.getBakgroundOfSelectedFileInInactiveTable()));
 
             // Request focus on text field
             filenameField.requestFocus();

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
@@ -106,20 +106,6 @@ public class FileTableCellRenderer implements TableCellRenderer, ThemeListener {
         return ThemeCache.backgroundColors[ThemeCache.INACTIVE][ThemeCache.SELECTED];
     }
 
-    public Color getBakgroundOfNormalFileInInactiveTable() {
-        return ThemeCache.backgroundColors[ThemeCache.INACTIVE][ThemeCache.NORMAL];
-    }
-
-    public Color getForegroundOfSelectedFileInInactiveTable(int row, AbstractFile file) {
-        int colorIndex = getColorIndex(row, file, tableModel);
-        return ThemeCache.foregroundColors[ThemeCache.INACTIVE][ThemeCache.SELECTED][colorIndex];
-    }
-
-    public Color getForegroundOfNormalFileInInactiveTable(int row, AbstractFile file) {
-        int colorIndex = getColorIndex(row, file, tableModel);
-        return ThemeCache.foregroundColors[ThemeCache.INACTIVE][ThemeCache.NORMAL][colorIndex];
-    }
-
     /**
      * Sets CellLabels' font to the current one.
      */

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -40,6 +40,7 @@ Improvements:
 - Symbolic links are extracted properly from zip archives to the local file system.
 - Local symbolic links are packed properly into zip and tar archives.
 - Unpacking of 7z archives is now faster and more reliable using a newer native library.
+- The filename cell is rendered differently when renaming a file to reflect that the filename is editable when no text is selected.
 
 Localization:
 -


### PR DESCRIPTION
Previously, as part of the fix for #515, the text field became sort
of hidden by setting its colors to those of the selected row in the
file table. That confused users and made them believe that the cell
is not editable anymore when there was no selected text.

Now, the text field is set with its default colors and with a line
border rather than an empty border.