### PR TITLE
Fix/workaround for SplitPane not auto-resizing after closing Terminal

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
@@ -166,6 +166,15 @@ public class ToggleTerminalAction extends ActiveTabAction {
         //mainFrame.getToolBarPanel().setVisible(true);
         //mainFrame.getCommandBar().setVisible(true);
         mainFrame.getSplitPane().setVisible(true);
+        // This is a fix for main window resizing issue where after closing (removing)
+        // terminal, SplitPane (folder panels) didn't resize accordingly.
+        // Not sure if it is the proper fix, maybe instead of hiding SplitPane we should
+        // remove it before showing Terminal, and then re-adding it after closing?
+        // Or after SplitPanel#setVisible something else in addition should be called?
+        mainFrame.getMainPanel().remove(mainFrame.getSplitPane());
+        mainFrame.getMainPanel().add(mainFrame.getSplitPane(), BorderLayout.CENTER);
+        mainFrame.getSplitPane().revalidate();
+
         SwingUtilities.invokeLater(mainFrame.getActiveTable()::requestFocusInWindow);
     }
 }


### PR DESCRIPTION
Fix/workaround for https://github.com/mucommander/mucommander/pull/739#issuecomment-1250332115

Please see a comment in the code and let me know what you think.