### PR TITLE
Terminal fixes: hide initial cd directory command, hide terminal when…

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
@@ -148,8 +148,7 @@ public class ToggleTerminalAction extends ActiveTabAction {
                     keyEvent.setKeyCode(-1);
                     revertToTableView();
                     setVisible(false);
-                }
-                if (!terminal.getTtyConnector().isConnected()) {
+                } else if (!terminal.getTtyConnector().isConnected()) {
                     // just close terminal if it is not active/connected (for example when sb typed 'exit')
                     revertToTableView();
                     setVisible(false);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
@@ -149,6 +149,11 @@ public class ToggleTerminalAction extends ActiveTabAction {
                     revertToTableView();
                     setVisible(false);
                 }
+                if (!terminal.getTtyConnector().isConnected()) {
+                    // just close terminal if it is not active/connected (for example when sb typed 'exit')
+                    revertToTableView();
+                    setVisible(false);
+                }
             }
         };
     }

--- a/mucommander-core/src/main/java/com/mucommander/ui/terminal/TerminalWindow.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/terminal/TerminalWindow.java
@@ -109,6 +109,7 @@ public final class TerminalWindow {
                 envs = new HashMap<>(System.getenv());
                 envs.putAll(getDefaultLocaleSetting());
                 envs.put("TERM", "xterm-256color");
+                envs.put("HISTCONTROL", "ignoreboth");
                 if (OsFamily.MAC_OS.isCurrent()) {
                     envs.put("BASH_SILENCE_DEPRECATION_WARNING", "1");
                 }


### PR DESCRIPTION
Terminal fixes: 
- hide initial cd directory command
- hide terminal when it is closed via `exit`/Ctrl-D command line and another key is pressed