### PR TITLE
#402 Can't delete to trash on macOS Big Sur

### DIFF
--- a/mucommander-os-macos/build.gradle
+++ b/mucommander-os-macos/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(":mucommander-process")
     api project(":mucommander-translator")
 
-    comprise 'net.java.dev.jna:jna-platform:5.5.0'
+    comprise 'net.java.dev.jna:jna-platform:5.12.1'
     implementation 'com.googlecode.plist:dd-plist:1.23'
 
     // the java.desktop module that contains macOS-specific extensions


### PR DESCRIPTION
Fix for issue #402 
Changes:
* Bump `jna-platform` for macos module up to 5.12.1 (latest).