### PR TITLE
Change default shortcut of ToggleTerminal

### DIFF
--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/ActionShortcuts.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/ActionShortcuts.java
@@ -252,7 +252,7 @@ public class ActionShortcuts {
         case ToggleHiddenFiles:
             return KeyStroke.getKeyStroke(KeyEvent.VK_H, KeyEvent.SHIFT_DOWN_MASK | KeyEvent.ALT_DOWN_MASK);
         case ToggleTerminal:
-            return KeyStroke.getKeyStroke(KeyEvent.VK_O, KeyEvent.CTRL_DOWN_MASK);
+            return KeyStroke.getKeyStroke(KeyEvent.VK_F12, 0);
         case ToggleTree:
             return KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyEvent.CTRL_DOWN_MASK);
         case UnmarkAll:

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/ActionShortcuts.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/ActionShortcuts.java
@@ -151,8 +151,6 @@ public class ActionShortcuts extends com.mucommander.desktop.ActionShortcuts {
             return KeyStroke.getKeyStroke(KeyEvent.VK_F5, KeyEvent.META_DOWN_MASK);
         case SwapFolders:
             return KeyStroke.getKeyStroke(KeyEvent.VK_U, KeyEvent.META_DOWN_MASK);
-        case ToggleTerminal:
-            return KeyStroke.getKeyStroke(KeyEvent.VK_O, KeyEvent.META_DOWN_MASK);
         case ToggleTree:
             return KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyEvent.META_DOWN_MASK);
         case UnmarkAll:


### PR DESCRIPTION
The current shotcut (ctrl+O / meta+O) conflicts with that of 'Open in other panel' action and therefore is changed.