### PR TITLE
Dock/TaskBar icon status with jobs progress updates

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
@@ -626,7 +626,7 @@ public class DesktopManager {
     }
 
     /**
-     * Requests users attention, for example on macOS by bouncing dock icon.
+     * Requests user attention, for example on macOS by bouncing dock icon.
      */
     public static void requestUserAttention() {
         desktop.requestUserAttention();

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
@@ -607,4 +607,28 @@ public class DesktopManager {
         if (actionShortcuts != null)
             DesktopManager.actionShortcuts = actionShortcuts;
     }
+
+    /**
+     * Sets badge number on Dock/TaskBar app icon. To remove the badge provide the negative value.
+     * @param number a number to be displayed over app icon
+     */
+    public static void setIconBadgeNumber(int number) {
+        desktop.setIconBadgeNumber(number);
+    }
+
+    /**
+     * Sets progress bar on Dock/Taskbar app icon. To remove the progress bar, provider number
+     * outside of 1-100 range.
+     * @param progress the progress to display
+     */
+    public static void setIconProgress(int progress) {
+        desktop.setIconProgress(progress);
+    }
+
+    /**
+     * Requests users attention, for example on macOS by bouncing dock icon.
+     */
+    public static void requestUserAttention() {
+        desktop.requestUserAttention();
+    }
 }

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
@@ -618,7 +618,7 @@ public class DesktopManager {
 
     /**
      * Sets progress bar on Dock/Taskbar app icon. To remove the progress bar, provider number
-     * outside of 1-100 range.
+     * outside 1-100 range.
      * @param progress the progress to display
      */
     public static void setIconProgress(int progress) {

--- a/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/desktop/DesktopManager.java
@@ -609,11 +609,11 @@ public class DesktopManager {
     }
 
     /**
-     * Sets badge number on Dock/TaskBar app icon. To remove the badge provide the negative value.
-     * @param number a number to be displayed over app icon
+     * Sets badge number on Dock/TaskBar app icon. To remove the badge provide a negative value or zero.
+     * @param numberOfJobs a number to be displayed over app icon
      */
-    public static void setIconBadgeNumber(int number) {
-        desktop.setIconBadgeNumber(number);
+    public static void setIconBadgeNumber(int numberOfJobs) {
+        desktop.setIconBadgeNumber(numberOfJobs);
     }
 
     /**

--- a/mucommander-core/src/main/java/com/mucommander/job/FileJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/FileJob.java
@@ -101,6 +101,7 @@ public interface FileJob extends Runnable {
 
     /**
      * Returns this job's percentage of completion, as a float comprised between 0 and 1.
+     * TODO make it more accurate: https://github.com/mucommander/mucommander/issues/565
      *
      * @return this job's percentage of completion, as a float comprised between 0 and 1
      */

--- a/mucommander-core/src/main/java/com/mucommander/job/FileJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/FileJob.java
@@ -28,7 +28,7 @@ import com.mucommander.ui.dialog.file.ProgressDialog;
  */
 public interface FileJob extends Runnable {
     /**
-     * Indicates whether or not this job is executed in a non-blocking mode.
+     * Indicates whether this job is executed in a non-blocking mode.
      *
      * @return true if the job is executed in the background, false otherwise.
      */
@@ -101,7 +101,6 @@ public interface FileJob extends Runnable {
 
     /**
      * Returns this job's percentage of completion, as a float comprised between 0 and 1.
-     * TODO make it more accurate: https://github.com/mucommander/mucommander/issues/565
      *
      * @return this job's percentage of completion, as a float comprised between 0 and 1
      */

--- a/mucommander-core/src/main/java/com/mucommander/job/JobProgress.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/JobProgress.java
@@ -145,6 +145,7 @@ public class JobProgress {
 		// Total job percent is based on the *number* of files remaining, not
 		// their actual size.
 		// So this is very approximate.
+		// TODO make it more accurate: https://github.com/mucommander/mucommander/issues/565
 		float totalPercentFloat = job.getTotalPercentDone();
 		totalPercentInt = (int) (100 * totalPercentFloat);
 

--- a/mucommander-core/src/main/java/com/mucommander/job/JobProgress.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/JobProgress.java
@@ -145,7 +145,6 @@ public class JobProgress {
 		// Total job percent is based on the *number* of files remaining, not
 		// their actual size.
 		// So this is very approximate.
-		// TODO make it more accurate: https://github.com/mucommander/mucommander/issues/565
 		float totalPercentFloat = job.getTotalPercentDone();
 		totalPercentInt = (int) (100 * totalPercentFloat);
 

--- a/mucommander-core/src/main/java/com/mucommander/job/JobsManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/JobsManager.java
@@ -19,6 +19,7 @@ package com.mucommander.job;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -211,18 +212,15 @@ public class JobsManager implements FileJobListener {
 	            .filter(FileJob::isRunInBackground)
 	            .collect(Collectors.toList());
 	}
-	
+
 	/**
-	 * Returns a progress of a job with specified index.
-	 * @param rowIndex an index of a job
-	 * @return a progress information or null if job doesn't exists
+	 * Returns jobs that are running either in the foreground or background.
+	 * @return jobs that are running either in the foreground or background.
 	 */
-	public JobProgress getJobProgres(int rowIndex) {
-		if (rowIndex < jobs.size()) {
-			FileJob job = jobs.get(rowIndex);
-			return job.getJobProgress();
-		}
-		return null;
+	public List<FileJob> getAllJobs() {
+		return jobs.stream()
+				.filter(job -> job.getState() != FileJobState.FINISHED)
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -79,7 +79,7 @@ public class MainFrame extends JFrame implements LocationListener {
 
     private FolderPanel leftFolderPanel;
     private FolderPanel rightFolderPanel;
-	
+
     private FileTable leftTable;
     private FileTable rightTable;
     
@@ -97,10 +97,10 @@ public class MainFrame extends JFrame implements LocationListener {
 
     /** Status bar instance */
     private StatusBar statusBar;
-	
+
     /** Command bar instance */
     private CommandBar commandBar;
-	
+
     /** Is no events mode enabled ? */
     private boolean noEventsMode;
 
@@ -227,22 +227,24 @@ public class MainFrame extends JFrame implements LocationListener {
         // Note: the vertical/horizontal terminology used in muCommander is just the opposite of the one used
         // in JSplitPane which is anti-natural / confusing.
         splitPane = new ProportionalSplitPane(this,
-                MuSnapshot.getSnapshot().getVariable(MuSnapshot.getSplitOrientation(0), MuSnapshot.DEFAULT_SPLIT_ORIENTATION).equals(MuSnapshot.VERTICAL_SPLIT_ORIENTATION) ?
-                                              	JSplitPane.HORIZONTAL_SPLIT:JSplitPane.VERTICAL_SPLIT,
-                                              false,
-                                              MainFrame.this.leftFolderPanel,
-                                              MainFrame.this.rightFolderPanel) {
-        	// We don't want any extra space around split pane
-        	@Override
-        	public Insets getInsets() {
-        		return new Insets(0, 0, 0, 0);
-        	}
+                MuSnapshot.getSnapshot().getVariable(
+                        MuSnapshot.getSplitOrientation(0),
+                        MuSnapshot.DEFAULT_SPLIT_ORIENTATION).equals(MuSnapshot.VERTICAL_SPLIT_ORIENTATION) ?
+                        JSplitPane.HORIZONTAL_SPLIT:JSplitPane.VERTICAL_SPLIT,
+                        false,
+                        MainFrame.this.leftFolderPanel,
+                        MainFrame.this.rightFolderPanel) {
+            // We don't want any extra space around split pane
+            @Override
+            public Insets getInsets() {
+                return new Insets(0, 0, 0, 0);
+            }
         };
 
         // Remove any default border the split pane has
         splitPane.setBorder(null);
 
-        // Adds buttons that allow to collapse and expand the split pane in both directions
+        // Add buttons that allow to collapse and expand the split pane in both directions
         splitPane.setOneTouchExpandable(true);
 
         // Disable all the JSplitPane accessibility shortcuts that are registered by default, as some of them
@@ -259,7 +261,7 @@ public class MainFrame extends JFrame implements LocationListener {
         // Add status bar
         this.statusBar = new StatusBar(this);
         southPanel.add(statusBar);
-		
+
         // Show command bar only if it hasn't been disabled in the preferences
         this.commandBar = new CommandBar(this);
         // Note: CommandBar.setVisible() has to be called no matter if CommandBar is visible or not, in order for it to be properly initialized
@@ -286,35 +288,31 @@ public class MainFrame extends JFrame implements LocationListener {
     }
 
     public MainFrame(ConfFileTableTab leftTab, FileTableConfiguration leftTableConf,
-    	             ConfFileTableTab rightTab, FileTableConfiguration rightTableConf) {
-    	this(new ConfFileTableTab[] {leftTab}, 0, leftTableConf, new ConfFileTableTab[] {rightTab}, 0, rightTableConf);
+                     ConfFileTableTab rightTab, FileTableConfiguration rightTableConf) {
+        this(new ConfFileTableTab[] {leftTab}, 0, leftTableConf, new ConfFileTableTab[] {rightTab}, 0, rightTableConf);
     }
 
     /**
      * Creates a new main frame set to the given initial folders.
-     *
-     * @param leftInitialFolders the initial folders to display in the left panel's tabs
-     * @param rightInitialFolders the initial folders to display in the right panel's tabs
      */
     public MainFrame(ConfFileTableTab[] leftTabs, int indexOfLeftSelectedTab, FileTableConfiguration leftTableConf,
-    		         ConfFileTableTab[] rightTabs, int indexOfRightSelectedTab, FileTableConfiguration rightTableConf) {
-    		/*AbstractFile[] leftInitialFolders, AbstractFile[] rightInitialFolders,
-    				 int indexOfLeftSelectedTab, int indexOfRightSelectedTab,
-    			     FileURL[] leftLocationHistory, FileURL[] rightLocationHistory) { */
+                     ConfFileTableTab[] rightTabs, int indexOfRightSelectedTab, FileTableConfiguration rightTableConf) {
+
         init(new FolderPanel(this, leftTabs, indexOfLeftSelectedTab, leftTableConf), 
-        	 new FolderPanel(this, rightTabs, indexOfRightSelectedTab, rightTableConf));
+             new FolderPanel(this, rightTabs, indexOfRightSelectedTab, rightTableConf));
 
         for (boolean isLeft = true; ; isLeft=false) {
-        	FileTable fileTable = isLeft ? leftTable : rightTable;
-        	fileTable.sortBy(Column.valueOf(MuSnapshot.getSnapshot().getVariable(MuSnapshot.getFileTableSortByVariable(0, isLeft), MuSnapshot.DEFAULT_SORT_BY).toUpperCase()),
+            FileTable fileTable = isLeft ? leftTable : rightTable;
+            fileTable.sortBy(Column.valueOf(MuSnapshot.getSnapshot().getVariable(MuSnapshot.getFileTableSortByVariable(0, isLeft), MuSnapshot.DEFAULT_SORT_BY).toUpperCase()),
                     !MuSnapshot.getSnapshot().getVariable(MuSnapshot.getFileTableSortOrderVariable(0, isLeft), MuSnapshot.DEFAULT_SORT_ORDER).equals(MuSnapshot.SORT_ORDER_DESCENDING));
-        	
-        	FolderPanel folderPanel = isLeft ? leftFolderPanel : rightFolderPanel;
-        	folderPanel.setTreeWidth(MuSnapshot.getSnapshot().getVariable(MuSnapshot.getTreeWidthVariable(0, isLeft), 150));
-        	folderPanel.setTreeVisible(MuSnapshot.getSnapshot().getVariable(MuSnapshot.getTreeVisiblityVariable(0, isLeft), false));
-        	
-        	if (!isLeft)
-        		break;
+
+            FolderPanel folderPanel = isLeft ? leftFolderPanel : rightFolderPanel;
+            folderPanel.setTreeWidth(MuSnapshot.getSnapshot().getVariable(MuSnapshot.getTreeWidthVariable(0, isLeft), 150));
+            folderPanel.setTreeVisible(MuSnapshot.getSnapshot().getVariable(MuSnapshot.getTreeVisiblityVariable(0, isLeft), false));
+
+            if (!isLeft) {
+                break;
+            }
         }
     }
 
@@ -322,15 +320,15 @@ public class MainFrame extends JFrame implements LocationListener {
      * Copy constructor
      */
     public MainFrame(MainFrame mainFrame) {
-    	FolderPanel leftFolderPanel = mainFrame.getLeftPanel(); 
-    	FolderPanel rightFolderPanel = mainFrame.getRightPanel();
-    	FileTable leftFileTable = leftFolderPanel.getFileTable();
-    	FileTable rightFileTable = rightFolderPanel.getFileTable();
+        FolderPanel leftFolderPanel = mainFrame.getLeftPanel();
+        FolderPanel rightFolderPanel = mainFrame.getRightPanel();
+        FileTable leftFileTable = leftFolderPanel.getFileTable();
+        FileTable rightFileTable = rightFolderPanel.getFileTable();
 
-    	init(new FolderPanel(this, new ConfFileTableTab[] {new ConfFileTableTab(leftFolderPanel.getCurrentFolder().getURL())}, 0, leftFileTable.getConfiguration()),
+        init(new FolderPanel(this, new ConfFileTableTab[] {new ConfFileTableTab(leftFolderPanel.getCurrentFolder().getURL())}, 0, leftFileTable.getConfiguration()),
              new FolderPanel(this, new ConfFileTableTab[] {new ConfFileTableTab(rightFolderPanel.getCurrentFolder().getURL())}, 0, rightFileTable.getConfiguration()));
 
-    	// TODO: Sorting should be part of the FileTable configuration
+        // TODO: Sorting should be part of the FileTable configuration
         this.leftTable.sortBy(leftFileTable.getSortInfo());
         this.rightTable.sortBy(rightFileTable.getSortInfo());
     }
@@ -371,7 +369,7 @@ public class MainFrame extends JFrame implements LocationListener {
     public boolean getNoEventsMode() {
         return this.noEventsMode;
     }
-	
+
     /**
      * Enables/disables the 'no events mode' which prevents mouse and keyboard events from being received
      * by the application (MainFrame, its subcomponents and the menu bar).
@@ -380,12 +378,12 @@ public class MainFrame extends JFrame implements LocationListener {
      */
     public void setNoEventsMode(boolean enabled) {
         // Piece of code used in 0.8 beta1 and removed after because it's way too slow, kept here for the record 
-        //		// Glass pane has empty mouse and key adapters (created in the constructor)
-        //		// which will catch all mouse and keyboard events 
-        //		getGlassPane().setVisible(enabled);
-        //		getJMenuBar().setEnabled(!enabled);
-        //		// Remove focus from whatever component in FolderPanel which had focus
-        //		getGlassPane().requestFocus();
+        //  // Glass pane has empty mouse and key adapters (created in the constructor)
+        //  // which will catch all mouse and keyboard events
+        //  getGlassPane().setVisible(enabled);
+        //  getJMenuBar().setEnabled(!enabled);
+        //  // Remove focus from whatever component in FolderPanel which had focus
+        //  getGlassPane().requestFocus();
 
         this.noEventsMode = enabled;
     }
@@ -471,7 +469,7 @@ public class MainFrame extends JFrame implements LocationListener {
      */
     void setActiveTable(FileTable table) {
         boolean activeTableChanged = activeTable != table;
-        if(activeTableChanged) {
+        if (activeTableChanged) {
             this.activeTable = table;
 
             // Update window title to reflect new active table
@@ -482,7 +480,7 @@ public class MainFrame extends JFrame implements LocationListener {
         }
     }
 
-	
+
     /**
      * Returns the inactive table, i.e. the complement of {@link #getActiveTable()}.
      *
@@ -647,15 +645,18 @@ public class MainFrame extends JFrame implements LocationListener {
      * @return <code>true</code> if this MainFrame is active, or is an ancestor of a Window that is currently active
      */
     public boolean isAncestorOfActiveWindow() {
-        if(isActive())
+        if (isActive()) {
             return true;
+        }
 
         Window ownedWindows[] = getOwnedWindows();
 
         int nbWindows = ownedWindows.length;
-        for(int i=0; i<nbWindows; i++)
-            if(ownedWindows[i].isActive())
+        for (int i = 0; i < nbWindows; i++) {
+            if (ownedWindows[i].isActive()) {
                 return true;
+            }
+        }
 
         return false;
     }
@@ -668,28 +669,30 @@ public class MainFrame extends JFrame implements LocationListener {
         // Update window title
         String title = activeTable.getFolderPanel().getCurrentFolder().getAbsolutePath();
 
-	// Add the application name to window title on all OSs except MAC
-        if (!OsFamily.MAC_OS.isCurrent())
-        	title += " - muCommander";
+        // Add the application name to window title on all OSs except MAC
+        if (!OsFamily.MAC_OS.isCurrent()) {
+            title += " - muCommander";
+        }
 
         java.util.List<MainFrame> mainFrames = WindowManager.getMainFrames();
-        if(mainFrames.size()>1)
-            title += " ["+(mainFrames.indexOf(this)+1)+"]";
+        if (mainFrames.size() > 1) {
+            title += " [" + (mainFrames.indexOf(this) + 1) + "]";
+        }
         setTitle(title);
 
-        if(OsFamily.MAC_OS.isCurrent()) {
+        if (OsFamily.MAC_OS.isCurrent()) {
             // Displays the document icon in the window title bar, works only for local files
             AbstractFile currentFolder = activeTable.getFolderPanel().getCurrentFolder();
             Object javaIoFile;
-            if(currentFolder.getURL().getScheme().equals(LocalFile.SCHEMA)) {
+            if (currentFolder.getURL().getScheme().equals(LocalFile.SCHEMA)) {
                 // If the current folder is an archive entry, display the archive file, this is the closest we can get
                 // with a java.io.File
-                if(currentFolder.hasAncestor(AbstractArchiveEntryFile.class))
+                if (currentFolder.hasAncestor(AbstractArchiveEntryFile.class)) {
                     javaIoFile = currentFolder.getParentArchive().getUnderlyingFileObject();
-                else
+                } else {
                     javaIoFile = currentFolder.getUnderlyingFileObject();
-            }
-            else {
+                }
+            } else {
                 // If the current folder is not a local file, use the special /Network directory which is sort of
                 // 'Network Neighborhood'.
                 javaIoFile = new java.io.File("/Network");
@@ -700,8 +703,6 @@ public class MainFrame extends JFrame implements LocationListener {
             getRootPane().putClientProperty("Window.documentFile", javaIoFile);
         }
     }
-    
-
 
     /**
      * Returns <code>true</code> if only one panel is show
@@ -723,7 +724,6 @@ public class MainFrame extends JFrame implements LocationListener {
         return singlePanel;
     }
 
-
     ///////////////////////
     // Overridden methods //
     ///////////////////////
@@ -738,8 +738,6 @@ public class MainFrame extends JFrame implements LocationListener {
         super.toFront();
     }
 
-
-
     ///////////////////
     // Inner classes //
     ///////////////////
@@ -753,16 +751,21 @@ public class MainFrame extends JFrame implements LocationListener {
 
         @Override
         public Component getComponentAfter(Container container, Component component) {
-        	if (component==leftFolderPanel.getFoldersTreePanel().getTree())
-		        return leftTable;
-		    if (component==rightFolderPanel.getFoldersTreePanel().getTree())
-		        return rightTable;
-		    if(component== leftFolderPanel.getLocationTextField())
+            if (component == leftFolderPanel.getFoldersTreePanel().getTree()) {
                 return leftTable;
-            if(component== leftTable)
+            }
+            if (component == rightFolderPanel.getFoldersTreePanel().getTree()) {
                 return rightTable;
-            if(component== rightFolderPanel.getLocationTextField())
+            }
+            if (component == leftFolderPanel.getLocationTextField()) {
+                return leftTable;
+            }
+            if (component == leftTable) {
                 return rightTable;
+            }
+            if (component== rightFolderPanel.getLocationTextField()) {
+                return rightTable;
+            }
             // otherwise (component==table2)
             return leftTable;
         }
@@ -771,7 +774,7 @@ public class MainFrame extends JFrame implements LocationListener {
         public Component getComponentBefore(Container container, Component component) {
             // Completely symmetrical with getComponentAfter
             return getComponentAfter(container, component);
-       }
+        }
 
         @Override
         public Component getFirstComponent(Container container) {
@@ -799,7 +802,7 @@ public class MainFrame extends JFrame implements LocationListener {
     }
 
     /**
-     * Update the header renderer of both tables according to {@link FileTable#createHeaderRenderer}
+     * Update the header renderer of both tables according to {@link FileTable#createHeaderRenderer()}}
      */
     public void updateFileTablesHeaderRenderer() {
         leftTable.updateHeaderRenderer();
@@ -807,8 +810,8 @@ public class MainFrame extends JFrame implements LocationListener {
     }
     
     /**********************************
-	 * LocationListener Implementation
-	 **********************************/
+     * LocationListener Implementation
+     **********************************/
 
     public void locationChanged(LocationEvent e) {
         // Update window title to reflect the new current folder

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -47,9 +47,6 @@ import com.mucommander.conf.MuPreference;
 import com.mucommander.conf.MuPreferences;
 import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.desktop.ActionType;
-import com.mucommander.job.FileJob;
-import com.mucommander.job.JobListener;
-import com.mucommander.job.JobsManager;
 import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.ui.action.ActionKeymap;
 import com.mucommander.ui.action.ActionManager;
@@ -67,6 +64,7 @@ import com.mucommander.ui.main.table.FileTableConfiguration;
 import com.mucommander.ui.main.table.SortInfo;
 import com.mucommander.ui.main.tabs.ConfFileTableTab;
 import com.mucommander.ui.main.toolbar.ToolBar;
+import com.mucommander.ui.notifier.NotifierProvider;
 
 /**
  * This is the main frame, which contains all other UI components visible on a mucommander window.
@@ -136,47 +134,13 @@ public class MainFrame extends JFrame implements LocationListener {
 
             setIconImages(icons);
         }
-
-        JobsManager.getInstance().addJobListener(new JobListener() {
-            long lastUpdate;
-
-            // TODO abusing #jobProgress & #jobRemoved to get events to trigger desktop/taskbar icon updates
-            @Override
-            public void jobProgress(FileJob source, boolean fullUpdate) {
-                updateAppIcon();
-            }
-
-            @Override
-            public void jobRemoved(FileJob source) {
-                updateAppIcon();
-            }
-
-            private void updateAppIcon() {
-                List<FileJob> jobs = JobsManager.getInstance().getAllJobs();
-                if (!jobs.isEmpty()) {
-                    // Update icon every 1s
-                    if (lastUpdate + 1000L < System.currentTimeMillis()) {
-                        lastUpdate = System.currentTimeMillis();
-                        long sum = 0;
-                        int jobsCount = 0;
-                        for (FileJob job : jobs) {
-                            sum += job.getJobProgress().getTotalPercentInt();
-                            jobsCount++;
-                        }
-                        DesktopManager.setIconBadgeNumber(jobsCount);
-                        DesktopManager.setIconProgress((int) sum / jobsCount);
-                    }
-                } else {
-                    DesktopManager.setIconBadgeNumber(-1); // turn off progress bar on icon
-                    DesktopManager.setIconProgress(-1); // turn off badge on icon
-                }
-            }
-        });
     }
 
     private void init(FolderPanel leftFolderPanel, FolderPanel rightFolderPanel) {
         // Set the window icon
         setWindowIcon();
+        // Register jobs listeners for UI notification purposes
+        NotifierProvider.registerJobsListeners();
 
         DesktopManager.customizeMainFrame(this);
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -153,7 +153,7 @@ public class MainFrame extends JFrame implements LocationListener {
 
             private void updateAppIcon() {
                 List<FileJob> jobs = JobsManager.getInstance().getAllJobs();
-                if (jobs.size() > 0) {
+                if (!jobs.isEmpty()) {
                     // Update icon every 1s
                     if (lastUpdate + 1000L < System.currentTimeMillis()) {
                         lastUpdate = System.currentTimeMillis();
@@ -163,7 +163,7 @@ public class MainFrame extends JFrame implements LocationListener {
                             sum += job.getJobProgress().getTotalPercentInt();
                             jobsCount++;
                         }
-                        DesktopManager.setIconBadgeNumber(jobs.size());
+                        DesktopManager.setIconBadgeNumber(jobsCount);
                         DesktopManager.setIconProgress((int) sum / jobsCount);
                     }
                 } else {

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -154,12 +154,13 @@ public class MainFrame extends JFrame implements LocationListener {
             private void updateAppIcon() {
                 List<FileJob> jobs = JobsManager.getInstance().getAllJobs();
                 if (jobs.size() > 0) {
+                    // Update icon every 1s
                     if (lastUpdate + 1000L < System.currentTimeMillis()) {
                         lastUpdate = System.currentTimeMillis();
                         long sum = 0;
                         int jobsCount = 0;
                         for (FileJob job : jobs) {
-                            sum += job.getJobProgress().getFilePercentInt();
+                            sum += job.getJobProgress().getTotalPercentInt();
                             jobsCount++;
                         }
                         DesktopManager.setIconBadgeNumber(jobs.size());
@@ -288,7 +289,7 @@ public class MainFrame extends JFrame implements LocationListener {
     	             ConfFileTableTab rightTab, FileTableConfiguration rightTableConf) {
     	this(new ConfFileTableTab[] {leftTab}, 0, leftTableConf, new ConfFileTableTab[] {rightTab}, 0, rightTableConf);
     }
-    
+
     /**
      * Creates a new main frame set to the given initial folders.
      *

--- a/mucommander-core/src/main/java/com/mucommander/ui/notifier/NotifierProvider.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/notifier/NotifierProvider.java
@@ -36,8 +36,9 @@ public class NotifierProvider {
 
     static {
         // Finds and creates a suitable AbstractNotifier instance for the platform, if there is one
-        if (SystemTray.isSupported())
+        if (SystemTray.isSupported()) {
             defaultNotifier = new SystemTrayNotifier();
+        }
     }
 
     /**
@@ -47,7 +48,7 @@ public class NotifierProvider {
      * @return true if an AbstractNotifier instance is available
      */
     public static boolean isAvailable() {
-        return getNotifier()!=null;
+        return getNotifier() != null;
     }
 
     /**
@@ -60,8 +61,9 @@ public class NotifierProvider {
      */
     public static AbstractNotifier getNotifier() {
         AbstractNotifier notifier = DesktopManager.getNotifier();
-        if (notifier != null)
+        if (notifier != null) {
             return notifier;
+        }
         return defaultNotifier;
     }
 
@@ -83,8 +85,8 @@ public class NotifierProvider {
      * <p>
      * Note that this method is executed in a separate thread after all pending Swing events have been processed,
      * to ensure in the event of a window being made inactive that the notification will not be triggered. This method
-     * immediately return s(i.e. does not wait for pending events) and thus is not be able to return if the notification
-     * was displayed or not, unlike {@link #displayNotification(NotificationType, String, String)}.
+     * immediately returns (i.e. does not wait for pending events) and thus is not be able to return if the notification
+     * was displayed or not, unlike {@link SystemTrayNotifier#displayNotification(NotificationType, String, String)}.
      * </p>
      *
      * @param notificationType one of the available notification types, see {@link NotificationType} for possible values
@@ -93,14 +95,17 @@ public class NotifierProvider {
      */
     public static void displayBackgroundNotification(final NotificationType notificationType, final String title, final String description) {
         SwingUtilities.invokeLater(() -> {
-            if(WindowManager.getCurrentMainFrame().isAncestorOfActiveWindow()) {
+            if (WindowManager.getCurrentMainFrame().isAncestorOfActiveWindow()) {
                 LOGGER.debug("Ignoring notification, application is in foreground");
                 return;
             }
 
-            DesktopManager.requestUserAttention();  // bounce app icon if supported by OS
-            if(!getNotifier().displayNotification(notificationType, title, description))
+            // bounce app icon if supported by OS
+            DesktopManager.requestUserAttention();
+
+            if (!getNotifier().displayNotification(notificationType, title, description)) {
                 LOGGER.debug("Notification failed to be displayed");
+            }
         });
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/notifier/NotifierProvider.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/notifier/NotifierProvider.java
@@ -98,6 +98,7 @@ public class NotifierProvider {
                 return;
             }
 
+            DesktopManager.requestUserAttention();  // bounce app icon if supported by OS
             if(!getNotifier().displayNotification(notificationType, title, description))
                 LOGGER.debug("Notification failed to be displayed");
         });

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
@@ -178,17 +178,12 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
         boolean opSupportedByAwt = false;
         if (Taskbar.isTaskbarSupported() &&
                 Taskbar.getTaskbar().isSupported(Taskbar.Feature.PROGRESS_VALUE)) {
-            if (progress >= 0 && progress <= 100) {
-                Taskbar.getTaskbar().setProgressValue(progress);
-            } else {
-                Taskbar.getTaskbar().setProgressValue(-1);
-            }
 
             // Apparently there's a problem with AWT with above code on macOS (https://bugs.openjdk.org/browse/JDK-8300037), so:
             // work around starts:
             EventQueue.invokeLater(() -> {
                 Taskbar.getTaskbar().setIconImage(Taskbar.getTaskbar().getIconImage());
-                Taskbar.getTaskbar().setProgressValue(progress);
+                Taskbar.getTaskbar().setProgressValue(progress >= 0 && progress <= 100 ? progress : -1);
             });
             // work around ends
             opSupportedByAwt = true;

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
@@ -17,6 +17,7 @@
 
 package com.mucommander.desktop;
 
+import java.awt.Taskbar;
 import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 
@@ -154,5 +155,47 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
      */
     public ActionShortcuts getActionShortcuts() {
         return new ActionShortcuts();
+    }
+
+    @Override
+    public boolean setIconBadgeNumber(int number) {
+        boolean opSuccessful = false;
+        if (Taskbar.isTaskbarSupported() &&
+                Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_BADGE_TEXT)) {
+            if (number >= 0) {
+                Taskbar.getTaskbar().setIconBadge(Integer.toString(number));
+            } else {
+                Taskbar.getTaskbar().setIconBadge(null);
+            }
+            opSuccessful = true;
+        }
+        return opSuccessful;
+    }
+
+    @Override
+    public boolean setIconProgress(int progress) {
+        boolean opSuccessful = false;
+        if (Taskbar.isTaskbarSupported() &&
+                Taskbar.getTaskbar().isSupported(Taskbar.Feature.PROGRESS_VALUE)) {
+            if (progress >= 0 && progress <= 100) {
+                Taskbar.getTaskbar().setProgressValue(progress);
+            } else {
+                Taskbar.getTaskbar().setProgressValue(-1);
+            }
+            opSuccessful = true;
+        }
+        return opSuccessful;
+    }
+
+    @Override
+    public boolean requestUserAttention() {
+        boolean opSuccessful = false;
+        if (Taskbar.isTaskbarSupported() &&
+                Taskbar.getTaskbar().isSupported(Taskbar.Feature.USER_ATTENTION)) {
+            // TODO check if we need to "unrequest" attention
+            Taskbar.getTaskbar().requestUserAttention(true, false);
+            opSuccessful = true;
+        }
+        return opSuccessful;
     }
 }

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
@@ -158,12 +158,12 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
     }
 
     @Override
-    public boolean setIconBadgeNumber(int number) {
+    public boolean setIconBadgeNumber(int numberOfJobs) {
         boolean opSuccessful = false;
         if (Taskbar.isTaskbarSupported() &&
                 Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_BADGE_TEXT)) {
-            if (number >= 0) {
-                Taskbar.getTaskbar().setIconBadge(Integer.toString(number));
+            if (numberOfJobs > 0) {
+                Taskbar.getTaskbar().setIconBadge(Integer.toString(numberOfJobs));
             } else {
                 Taskbar.getTaskbar().setIconBadge(null);
             }

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
@@ -188,11 +188,7 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
             // work around starts:
             EventQueue.invokeLater(() -> {
                 Taskbar.getTaskbar().setIconImage(Taskbar.getTaskbar().getIconImage());
-                if (progress >= 0 && progress <= 100) {
-                    Taskbar.getTaskbar().setProgressValue(progress);
-                } else {
-                    Taskbar.getTaskbar().setProgressValue(-1);
-                }
+                Taskbar.getTaskbar().setProgressValue(progress);
             });
             // work around ends
             opSupportedByAwt = true;

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
@@ -17,6 +17,7 @@
 
 package com.mucommander.desktop;
 
+import java.awt.EventQueue;
 import java.awt.Taskbar;
 import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
@@ -182,6 +183,18 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
             } else {
                 Taskbar.getTaskbar().setProgressValue(-1);
             }
+
+            // Apparently there's a problem with AWT with above code on macOS (https://bugs.openjdk.org/browse/JDK-8300037), so:
+            // work around starts:
+            EventQueue.invokeLater(() -> {
+                Taskbar.getTaskbar().setIconImage(Taskbar.getTaskbar().getIconImage());
+                if (progress >= 0 && progress <= 100) {
+                    Taskbar.getTaskbar().setProgressValue(progress);
+                } else {
+                    Taskbar.getTaskbar().setProgressValue(-1);
+                }
+            });
+            // work around ends
             opSupportedByAwt = true;
         }
         return opSupportedByAwt;

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DefaultDesktopAdapter.java
@@ -159,7 +159,7 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
 
     @Override
     public boolean setIconBadgeNumber(int numberOfJobs) {
-        boolean opSuccessful = false;
+        boolean opSupportedByAwt = false;
         if (Taskbar.isTaskbarSupported() &&
                 Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_BADGE_TEXT)) {
             if (numberOfJobs > 0) {
@@ -167,14 +167,14 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
             } else {
                 Taskbar.getTaskbar().setIconBadge(null);
             }
-            opSuccessful = true;
+            opSupportedByAwt = true;
         }
-        return opSuccessful;
+        return opSupportedByAwt;
     }
 
     @Override
     public boolean setIconProgress(int progress) {
-        boolean opSuccessful = false;
+        boolean opSupportedByAwt = false;
         if (Taskbar.isTaskbarSupported() &&
                 Taskbar.getTaskbar().isSupported(Taskbar.Feature.PROGRESS_VALUE)) {
             if (progress >= 0 && progress <= 100) {
@@ -182,20 +182,20 @@ public class DefaultDesktopAdapter implements DesktopAdapter {
             } else {
                 Taskbar.getTaskbar().setProgressValue(-1);
             }
-            opSuccessful = true;
+            opSupportedByAwt = true;
         }
-        return opSuccessful;
+        return opSupportedByAwt;
     }
 
     @Override
     public boolean requestUserAttention() {
-        boolean opSuccessful = false;
+        boolean opSupportedByAwt = false;
         if (Taskbar.isTaskbarSupported() &&
                 Taskbar.getTaskbar().isSupported(Taskbar.Feature.USER_ATTENTION)) {
             // TODO check if we need to "unrequest" attention
             Taskbar.getTaskbar().requestUserAttention(true, false);
-            opSuccessful = true;
+            opSupportedByAwt = true;
         }
-        return opSuccessful;
+        return opSupportedByAwt;
     }
 }

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopAdapter.java
@@ -174,11 +174,11 @@ public interface DesktopAdapter {
     ActionShortcuts getActionShortcuts();
 
     /**
-     * Sets badge number on Dock/TaskBar app icon. To remove the badge provide the negative value.
-     * @param number a number to be displayed over app icon
+     * Sets badge number on Dock/TaskBar app icon. To remove the badge provide a negative value or zero.
+     * @param numberOfJobs a number to be displayed over app icon
      * @return true if operation was supported by platform
      */
-    boolean setIconBadgeNumber(int number);
+    boolean setIconBadgeNumber(int numberOfJobs);
 
     /**
      * Sets progress bar on Dock/Taskbar app icon. To remove the progress bar, provider number

--- a/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopAdapter.java
+++ b/mucommander-os-api/src/main/java/com/mucommander/desktop/DesktopAdapter.java
@@ -172,4 +172,25 @@ public interface DesktopAdapter {
     default void customizeMainFrame(Window window) {}
     default List<Pair<JLabel, JComponent>> getExtendedFileProperties(AbstractFile file) { return Collections.emptyList(); }
     ActionShortcuts getActionShortcuts();
+
+    /**
+     * Sets badge number on Dock/TaskBar app icon. To remove the badge provide the negative value.
+     * @param number a number to be displayed over app icon
+     * @return true if operation was supported by platform
+     */
+    boolean setIconBadgeNumber(int number);
+
+    /**
+     * Sets progress bar on Dock/Taskbar app icon. To remove the progress bar, provider number
+     * outside of 1-100 range.
+     * @param progress the progress to display
+     * @return true if operation was supported by platform
+     */
+    boolean setIconProgress(int progress);
+
+    /**
+     * Requests users attention, for example on macOS by bouncing dock icon.
+     * @return true if operation was supported by platform
+     */
+    boolean requestUserAttention();
 }

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -245,13 +245,13 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
     }
 
     @Override
-    public boolean setIconBadgeNumber(int number) {
+    public boolean setIconBadgeNumber(int numberOfJobs) {
         // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2
-        if (super.setIconBadgeNumber(number)) {
+        if (super.setIconBadgeNumber(numberOfJobs)) {
             return true;
         }
-        if (number >= 0) {
-            Application.getApplication().setDockIconBadge(Integer.toString(number));
+        if (numberOfJobs > 0) {
+            Application.getApplication().setDockIconBadge(Integer.toString(numberOfJobs));
         } else {
             Application.getApplication().setDockIconBadge(null);
         }

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -246,7 +246,8 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
 
     @Override
     public boolean setIconBadgeNumber(int numberOfJobs) {
-        // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2
+        // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2,
+        // however on java 20 it works
         if (super.setIconBadgeNumber(numberOfJobs)) {
             return true;
         }
@@ -260,7 +261,8 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
 
     @Override
     public boolean setIconProgress(int progress) {
-        // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2
+        // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2,
+        // however on java 20 it works
         if (super.setIconProgress(progress)) {
             return true;
         }

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -35,6 +35,7 @@ import javax.swing.SwingConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.apple.eawt.Application;
 import com.apple.eawt.FullScreenUtilities;
 import com.apple.eio.FileManager;
 import com.dd.plist.BinaryPropertyListParser;
@@ -241,5 +242,41 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
             LOGGER.error("Error finding default shell for user, going to use a default one", e);
         }
         return result;
+    }
+
+    @Override
+    public boolean setIconBadgeNumber(int number) {
+        // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2
+        if (super.setIconBadgeNumber(number)) {
+            return true;
+        }
+        if (number >= 0) {
+            Application.getApplication().setDockIconBadge(Integer.toString(number));
+        } else {
+            Application.getApplication().setDockIconBadge(null);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean setIconProgress(int progress) {
+        // Hmm, Taskbar.isTaskbarSupported returns false on my macOS 10.15.7 and java 14.0.2
+        if (super.setIconProgress(progress)) {
+            return true;
+        }
+        if (progress >= 0 || progress <= 100) {
+            Application.getApplication().setDockIconProgress(progress);
+        } else {
+            Application.getApplication().setDockIconProgress(-1);
+        }
+        return true;
+    }
+
+    public boolean requestUserAttention() {
+        if (super.requestUserAttention()) {
+            return true;
+        }
+        Application.getApplication().requestUserAttention(false);
+        return true;
     }
 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -36,6 +36,7 @@ New features:
 - Undo and redo actions for the internal binary editor.
 - Additional search options for the internal text viewer/editor: case-sensitivity, whole-words, regular expressions, forward/backward.
 - Browsing and extracting multi-volume RAR 5+ files.
+- Dock/TaskBar icon showing jobs' progress updates
 
 Improvements:
 - When sorting a file table by filenames, the sort operation performs a locale-sensitive String comparison.

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -36,7 +36,7 @@ New features:
 - Undo and redo actions for the internal binary editor.
 - Additional search options for the internal text viewer/editor: case-sensitivity, whole-words, regular expressions, forward/backward.
 - Browsing and extracting multi-volume RAR 5+ files.
-- Dock/TaskBar icon showing jobs' progress updates
+- Dock/TaskBar icon shows the amount of active jobs and their progress
 
 Improvements:
 - When sorting a file table by filenames, the sort operation performs a locale-sensitive String comparison.


### PR DESCRIPTION
Added FileJobs' status updates on App Icon - under macOS in Dock or in Taskbar in Windows/Ubuntu (Unity).
- progress (probably not calculated accurately - probably I should use `getTotalPercentDone` instead of `getJobProgress.getFilePercentInt`)
- badge number - number of jobs (all i.e. foreground and background jobs)
- icon bouncing when user attention is required (file exists etc)

Screenshot:
![muc-icon](https://user-images.githubusercontent.com/360665/209575055-6dad58e7-618f-4637-a1e3-1677b220354c.png)


This is PoC - only checked on macOS Catalina.

All comments are welcomed.
