### PR TITLE
Improve toggling to/from terminal view

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/ActionManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/ActionManager.java
@@ -203,7 +203,6 @@ public class ActionManager {
     	registerAction(new ShowRootFoldersQLAction.Descriptor(), 			ShowRootFoldersQLAction::new);
     	registerAction(new ShowServerConnectionsAction.Descriptor(),        ShowServerConnectionsAction::new);
     	registerAction(new ShowTabsQLAction.Descriptor(),					ShowTabsQLAction::new);
-    	registerAction(new ShowTerminalAction.Descriptor(),                 ShowTerminalAction::new);
     	registerAction(new SortByDateAction.Descriptor(),             		SortByDateAction::new);
     	registerAction(new SortByExtensionAction.Descriptor(),              SortByExtensionAction::new);
     	registerAction(new SortByGroupAction.Descriptor(),            		SortByGroupAction::new);
@@ -232,6 +231,7 @@ public class ActionManager {
     	registerAction(new ToggleShowFoldersFirstAction.Descriptor(),       ToggleShowFoldersFirstAction::new);
     	registerAction(new ToggleSizeColumnAction.Descriptor(),             ToggleSizeColumnAction::new);
     	registerAction(new ToggleStatusBarAction.Descriptor(),              ToggleStatusBarAction::new);
+        registerAction(new ToggleTerminalAction.Descriptor(),               ToggleTerminalAction::new);
     	registerAction(new ToggleToolBarAction.Descriptor(),                ToggleToolBarAction::new);
     	registerAction(new ToggleTreeAction.Descriptor(),             	    ToggleTreeAction::new);
     	registerAction(new UnmarkAllAction.Descriptor(),            		UnmarkAllAction::new);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
@@ -21,10 +21,12 @@ import com.jediterm.terminal.ui.JediTermWidget;
 import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 import com.mucommander.core.desktop.DesktopManager;
+import com.mucommander.desktop.ActionType;
 import com.mucommander.text.Translator;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.ActionKeymap;
 import com.mucommander.ui.action.ActionProperties;
 import com.mucommander.ui.main.MainFrame;
 
@@ -40,14 +42,14 @@ import javax.swing.SwingUtilities;
  * This action shows built-in terminal (it mimics the behavior of Midnight Commander Ctrl-O command
  * that originates back from Norton Commander).
  */
-public class ShowTerminalAction extends ActiveTabAction {
+public class ToggleTerminalAction extends ActiveTabAction {
 
     private JediTermWidget terminal;
 
     private String cwd; // keep it as String or as MonitoredFile maybe?
     private boolean isTermShown;
 
-    public ShowTerminalAction(MainFrame mainFrame, Map<String, Object> properties) {
+    public ToggleTerminalAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setEnabled(DesktopManager.canOpenInFileManager());
@@ -90,9 +92,10 @@ public class ShowTerminalAction extends ActiveTabAction {
 
                 terminal.getTerminalPanel().addCustomKeyListener(new KeyAdapter() {
                     public void keyPressed(KeyEvent keyEvent) {
-                        // TODO get the real configured key seq
-                        if (keyEvent.getKeyCode() == KeyEvent.VK_O &&
-                                (keyEvent.getModifiersEx() & KeyEvent.CTRL_DOWN_MASK) != 0) {
+                        KeyStroke pressedKeyStroke = KeyStroke.getKeyStrokeForEvent(keyEvent);
+                        KeyStroke accelerator = ActionKeymap.getAccelerator(ActionType.ToggleTerminal.toString());
+                        KeyStroke alternateAccelerator = ActionKeymap.getAlternateAccelerator(ActionType.ToggleTerminal.toString());
+                        if (pressedKeyStroke.equals(accelerator) || pressedKeyStroke.equals(alternateAccelerator)) {
                             revertToTableView();
                             isTermShown = false;
                         }
@@ -116,7 +119,7 @@ public class ShowTerminalAction extends ActiveTabAction {
     }
 
     public static class Descriptor extends AbstractActionDescriptor {
-        public static final String ACTION_ID = "ShowTerminal";
+        public static final String ACTION_ID = "ToggleTerminal";
 
         public String getId() {
             return ACTION_ID;
@@ -126,17 +129,9 @@ public class ShowTerminalAction extends ActiveTabAction {
             return ActionCategory.NAVIGATION;
         }
 
-        public KeyStroke getDefaultAltKeyStroke() {
-            return null;
-        }
-
-        public KeyStroke getDefaultKeyStroke() {
-            return KeyStroke.getKeyStroke(KeyEvent.VK_O, KeyEvent.CTRL_DOWN_MASK);
-        }
-
         @Override
         public String getLabel() {
-            return Translator.get(ActionProperties.getActionLabelKey(ShowTerminalAction.Descriptor.ACTION_ID),
+            return Translator.get(ActionProperties.getActionLabelKey(ToggleTerminalAction.Descriptor.ACTION_ID),
                     DesktopManager.canOpenInFileManager() ? DesktopManager.getFileManagerName()
                             : Translator.get("file_manager"));
         }

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/ActionShortcuts.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/ActionShortcuts.java
@@ -251,6 +251,8 @@ public class ActionShortcuts {
             return KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0);
         case ToggleHiddenFiles:
             return KeyStroke.getKeyStroke(KeyEvent.VK_H, KeyEvent.SHIFT_DOWN_MASK | KeyEvent.ALT_DOWN_MASK);
+        case ToggleTerminal:
+            return KeyStroke.getKeyStroke(KeyEvent.VK_O, KeyEvent.CTRL_DOWN_MASK);
         case ToggleTree:
             return KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyEvent.CTRL_DOWN_MASK);
         case UnmarkAll:

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/ActionType.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/ActionType.java
@@ -178,6 +178,7 @@ public enum ActionType {
     ToggleShowFoldersFirst("ToggleShowFoldersFirst"),
     ToggleSizeColumn("ToggleSizeColumn"),
     ToggleStatusBar("ToggleStatusBar"),
+    ToggleTerminal("ToggleTerminal"),
     ToggleToolBar("ToggleToolBar"),
     ToggleTree("ToggleTree"),
     ToggleUseSinglePanel("ToggleSinglePanel"),

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/ActionShortcuts.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/ActionShortcuts.java
@@ -151,6 +151,8 @@ public class ActionShortcuts extends com.mucommander.desktop.ActionShortcuts {
             return KeyStroke.getKeyStroke(KeyEvent.VK_F5, KeyEvent.META_DOWN_MASK);
         case SwapFolders:
             return KeyStroke.getKeyStroke(KeyEvent.VK_U, KeyEvent.META_DOWN_MASK);
+        case ToggleTerminal:
+            return KeyStroke.getKeyStroke(KeyEvent.VK_O, KeyEvent.META_DOWN_MASK);
         case ToggleTree:
             return KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyEvent.META_DOWN_MASK);
         case UnmarkAll:


### PR DESCRIPTION
Rename ShowTerminal action to ToggleTerminal since it is also responsible to switch back from the terminal view, and respect the configured shortcut or alternative-shortcut for switching back from the terminal view to the file table