### PR TITLE
Editor Fix to avoid writing BOM for new UTF-8 files

### DIFF
--- a/mucommander-commons-io/src/main/java/com/mucommander/commons/io/bom/BOMConstants.java
+++ b/mucommander-commons-io/src/main/java/com/mucommander/commons/io/bom/BOMConstants.java
@@ -25,6 +25,10 @@ package com.mucommander.commons.io.bom;
 public interface BOMConstants {
 
     /** UTF-8 BOM: EF BB BF */
+    /**
+     * @deprecated BOM is not usually set for UTF-8 - see: https://github.com/mucommander/mucommander/issues/835
+     */
+    @Deprecated
     public final static BOM UTF8_BOM = new BOM(
             new byte[]{(byte)0xEF, (byte)0xBB, (byte)0xBF},
             "UTF-8",

--- a/mucommander-commons-io/src/main/java/com/mucommander/commons/io/bom/BOMWriter.java
+++ b/mucommander-commons-io/src/main/java/com/mucommander/commons/io/bom/BOMWriter.java
@@ -76,8 +76,8 @@ public class BOMWriter extends OutputStreamWriter {
      * subsequently encode characters in the specified encoding.
      *
      * @param out the <code>OutputStream</code> to write the encoded data to
-     * @param bom the byte-order mark to write at the beginning of the stream.
      * @param encoding character encoding to use for encoding characters.
+     * @param bom the byte-order mark to write at the beginning of the stream.
      * @throws UnsupportedEncodingException if the specified encoding is not a character encoding supported by the Java runtime.
      */
     protected BOMWriter(OutputStream out, String encoding, BOM bom) throws UnsupportedEncodingException {

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
@@ -201,7 +201,13 @@ class TextEditor extends BasicFileEditor implements DocumentListener, EncodingLi
     }
 
     private void write(OutputStream out) throws IOException {
-        textEditorImpl.write(new BOMWriter(out, textViewerDelegate.getEncoding()));
+        boolean isUtf8 = "UTF-8".equalsIgnoreCase(textViewerDelegate.getEncoding());
+        textEditorImpl.write(new BOMWriter(out, textViewerDelegate.getEncoding()) {
+            {
+                // Don't write BOM for utf-8 - see: https://github.com/mucommander/mucommander/issues/835
+                bomWriteChecked = isUtf8;
+            }
+        });
     }
 
     @Override

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
@@ -53,6 +53,7 @@ import com.mucommander.viewer.CloseCancelledException;
 
 
 import java.awt.event.ActionListener;
+import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.Map;
 
@@ -201,13 +202,9 @@ class TextEditor extends BasicFileEditor implements DocumentListener, EncodingLi
     }
 
     private void write(OutputStream out) throws IOException {
-        boolean isUtf8 = "UTF-8".equalsIgnoreCase(textViewerDelegate.getEncoding());
-        textEditorImpl.write(new BOMWriter(out, textViewerDelegate.getEncoding()) {
-            {
-                // Don't write BOM for utf-8 - see: https://github.com/mucommander/mucommander/issues/835
-                bomWriteChecked = isUtf8;
-            }
-        });
+        var isUtf8 = "UTF-8".equalsIgnoreCase(textViewerDelegate.getEncoding());
+        textEditorImpl.write(isUtf8 ?
+                new OutputStreamWriter(out) : new BOMWriter(out, textViewerDelegate.getEncoding()));
     }
 
     @Override


### PR DESCRIPTION
Editor: Fix to avoid writing BOM for new UTF-8 files - #835 