### PR TITLE
Viewer/Editor make utf-8 default instead of ISO-8859-1

### DIFF
--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
@@ -140,9 +140,11 @@ public class TextViewer implements FileViewer, EncodingListener, ActionListener 
                 }
             }
 
-            /* TODO this will return ISO-8859-1 for a normal text... which could have been
-               OKeyish sometime ago, but now UTF-8 should be set (emoticons etc) */
             String encoding = EncodingDetector.detectEncoding(in);
+            if ("ISO-8859-1".equalsIgnoreCase(encoding)) {
+                // Override encoding to ensure UTF-8 chars that user may enter are saved correctly.
+                encoding = "UTF-8";
+            }
 
             if (in instanceof RandomAccessInputStream) {
                 // Seek to the beginning of the file and reuse the stream


### PR DESCRIPTION
Viewer/Editor make utf-8 default instead of ISO-8859-1.

Use case:
- open in Editor any java file in muC
- in Editor menu -> encoding you can see `ISO-8859-1`
- start typing some UTF-8 national characters or paste UTF-8 emoticon
- save
- re-open - `ISO-8859-1` is still chosen and recently modified text is broken

What I propose here is to use UTF-8 a default when `ISO-8859-1` detected. Other quick idea is to use system default charset instead of hard-coded UTF-8.
