### PR TITLE
Status bar improvements

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/protocol/local/LocalFile.java
@@ -156,8 +156,8 @@ public class LocalFile extends ProtocolFile {
     /**
      * List of known UNIX filesystems.
      */
-    public static final String[] KNOWN_UNIX_FS = { "adfs", "affs", "autofs", "cifs", "coda", "cramfs",
-            "debugfs", "efs", "ext2", "ext3", "fuseblk", "hfs", "hfsplus", "hpfs",
+    public static final String[] KNOWN_UNIX_FS = { "adfs", "affs", "autofs", "btrfs", "cifs", "coda", "cramfs",
+            "debugfs", "efs", "ext2", "ext3", "ext4", "fuseblk", "hfs", "hfsplus", "hpfs",
             "iso9660", "jfs", "minix", "msdos", "ncpfs", "nfs", "nfs4", "ntfs",
             "qnx4", "reiserfs", "smbfs", "udf", "ufs", "usbfs", "vfat", "xfs" };
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/StatusBar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/StatusBar.java
@@ -380,6 +380,7 @@ public class StatusBar extends JPanel {
             nbSelectedFiles = nbMarkedFiles;
 
         StringBuilder filesInfo = new StringBuilder();
+        String tooltip = null;
 		
         if (fileCount==0) {
             // Set status bar to a space character, not an empty string
@@ -391,12 +392,14 @@ public class StatusBar extends JPanel {
             if (nbMarkedFiles > 0)
                 filesInfo.append(String.format(" - %s", SizeFormat.format(markedTotalSize, selectedFileSizeFormat)));
 	
-            if (selectedFile != null)
+            if (selectedFile != null) {
                 filesInfo.append(String.format(" - %s", selectedFile.getName()));
+                tooltip = selectedFile.getName();
+            }
         }		
 
         // Update label
-        setStatusInfo(filesInfo.toString());
+        setStatusInfo(filesInfo.toString(), tooltip, null, false);
     }
 
 
@@ -409,7 +412,12 @@ public class StatusBar extends JPanel {
      * @param iconBeforeText if true, icon will be placed on the left side of the text, if not on the right side
      */
     public void setStatusInfo(String text, Icon icon, boolean iconBeforeText) {
+        setStatusInfo(text, null, icon, iconBeforeText);
+    }
+
+    private void setStatusInfo(String text, String tooltip, Icon icon, boolean iconBeforeText) {
         selectedFilesLabel.setText(text);
+        selectedFilesLabel.setToolTipText(tooltip);
 
         if(icon==null) {
             // What we don't want here is the label's height to change depending on whether it has an icon or not.

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/StatusBar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/StatusBar.java
@@ -17,8 +17,10 @@
 
 package com.mucommander.ui.main;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Graphics;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -30,7 +32,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 
 import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -171,33 +172,35 @@ public class StatusBar extends JPanel {
      */
     public StatusBar(MainFrame mainFrame) {
         // Create and add status bar
-        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        setLayout(new BorderLayout());
 
         this.mainFrame = mainFrame;
 		
         selectedFilesLabel = new JLabel("");
         dial               = new SpinningDial();
-        add(selectedFilesLabel);
+        add(selectedFilesLabel, BorderLayout.CENTER);
 
-        add(Box.createHorizontalGlue());
+        JPanel eastPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
 
         JobsPopupButton jobsButton = new JobsPopupButton();
         jobsButton.setPopupMenuLocation(SwingConstants.TOP);
 
-        add(jobsButton);
-        add(Box.createRigidArea(new Dimension(2, 0)));
+        eastPanel.add(jobsButton);
+        eastPanel.add(Box.createRigidArea(new Dimension(2, 0)));
 
         // Add a button for interacting with the trash, only if the current platform has a trash implementation
         if (DesktopManager.getTrash() != null) {
             TrashPopupButton trashButton = new TrashPopupButton(mainFrame);
             trashButton.setPopupMenuLocation(SwingConstants.TOP);
 
-            add(trashButton);
-            add(Box.createRigidArea(new Dimension(2, 0)));
+            eastPanel.add(trashButton);
+            eastPanel.add(Box.createRigidArea(new Dimension(2, 0)));
         }
 
         volumeSpaceLabel = new VolumeSpaceLabel();
-        add(volumeSpaceLabel);
+        eastPanel.add(volumeSpaceLabel);
+
+        add(eastPanel, BorderLayout.EAST);
 
         // Show/hide this status bar based on user preferences
         // Note: setVisible has to be called even with true for the auto-update thread to be initialized

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTableCellRenderer.java
@@ -225,7 +225,7 @@ public class FileTableCellRenderer implements TableCellRenderer, ThemeListener {
                     label.setText(leftText+"..."+rightText);
                 }
 
-                // Set the toop
+                // Set the tooltip
                 label.setToolTipText(text);
             }
             // Have to set it to null otherwise the defaultRender sets the tooltip text to the last one

--- a/mucommander-translator/src/main/java/com/mucommander/text/Translator.java
+++ b/mucommander-translator/src/main/java/com/mucommander/text/Translator.java
@@ -97,9 +97,9 @@ public class Translator {
      * @param paramValues array of parameters which will be used as values for variables.
      * @return the localized text String for the given key expressed in the current language
      */
-    public static String get(String key, String... paramValues) {
+    public static String get(String key, Object... paramValues) {
         if (dictionaryBundle.containsKey(key))
-            return MessageFormat.format(dictionaryBundle.getString(key), (Object[]) paramValues);
+            return MessageFormat.format(dictionaryBundle.getString(key), paramValues);
 
         if (languagesBundle.containsKey(key))
             return languagesBundle.getString(key);

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -36,6 +36,7 @@ New features:
 
 Improvements:
 - 'Show in enclosing folder' action no longer opens a new tab but changes the current tab instead.
+- The free space indicator within the status bar is updated quicker for 'ext4' and 'btrfs' UNIX file systems.
 
 Localization:
 -

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -37,6 +37,7 @@ New features:
 Improvements:
 - 'Show in enclosing folder' action no longer opens a new tab but changes the current tab instead.
 - The free space indicator within the status bar is updated quicker for 'ext4' and 'btrfs' UNIX file systems.
+- The trash icon and free space indicator remain visible in the status bar when a file with a long name is selected.
 
 Localization:
 -


### PR DESCRIPTION
- show the free space of 'ext4' and 'btrfs' UNIX file systems within the status bar more quickly
- code cleanup
- make sure the rightmost components of the status bar (trash icon and free space indicator) are visible also when a file with a long name is selected. the selected filename would be truncated in this case, however, the complete filename is displayed as a tooltip