### PR TITLE
Fix NPE when opening the customize command bar dialog

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/commandbar/CommandBarButton.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/commandbar/CommandBarButton.java
@@ -90,7 +90,7 @@ public class CommandBarButton extends NonFocusableButton implements Configuratio
 	public void setText(String text) {
 	    MuAction action = (MuAction) getAction();
 	    // Append the action's shortcut to the button's label
-	    if(action.getAcceleratorText() != null)
+	    if (action != null && action.getAcceleratorText() != null)
 	        text += " [" + action.getAcceleratorText() + ']';
 	    super.setText(text);
 	}


### PR DESCRIPTION
The buttons that are presented in this dialog are not set with their corresponding actions, so we need to add a null-check when setting their text.