### PR TITLE
Eager loading of snapshot properties

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/search/SearchDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchDialog.java
@@ -140,7 +140,7 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
         l.setLabelFor(searchFilesField);
         l.setDisplayedMnemonic('n');
 
-        boolean lastMatchRegex = Boolean.parseBoolean(SearchProperty.MATCH_REGEX.getCurrentValue());
+        boolean lastMatchRegex = Boolean.parseBoolean(SearchProperty.MATCH_REGEX.getValue());
         wildcards = new JLabel(!lastMatchRegex ? Translator.get("search_dialog.wildcards") : " ");
         compPanel.addRow("", wildcards, 10);
 
@@ -148,7 +148,7 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
         gbc.weightx = 1.0;
         JPanel groupingPanel = new ProportionalGridPanel(2, gbc);
 
-        boolean lastMatchCase = Boolean.parseBoolean(SearchProperty.MATCH_CASESENSITIVE.getCurrentValue());
+        boolean lastMatchCase = Boolean.parseBoolean(SearchProperty.MATCH_CASESENSITIVE.getValue());
         matchCase = new JCheckBox(SearchProperty.MATCH_CASESENSITIVE.getTranslation(), lastMatchCase);
         groupingPanel.add(matchCase);
 
@@ -190,31 +190,31 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
 
         groupingPanel = new ProportionalGridPanel(2, gbc);
 
-        boolean value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_SUBFOLDERS.getCurrentValue());
+        boolean value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_SUBFOLDERS.getValue());
         searchInSubfolders = new JCheckBox(SearchProperty.SEARCH_IN_SUBFOLDERS.getTranslation(), value);
         groupingPanel.add(searchInSubfolders);
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_SUBFOLDERS.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_SUBFOLDERS.getValue());
         searchForSubfolders = new JCheckBox(SearchProperty.SEARCH_FOR_SUBFOLDERS.getTranslation(), value);
         groupingPanel.add(searchForSubfolders);
 
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_ARCHIVES.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_ARCHIVES.getValue());
         searchInArchives = new JCheckBox(SearchProperty.SEARCH_IN_ARCHIVES.getTranslation(), value);
         groupingPanel.add(searchInArchives);
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_ARCHIVES.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_ARCHIVES.getValue());
         searchForArchives = new JCheckBox(SearchProperty.SEARCH_FOR_ARCHIVES.getTranslation(), value);
         groupingPanel.add(searchForArchives);
 
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_HIDDEN.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_HIDDEN.getValue());
         searchInHidden = new JCheckBox(SearchProperty.SEARCH_IN_HIDDEN.getTranslation(), value);
         groupingPanel.add(searchInHidden);
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_HIDDEN.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_HIDDEN.getValue());
         searchForHidden = new JCheckBox(SearchProperty.SEARCH_FOR_HIDDEN.getTranslation(), value);
         groupingPanel.add(searchForHidden);
 
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_SYMLINKS.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_IN_SYMLINKS.getValue());
         searchInSymlinks = new JCheckBox(SearchProperty.SEARCH_IN_SYMLINKS.getTranslation(), value);
         groupingPanel.add(searchInSymlinks);
-        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_SYMLINKS.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.SEARCH_FOR_SYMLINKS.getValue());
         searchForSymlinks = new JCheckBox(SearchProperty.SEARCH_FOR_SYMLINKS.getTranslation(), value);
         groupingPanel.add(searchForSymlinks);
 
@@ -226,14 +226,14 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
         IntEditor editor = new IntEditor(depth, "#####", UNLIMITED_DEPTH);
         depth.setEditor(editor);
         depth.setModel(new SpinnerNumberModel(0, 0, null, 1));
-        depth.setValue(Integer.parseInt(SearchProperty.SEARCH_DEPTH.getCurrentValue()));
+        depth.setValue(Integer.parseInt(SearchProperty.SEARCH_DEPTH.getValue()));
         compPanel.addRow(SearchProperty.SEARCH_DEPTH.getTranslation(), depth, 5);
 
         threads = new JSpinner();
         editor = new IntEditor(threads, "#####", MAX_THREADS);
         threads.setEditor(editor);
         threads.setModel(new SpinnerNumberModel(0, 0, MAX_NUM_OF_SEARCH_THREADS, 1));
-        threads.setValue(Integer.parseInt(SearchProperty.SEARCH_THREADS.getCurrentValue()));
+        threads.setValue(Integer.parseInt(SearchProperty.SEARCH_THREADS.getValue()));
         compPanel.addRow(SearchProperty.SEARCH_THREADS.getTranslation(), threads, 5);
 
         fileSearchPanel.add(compPanel);
@@ -244,18 +244,18 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
         textSearchPanel.setBorder(BorderFactory.createTitledBorder(Translator.get("Text search (Optional)")));
         compPanel = new XAlignedComponentPanel(5);
 
-        String lastText = SearchProperty.SEARCH_TEXT.getCurrentValue();
+        String lastText = SearchProperty.SEARCH_TEXT.getValue();
         searchTextField = new SelectAllOnFocusTextField(lastText);
         l = compPanel.addRow(SearchProperty.SEARCH_TEXT.getTranslation(), searchTextField, 10);
         l.setLabelFor(searchTextField);
         l.setDisplayedMnemonic('t');
 
         groupingPanel = new ProportionalGridPanel(2, gbc);
-        value = Boolean.parseBoolean(SearchProperty.TEXT_CASESENSITIVE.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.TEXT_CASESENSITIVE.getValue());
         textCase = new JCheckBox(SearchProperty.TEXT_CASESENSITIVE.getTranslation(), value);
         groupingPanel.add(textCase);
 
-        value = Boolean.parseBoolean(SearchProperty.TEXT_MATCH_REGEX.getCurrentValue());
+        value = Boolean.parseBoolean(SearchProperty.TEXT_MATCH_REGEX.getValue());
         textRegex = new JCheckBox(SearchProperty.TEXT_MATCH_REGEX.getTranslation(), value);
         groupingPanel.add(textRegex);
         compPanel.addRow("", groupingPanel, 5);
@@ -283,7 +283,7 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
     }
 
     void addSizePanel(XAlignedComponentPanel compPanel) {
-        var firstSizeClause = SearchProperty.SEARCH_SIZE.getCurrentValue();
+        var firstSizeClause = SearchProperty.SEARCH_SIZE.getValue();
         JPanel firstSizePanel = new JPanel(new FlowLayout());
 
         var firstSizeRelation = SearchUtils.getSizeRelation(firstSizeClause);
@@ -298,7 +298,7 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
         firstSizeUnit.setSelectedIndex(SearchUtils.getSizeUnit(firstSizeClause).ordinal());
         firstSizePanel.add(firstSizeUnit);
 
-        var secondSizeClause = SearchProperty.SEARCH_SIZE2.getCurrentValue();
+        var secondSizeClause = SearchProperty.SEARCH_SIZE2.getValue();
         JPanel secondSizePanel = new JPanel(new FlowLayout());
 
         secondSizePanel.add(secondSizeRel);
@@ -445,23 +445,23 @@ public class SearchDialog extends FocusDialog implements ActionListener, Documen
             }
         }
 
-        SearchProperty.SEARCH_IN_SUBFOLDERS.update(String.valueOf(searchInSubfolders.isSelected()));
-        SearchProperty.SEARCH_IN_ARCHIVES.update(String.valueOf(searchInArchives.isSelected()));
-        SearchProperty.SEARCH_IN_HIDDEN.update(String.valueOf(searchInHidden.isSelected()));
-        SearchProperty.SEARCH_IN_SYMLINKS.update(String.valueOf(searchInSymlinks.isSelected()));
-        SearchProperty.SEARCH_FOR_SUBFOLDERS.update(String.valueOf(searchForSubfolders.isSelected()));
-        SearchProperty.SEARCH_FOR_ARCHIVES.update(String.valueOf(searchForArchives.isSelected()));
-        SearchProperty.SEARCH_FOR_HIDDEN.update(String.valueOf(searchForHidden.isSelected()));
-        SearchProperty.SEARCH_FOR_SYMLINKS.update(String.valueOf(searchForSymlinks.isSelected()));
-        SearchProperty.MATCH_CASESENSITIVE.update(String.valueOf(matchCase.isSelected()));
-        SearchProperty.MATCH_REGEX.update(String.valueOf(matchRegex.isSelected()));
-        SearchProperty.SEARCH_DEPTH.update(String.valueOf(((Number) depth.getValue()).intValue()));
-        SearchProperty.SEARCH_THREADS.update(String.valueOf(((Number) threads.getValue()).intValue()));
-        SearchProperty.TEXT_CASESENSITIVE.update(String.valueOf(textCase.isSelected()));
-        SearchProperty.TEXT_MATCH_REGEX.update(String.valueOf(textRegex.isSelected()));
-        SearchProperty.SEARCH_SIZE.update(buildSeachSizeClause(firstSizeRelation, firstSize, firstSizeUnit));
-        SearchProperty.SEARCH_SIZE2.update(buildSeachSizeClause(secondSizeRelation, secondSize, secondSizeUnit));
-        SearchProperty.SEARCH_TEXT.update(searchTextField.getText());
+        SearchProperty.SEARCH_IN_SUBFOLDERS.setValue(String.valueOf(searchInSubfolders.isSelected()));
+        SearchProperty.SEARCH_IN_ARCHIVES.setValue(String.valueOf(searchInArchives.isSelected()));
+        SearchProperty.SEARCH_IN_HIDDEN.setValue(String.valueOf(searchInHidden.isSelected()));
+        SearchProperty.SEARCH_IN_SYMLINKS.setValue(String.valueOf(searchInSymlinks.isSelected()));
+        SearchProperty.SEARCH_FOR_SUBFOLDERS.setValue(String.valueOf(searchForSubfolders.isSelected()));
+        SearchProperty.SEARCH_FOR_ARCHIVES.setValue(String.valueOf(searchForArchives.isSelected()));
+        SearchProperty.SEARCH_FOR_HIDDEN.setValue(String.valueOf(searchForHidden.isSelected()));
+        SearchProperty.SEARCH_FOR_SYMLINKS.setValue(String.valueOf(searchForSymlinks.isSelected()));
+        SearchProperty.MATCH_CASESENSITIVE.setValue(String.valueOf(matchCase.isSelected()));
+        SearchProperty.MATCH_REGEX.setValue(String.valueOf(matchRegex.isSelected()));
+        SearchProperty.SEARCH_DEPTH.setValue(String.valueOf(((Number) depth.getValue()).intValue()));
+        SearchProperty.SEARCH_THREADS.setValue(String.valueOf(((Number) threads.getValue()).intValue()));
+        SearchProperty.TEXT_CASESENSITIVE.setValue(String.valueOf(textCase.isSelected()));
+        SearchProperty.TEXT_MATCH_REGEX.setValue(String.valueOf(textRegex.isSelected()));
+        SearchProperty.SEARCH_SIZE.setValue(buildSeachSizeClause(firstSizeRelation, firstSize, firstSizeUnit));
+        SearchProperty.SEARCH_SIZE2.setValue(buildSeachSizeClause(secondSizeRelation, secondSize, secondSizeUnit));
+        SearchProperty.SEARCH_TEXT.setValue(searchTextField.getText());
 
         return true;
     }

--- a/mucommander-core/src/main/java/com/mucommander/search/SearchProperty.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchProperty.java
@@ -45,13 +45,13 @@ enum SearchProperty {
     private String key;
     private String i18nKey;
     private String defaultValue;
-    private String currentValue;
+    private String value;
 
     SearchProperty(String key, String i18nKey, String defaultValue) {
         this.key = key;
         this.i18nKey = i18nKey;
         this.defaultValue = defaultValue;
-        this.currentValue = defaultValue;
+        value = defaultValue;
     }
 
     public String getKey() {
@@ -74,23 +74,19 @@ enum SearchProperty {
                 .orElse(defaultValue);
     }
 
-    public void update(String value) {
-        currentValue = value;
-    }
-
-    public String getCurrentValue() {
-        return currentValue;
-    }
-
     public void setValue(String value) {
-        currentValue = value;
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
     }
 
     public boolean isDefault() {
-        return Objects.equals(defaultValue, currentValue);
+        return Objects.equals(defaultValue, value);
     }
 
     public String toString() {
-        return key + "=" + currentValue;
+        return key + "=" + value;
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/search/SearchProperty.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchProperty.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Objects;
 
 import com.mucommander.commons.util.Pair;
-import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.text.Translator;
 
 enum SearchProperty {
@@ -52,7 +51,7 @@ enum SearchProperty {
         this.key = key;
         this.i18nKey = i18nKey;
         this.defaultValue = defaultValue;
-        this.currentValue = MuSnapshot.getSnapshot().getVariable(MuSnapshot.SEARCH_SECTION + "." + key, defaultValue);
+        this.currentValue = defaultValue;
     }
 
     public String getKey() {
@@ -81,6 +80,10 @@ enum SearchProperty {
 
     public String getCurrentValue() {
         return currentValue;
+    }
+
+    public void setValue(String value) {
+        currentValue = value;
     }
 
     public boolean isDefault() {

--- a/mucommander-core/src/main/java/com/mucommander/search/SearchSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchSnapshot.java
@@ -16,33 +16,27 @@
  */
 package com.mucommander.search;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.mucommander.snapshot.MuSnapshot.SEARCH_SECTION;
 
 import com.mucommander.commons.conf.Configuration;
-import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
-public class SearchSnapshot implements MuSnapshotable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SearchSnapshot.class);
-
-    @Override
-    public void read(Configuration configuration) {
-        LOGGER.info("Loading snapshot configuration for " + SearchSnapshot.class);
-        for (var property : SearchProperty.values()) {
-            var prefKey = MuSnapshot.SEARCH_SECTION + "." + property.getKey();
-            property.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, property.getValue()));
-        }
+/**
+ * Snapshot preferences for file-search
+ * @author Arik Hadas
+ */
+public class SearchSnapshot extends MuSnapshotable<SearchProperty> {
+    public SearchSnapshot() {
+        super(SearchProperty::values,
+                SearchProperty::getValue,
+                SearchProperty::setValue,
+                pref -> pref.getKey() != null ? SEARCH_SECTION + "." + pref.getKey() : null);
     }
 
     @Override
-    public void write(Configuration configuration) {
-        for (var property : SearchProperty.values()) {
-            if (!property.isDefault()) {
-                var prefKey = MuSnapshot.SEARCH_SECTION + "." + property.getKey();
-                configuration.setVariable(prefKey, property.getValue());
-            }
-        }
+    protected void write(Configuration configuration, SearchProperty pref) {
+        // do not persist properties that are set with their default value
+        if (!pref.isDefault())
+            super.write(configuration, pref);
     }
-
 }

--- a/mucommander-core/src/main/java/com/mucommander/search/SearchSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchSnapshot.java
@@ -29,17 +29,19 @@ public class SearchSnapshot implements MuSnapshotable {
     @Override
     public void read(Configuration configuration) {
         LOGGER.info("Loading snapshot configuration for " + SearchSnapshot.class);
-        for (var searchProperty : SearchProperty.values()) {
-            var prefKey = MuSnapshot.SEARCH_SECTION + "." + searchProperty.getKey();
-            searchProperty.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, searchProperty.getDefaultValue()));
+        for (var property : SearchProperty.values()) {
+            var prefKey = MuSnapshot.SEARCH_SECTION + "." + property.getKey();
+            property.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, property.getValue()));
         }
     }
 
     @Override
     public void write(Configuration configuration) {
-        for (var searchProperty : SearchProperty.values()) {
-            if (!searchProperty.isDefault())
-                configuration.setVariable(MuSnapshot.SEARCH_SECTION + "." + searchProperty.getKey(), searchProperty.getCurrentValue());
+        for (var property : SearchProperty.values()) {
+            if (!property.isDefault()) {
+                var prefKey = MuSnapshot.SEARCH_SECTION + "." + property.getKey();
+                configuration.setVariable(prefKey, property.getValue());
+            }
         }
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/search/SearchSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/search/SearchSnapshot.java
@@ -16,11 +16,24 @@
  */
 package com.mucommander.search;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.mucommander.commons.conf.Configuration;
 import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 public class SearchSnapshot implements MuSnapshotable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchSnapshot.class);
+
+    @Override
+    public void read(Configuration configuration) {
+        LOGGER.info("Loading snapshot configuration for " + SearchSnapshot.class);
+        for (var searchProperty : SearchProperty.values()) {
+            var prefKey = MuSnapshot.SEARCH_SECTION + "." + searchProperty.getKey();
+            searchProperty.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, searchProperty.getDefaultValue()));
+        }
+    }
 
     @Override
     public void write(Configuration configuration) {

--- a/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshotable.java
+++ b/mucommander-core/src/main/java/com/mucommander/snapshot/MuSnapshotable.java
@@ -31,7 +31,7 @@ public interface MuSnapshotable {
      * 
      * @param configuration configuration
      */
-    default void read(Configuration configuration) {}
+    void read(Configuration configuration);
     
     /**
      * Performs storing/writing of snapshot preferences.

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorPreferences.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorPreferences.java
@@ -16,10 +16,6 @@
  */
 package com.mucommander.ui.viewer;
 
-import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
-
-import com.mucommander.snapshot.MuSnapshot;
-
 /**
  * Editor preferences.
  */
@@ -33,11 +29,11 @@ public enum EditorPreferences {
     ;
 
     private String prefKey;
-    private String currentValue;
+    private String value;
 
     EditorPreferences(String prefKey, String defaultValue) {
-        this.prefKey =  FILE_PRESENTER_SECTION + "." + prefKey;
-        this.currentValue = MuSnapshot.getSnapshot().getVariable(this.prefKey, defaultValue);
+        this.prefKey =  prefKey;
+        this.value = defaultValue;
     }
 
     public String getPrefKey() {
@@ -45,10 +41,10 @@ public enum EditorPreferences {
     }
 
     public String getValue() {
-        return currentValue;
+        return value;
     }
 
     public void setValue(String value) {
-        currentValue = value;
+        this.value = value;
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorSnapshot.java
@@ -16,18 +16,39 @@
  */
 package com.mucommander.ui.viewer;
 
+import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.mucommander.commons.conf.Configuration;
+import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for editor.
  */
 public final class EditorSnapshot implements MuSnapshotable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EditorSnapshot.class);
+
+    @Override
+    public void read(Configuration configuration) {
+        LOGGER.info("Loading snapshot configuration for " + EditorSnapshot.class);
+        for (var pref : EditorPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (pref != null) {
+                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
+                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
+            }
+        }
+    }
 
     @Override
     public void write(Configuration configuration) {
-        for (EditorPreferences pref : EditorPreferences.values()) {
-            if (pref.getPrefKey() != null) {
+        for (var pref : EditorPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
                 configuration.setVariable(pref.getPrefKey(), pref.getValue());
             }
         }

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/EditorSnapshot.java
@@ -18,39 +18,16 @@ package com.mucommander.ui.viewer;
 
 import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.mucommander.commons.conf.Configuration;
-import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for editor.
  */
-public final class EditorSnapshot implements MuSnapshotable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EditorSnapshot.class);
-
-    @Override
-    public void read(Configuration configuration) {
-        LOGGER.info("Loading snapshot configuration for " + EditorSnapshot.class);
-        for (var pref : EditorPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (pref != null) {
-                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
-                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
-            }
-        }
-    }
-
-    @Override
-    public void write(Configuration configuration) {
-        for (var pref : EditorPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
-                configuration.setVariable(pref.getPrefKey(), pref.getValue());
-            }
-        }
+public final class EditorSnapshot extends MuSnapshotable<EditorPreferences> {
+    public EditorSnapshot() {
+        super(EditorPreferences::values,
+                EditorPreferences::getValue,
+                EditorPreferences::setValue,
+                pref -> pref.getPrefKey() != null ? FILE_PRESENTER_SECTION + "." + pref.getPrefKey() : null);
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerPreferences.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerPreferences.java
@@ -16,10 +16,6 @@
  */
 package com.mucommander.ui.viewer;
 
-import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
-
-import com.mucommander.snapshot.MuSnapshot;
-
 /**
  * Viewer preferences.
  */
@@ -33,11 +29,11 @@ public enum ViewerPreferences {
     ;
 
     private String prefKey;
-    private String currentValue;
+    private String value;
 
     ViewerPreferences(String prefKey, String defaultValue) {
-        this.prefKey =  FILE_PRESENTER_SECTION + "." + prefKey;
-        this.currentValue = MuSnapshot.getSnapshot().getVariable(this.prefKey, defaultValue);
+        this.prefKey =  prefKey;
+        value = defaultValue;
     }
 
     public String getPrefKey() {
@@ -45,10 +41,10 @@ public enum ViewerPreferences {
     }
 
     public String getValue() {
-        return currentValue;
+        return value;
     }
 
     public void setValue(String value) {
-        currentValue = value;
+        this.value = value;
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerSnapshot.java
@@ -16,19 +16,40 @@
  */
 package com.mucommander.ui.viewer;
 
+import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.mucommander.commons.conf.Configuration;
+import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for viewer.
  */
 public final class ViewerSnapshot implements MuSnapshotable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ViewerSnapshot.class);
+
+    @Override
+    public void read(Configuration configuration) {
+        LOGGER.info("Loading snapshot configuration for " + ViewerSnapshot.class);
+        for (var pref : ViewerPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
+                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
+            }
+        }
+    }
 
     @Override
     public void write(Configuration configuration) {
-        for (ViewerPreferences pref : ViewerPreferences.values()) {
-            if (pref.getPrefKey() != null) {
-                configuration.setVariable(pref.getPrefKey(), pref.getValue());
+        for (var pref : ViewerPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
+                configuration.setVariable(prefKey, pref.getValue());
             }
         }
     }

--- a/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerSnapshot.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/viewer/ViewerSnapshot.java
@@ -18,39 +18,16 @@ package com.mucommander.ui.viewer;
 
 import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.mucommander.commons.conf.Configuration;
-import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for viewer.
  */
-public final class ViewerSnapshot implements MuSnapshotable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ViewerSnapshot.class);
-
-    @Override
-    public void read(Configuration configuration) {
-        LOGGER.info("Loading snapshot configuration for " + ViewerSnapshot.class);
-        for (var pref : ViewerPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
-                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
-            }
-        }
-    }
-
-    @Override
-    public void write(Configuration configuration) {
-        for (var pref : ViewerPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = FILE_PRESENTER_SECTION + "." + prefKey;
-                configuration.setVariable(prefKey, pref.getValue());
-            }
-        }
+public final class ViewerSnapshot extends MuSnapshotable<ViewerPreferences> {
+    public ViewerSnapshot() {
+        super(ViewerPreferences::values,
+                ViewerPreferences::getValue,
+                ViewerPreferences::setValue,
+                pref -> pref.getPrefKey() != null ? FILE_PRESENTER_SECTION + "." + pref.getPrefKey() : null);
     }
 }

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerPreferences.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerPreferences.java
@@ -16,12 +16,8 @@
  */
 package com.mucommander.viewer.image;
 
-import com.mucommander.snapshot.MuSnapshot;
-
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-
-import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
 /**
  * Image viewer preferences.
@@ -33,19 +29,14 @@ public enum ImageViewerPreferences {
     SHOW_STATUS_BAR("show_status_bar", "image_viewer.show_status_bar", Boolean.TRUE.toString())
     ;
 
-    /**
-     * Section describing information specific to image file presenter.
-     */
-    public static final String IMAGE_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "image";
-
     private String prefKey;
     private String i18nKey;
-    private String currentValue;
+    private String value;
 
     ImageViewerPreferences(String prefKey, String i18nKey, String defaultValue) {
-        this.prefKey = IMAGE_FILE_PRESENTER_SECTION + "." + prefKey;
+        this.prefKey = prefKey;
         this.i18nKey = i18nKey;
-        this.currentValue = MuSnapshot.getSnapshot().getVariable(this.prefKey, defaultValue);
+        value = defaultValue;
     }
 
     @Nonnull
@@ -60,10 +51,10 @@ public enum ImageViewerPreferences {
 
     @Nonnull
     public String getValue() {
-        return currentValue;
+        return value;
     }
 
     public void setValue(String value) {
-        currentValue = value;
+        this.value = value;
     }
 }

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerSnapshot.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerSnapshot.java
@@ -16,22 +16,48 @@
  */
 package com.mucommander.viewer.image;
 
-import com.mucommander.commons.conf.Configuration;
-import com.mucommander.snapshot.MuSnapshotable;
+import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mucommander.commons.conf.Configuration;
+import com.mucommander.snapshot.MuSnapshot;
+import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for image viewer.
  */
 @ParametersAreNonnullByDefault
 public final class ImageViewerSnapshot implements MuSnapshotable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageViewerSnapshot.class);
+
+    /**
+     * Section describing information specific to image file presenter.
+     */
+    public static final String IMAGE_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "image";
+
+    @Override
+    public void read(Configuration configuration) {
+        LOGGER.info("Loading snapshot configuration for " + ImageViewerSnapshot.class);
+        for (var pref : ImageViewerPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = IMAGE_FILE_PRESENTER_SECTION + "." + prefKey;
+                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
+            }
+        }
+    }
 
     @Override
     public void write(Configuration configuration) {
-        for (ImageViewerPreferences pref : ImageViewerPreferences.values()) {
-            if (pref.getPrefKey() != null) {
-                configuration.setVariable(pref.getPrefKey(), pref.getValue());
+        for (var pref : ImageViewerPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = IMAGE_FILE_PRESENTER_SECTION + "." + prefKey;
+                configuration.setVariable(prefKey, pref.getValue());
             }
         }
     }

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerSnapshot.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerSnapshot.java
@@ -18,47 +18,21 @@ package com.mucommander.viewer.image;
 
 import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.mucommander.commons.conf.Configuration;
-import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for image viewer.
  */
-@ParametersAreNonnullByDefault
-public final class ImageViewerSnapshot implements MuSnapshotable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ImageViewerSnapshot.class);
-
+public final class ImageViewerSnapshot extends MuSnapshotable<ImageViewerPreferences> {
     /**
      * Section describing information specific to image file presenter.
      */
     public static final String IMAGE_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "image";
 
-    @Override
-    public void read(Configuration configuration) {
-        LOGGER.info("Loading snapshot configuration for " + ImageViewerSnapshot.class);
-        for (var pref : ImageViewerPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = IMAGE_FILE_PRESENTER_SECTION + "." + prefKey;
-                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
-            }
-        }
-    }
-
-    @Override
-    public void write(Configuration configuration) {
-        for (var pref : ImageViewerPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = IMAGE_FILE_PRESENTER_SECTION + "." + prefKey;
-                configuration.setVariable(prefKey, pref.getValue());
-            }
-        }
+    public ImageViewerSnapshot() {
+        super(ImageViewerPreferences::values,
+                ImageViewerPreferences::getValue,
+                ImageViewerPreferences::setValue,
+                pref -> pref.getPrefKey() != null ? IMAGE_FILE_PRESENTER_SECTION + "." + pref.getPrefKey() : null);
     }
 }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditor.java
@@ -61,7 +61,7 @@ import javax.swing.JScrollPane;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 
-import static com.mucommander.viewer.text.TextViewerPreferences.TEXT_FILE_PRESENTER_SECTION;
+import static com.mucommander.viewer.text.TextViewerSnapshot.TEXT_FILE_PRESENTER_SECTION;
 
 
 /**

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewer.java
@@ -17,7 +17,7 @@
 
 package com.mucommander.viewer.text;
 
-import static com.mucommander.viewer.text.TextViewerPreferences.TEXT_FILE_PRESENTER_SECTION;
+import static com.mucommander.viewer.text.TextViewerSnapshot.TEXT_FILE_PRESENTER_SECTION;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
@@ -16,6 +16,8 @@
  */
 package com.mucommander.viewer.text;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -29,45 +31,65 @@ import java.util.function.Function;
 enum TextViewerPreferences {
 
     // Whether to wrap long lines.
-    LINE_WRAP("line_wrap", "text_viewer.line_wrap", false, t -> t::wrap),
+    @Metadata(false)
+    LINE_WRAP("line_wrap", "text_viewer.line_wrap", t -> t::wrap),
     // Whether to show line numbers.
-    LINE_NUMBERS("line_numbers", "text_viewer.line_numbers", true),
+    @Metadata
+    LINE_NUMBERS("line_numbers", "text_viewer.line_numbers"),
     // Whether to animate bracket matching
-    ANIMATE_BRACKET_MATCHING("animate_bracket_matching", "text_viewer.animate_bracket_matching", true, t -> t::animateBracketMatching),
+    @Metadata
+    ANIMATE_BRACKET_MATCHING("animate_bracket_matching", "text_viewer.animate_bracket_matching", t -> t::animateBracketMatching),
     // Whether to use anti-aliasing
-    ANTI_ALIASING("anti_aliasing", "text_viewer.anti_aliasing", true, t -> t::antiAliasing),
+    @Metadata
+    ANTI_ALIASING("anti_aliasing", "text_viewer.anti_aliasing", t -> t::antiAliasing),
     // Whether to use auto-indent
-    AUTO_INDENT("auto_indent", "text_viewer.auto_indent", false, t -> t::autoIndent, EditorViewerMode.EDITOR),
+    @Metadata(value = false, mode = EditorViewerMode.EDITOR)
+    AUTO_INDENT("auto_indent", "text_viewer.auto_indent", t -> t::autoIndent),
     // Whether to match brackets
-    BRACKET_MATCHING("bracket_matching", "text_viewer.bracket_matching", true, t -> t::bracketMatching),
+    @Metadata
+    BRACKET_MATCHING("bracket_matching", "text_viewer.bracket_matching", t -> t::bracketMatching),
     // Whether to clear lines with whitespaces
-    CLEAR_WHITE_SPACE("clear_whitespace_lines", "text_viewer.clear_whitespace_lines", true, t -> t::clearWhitespaceLines, EditorViewerMode.EDITOR),
+    @Metadata(mode = EditorViewerMode.EDITOR)
+    CLEAR_WHITE_SPACE("clear_whitespace_lines", "text_viewer.clear_whitespace_lines", t -> t::clearWhitespaceLines),
     // Whether to close curly braces
-    CLOSE_CURLY_BRACES("close_curly_braces", "text_viewer.close_curly_braces", true, t -> t::closeCurlyBraces, EditorViewerMode.EDITOR),
+    @Metadata(mode = EditorViewerMode.EDITOR)
+    CLOSE_CURLY_BRACES("close_curly_braces", "text_viewer.close_curly_braces", t -> t::closeCurlyBraces),
     // Whether to markup tags (only honored for markup languages, such as HTML, XML and PHP)
-    CLOSE_MARKUP_TAGS("close_markup_tags", "text_viewer.close_markup_tags", true, t -> t::closeMarkupTags, EditorViewerMode.EDITOR),
+    @Metadata(mode = EditorViewerMode.EDITOR)
+    CLOSE_MARKUP_TAGS("close_markup_tags", "text_viewer.close_markup_tags", t -> t::closeMarkupTags),
     // Whether to use code folding
-    CODE_FOLDING("code_folding", "text_viewer.code_folding", true, t -> t::codeFolding),
+    @Metadata
+    CODE_FOLDING("code_folding", "text_viewer.code_folding", t -> t::codeFolding),
     // Whether text drag-n-drop is enabled
-    DRAG_ENABLED("drag_n_drop", "text_viewer.drag_n_drop", true, t -> t::dragEnabled),
+    @Metadata
+    DRAG_ENABLED("drag_n_drop", "text_viewer.drag_n_drop", t -> t::dragEnabled),
     // Whether to show EOL markers
-    EOL_MARKERS("eol_markers", "text_viewer.eol_markers", false, t -> t::eolMarkersVisible),
+    @Metadata(false)
+    EOL_MARKERS("eol_markers", "text_viewer.eol_markers", t -> t::eolMarkersVisible),
     // Whether to slightly fade current line highlight
-    FADE_CURRENT_LINE_HL("fade_current_line", "text_viewer.fade_current_line", true, t -> t::fadeCurrentLineHighlight),
+    @Metadata
+    FADE_CURRENT_LINE_HL("fade_current_line", "text_viewer.fade_current_line", t -> t::fadeCurrentLineHighlight),
     // Whether to highlight a current line
-    HIGHLIGHT_CURRENT_LINE("highlight_current_line", "text_viewer.highlight_current_line", true, t -> t::highlightCurrentLine),
+    @Metadata
+    HIGHLIGHT_CURRENT_LINE("highlight_current_line", "text_viewer.highlight_current_line", t -> t::highlightCurrentLine),
     // Whether to mark occurrences
-    MARK_OCCURRENCES("mark_occurrences", "text_viewer.mark_occurrences", true, t -> t::markOccurrences),
+    @Metadata
+    MARK_OCCURRENCES("mark_occurrences", "text_viewer.mark_occurrences", t -> t::markOccurrences),
     // Whether to paint tab lines
-    PAINT_TAB_LINES("tab_lines", "text_viewer.tab_lines", true, t -> t::paintTabLines),
+    @Metadata
+    PAINT_TAB_LINES("tab_lines", "text_viewer.tab_lines", t -> t::paintTabLines),
     // Whether to paint rounded edges of selection
-    ROUNDED_SELECTION("rounded_selection", "text_viewer.rounded_selection", true, t -> t::roundedSelectionEdges),
+    @Metadata
+    ROUNDED_SELECTION("rounded_selection", "text_viewer.rounded_selection", t -> t::roundedSelectionEdges),
     // Whether to show popup with matched end-bracket (when off-screen)
-    SHOW_MATCHED_BRACKET("show_matched_bracket_popup", "text_viewer.show_matched_bracket_popup", true, t -> t::showMatchedBracketPopup),
+    @Metadata
+    SHOW_MATCHED_BRACKET("show_matched_bracket_popup", "text_viewer.show_matched_bracket_popup", t -> t::showMatchedBracketPopup),
     // Whether to emulated tabs with spaces
-    TABS_EMULATED("tabs_emulated", "text_viewer.tabs_emulated", true, t -> t::tabsEmulated, EditorViewerMode.EDITOR),
+    @Metadata(mode = EditorViewerMode.EDITOR)
+    TABS_EMULATED("tabs_emulated", "text_viewer.tabs_emulated", t -> t::tabsEmulated),
     // Whether to show whitespace chars
-    WHITESPACE_VISIBLE("whitespace_visible", "text_viewer.whitespace_visible", false, t -> t::whitespaceVisible),
+    @Metadata(false)
+    WHITESPACE_VISIBLE("whitespace_visible", "text_viewer.whitespace_visible", t -> t::whitespaceVisible),
 
     ; // end of prefs (syntax sugar aka developer vanity marker)
 
@@ -78,27 +100,35 @@ enum TextViewerPreferences {
 
     String prefKey;
     String i18nKey;
-    boolean value;
-    EditorViewerMode mode;
-
     Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter;
 
-    TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue) {
-        this(prefKey, i18nKey, defaultValue, null, EditorViewerMode.BOTH);
+    boolean value = true;
+    EditorViewerMode mode = EditorViewerMode.BOTH;
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Metadata {
+        // Default value
+        boolean value() default true;
+        EditorViewerMode mode() default EditorViewerMode.BOTH;
     }
 
-    TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue,
-            Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter) {
-        this(prefKey, i18nKey, defaultValue, textEditorSetter, EditorViewerMode.BOTH);
+    TextViewerPreferences(String prefKey, String i18nKey) {
+        this(prefKey, i18nKey, null);
     }
 
-    TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue,
-            Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter, EditorViewerMode mode) {
+    TextViewerPreferences(String prefKey, String i18nKey, Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter) {
         this.prefKey = prefKey;
         this.i18nKey = i18nKey;
         this.textEditorSetter = textEditorSetter;
-        this.value = defaultValue;
-        this.mode = mode;
+
+        Metadata metadata;
+        try {
+            metadata = getDeclaringClass().getDeclaredField(this.name()).getDeclaredAnnotation(Metadata.class);
+            mode = metadata.mode();
+            value = metadata.value();
+        } catch (NoSuchFieldException | SecurityException e) {
+            // ignore, the properties are initialized with the annotation's default values
+        }
     }
 
     public String getPrefKey() {

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
@@ -16,7 +16,8 @@
  */
 package com.mucommander.viewer.text;
 
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 
 /**
@@ -28,65 +29,45 @@ import java.util.function.BiConsumer;
 enum TextViewerPreferences {
 
     // Whether to wrap long lines.
-    LINE_WRAP("line_wrap", "text_viewer.line_wrap", false,
-            (textEditorImpl, aBoolean) -> textEditorImpl.wrap(aBoolean)),
+    LINE_WRAP("line_wrap", "text_viewer.line_wrap", false, t -> t::wrap),
     // Whether to show line numbers.
     LINE_NUMBERS("line_numbers", "text_viewer.line_numbers", true),
     // Whether to animate bracket matching
-    ANIMATE_BRACKET_MATCHING("animate_bracket_matching", "text_viewer.animate_bracket_matching", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.animateBracketMatching(aBoolean)),
+    ANIMATE_BRACKET_MATCHING("animate_bracket_matching", "text_viewer.animate_bracket_matching", true, t -> t::animateBracketMatching),
     // Whether to use anti-aliasing
-    ANTI_ALIASING("anti_aliasing", "text_viewer.anti_aliasing", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.antiAliasing(aBoolean)),
+    ANTI_ALIASING("anti_aliasing", "text_viewer.anti_aliasing", true, t -> t::antiAliasing),
     // Whether to use auto-indent
-    AUTO_INDENT("auto_indent", "text_viewer.auto_indent", false,
-            (textEditorImpl, aBoolean) -> textEditorImpl.autoIndent(aBoolean), EditorViewerMode.EDITOR),
+    AUTO_INDENT("auto_indent", "text_viewer.auto_indent", false, t -> t::autoIndent, EditorViewerMode.EDITOR),
     // Whether to match brackets
-    BRACKET_MATCHING("bracket_matching", "text_viewer.bracket_matching", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.bracketMatching(aBoolean)),
+    BRACKET_MATCHING("bracket_matching", "text_viewer.bracket_matching", true, t -> t::bracketMatching),
     // Whether to clear lines with whitespaces
-    CLEAR_WHITE_SPACE("clear_whitespace_lines", "text_viewer.clear_whitespace_lines", true,
-            (textEditorImpl, aBoolean) ->
-                    textEditorImpl.clearWhitespaceLines(aBoolean), EditorViewerMode.EDITOR),
+    CLEAR_WHITE_SPACE("clear_whitespace_lines", "text_viewer.clear_whitespace_lines", true, t -> t::clearWhitespaceLines, EditorViewerMode.EDITOR),
     // Whether to close curly braces
-    CLOSE_CURLY_BRACES("close_curly_braces", "text_viewer.close_curly_braces", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.closeCurlyBraces(aBoolean), EditorViewerMode.EDITOR),
+    CLOSE_CURLY_BRACES("close_curly_braces", "text_viewer.close_curly_braces", true, t -> t::closeCurlyBraces, EditorViewerMode.EDITOR),
     // Whether to markup tags (only honored for markup languages, such as HTML, XML and PHP)
-    CLOSE_MARKUP_TAGS("close_markup_tags", "text_viewer.close_markup_tags", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.closeMarkupTags(aBoolean), EditorViewerMode.EDITOR),
+    CLOSE_MARKUP_TAGS("close_markup_tags", "text_viewer.close_markup_tags", true, t -> t::closeMarkupTags, EditorViewerMode.EDITOR),
     // Whether to use code folding
-    CODE_FOLDING("code_folding", "text_viewer.code_folding", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.codeFolding(aBoolean)),
+    CODE_FOLDING("code_folding", "text_viewer.code_folding", true, t -> t::codeFolding),
     // Whether text drag-n-drop is enabled
-    DRAG_ENABLED("drag_n_drop", "text_viewer.drag_n_drop", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.dragEnabled(aBoolean)),
+    DRAG_ENABLED("drag_n_drop", "text_viewer.drag_n_drop", true, t -> t::dragEnabled),
     // Whether to show EOL markers
-    EOL_MARKERS("eol_markers", "text_viewer.eol_markers", false,
-            (textEditorImpl, aBoolean) -> textEditorImpl.eolMarkersVisible(aBoolean)),
+    EOL_MARKERS("eol_markers", "text_viewer.eol_markers", false, t -> t::eolMarkersVisible),
     // Whether to slightly fade current line highlight
-    FADE_CURRENT_LINE_HL("fade_current_line", "text_viewer.fade_current_line", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.fadeCurrentLineHighlight(aBoolean)),
+    FADE_CURRENT_LINE_HL("fade_current_line", "text_viewer.fade_current_line", true, t -> t::fadeCurrentLineHighlight),
     // Whether to highlight a current line
-    HIGHLIGHT_CURRENT_LINE("highlight_current_line", "text_viewer.highlight_current_line", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.highlightCurrentLine(aBoolean)),
+    HIGHLIGHT_CURRENT_LINE("highlight_current_line", "text_viewer.highlight_current_line", true, t -> t::highlightCurrentLine),
     // Whether to mark occurrences
-    MARK_OCCURRENCES("mark_occurrences", "text_viewer.mark_occurrences", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.markOccurrences(aBoolean)),
+    MARK_OCCURRENCES("mark_occurrences", "text_viewer.mark_occurrences", true, t -> t::markOccurrences),
     // Whether to paint tab lines
-    PAINT_TAB_LINES("tab_lines", "text_viewer.tab_lines", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.paintTabLines(aBoolean)),
+    PAINT_TAB_LINES("tab_lines", "text_viewer.tab_lines", true, t -> t::paintTabLines),
     // Whether to paint rounded edges of selection
-    ROUNDED_SELECTION("rounded_selection", "text_viewer.rounded_selection", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.roundedSelectionEdges(aBoolean)),
+    ROUNDED_SELECTION("rounded_selection", "text_viewer.rounded_selection", true, t -> t::roundedSelectionEdges),
     // Whether to show popup with matched end-bracket (when off-screen)
-    SHOW_MATCHED_BRACKET("show_matched_bracket_popup", "text_viewer.show_matched_bracket_popup", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.showMatchedBracketPopup(aBoolean)),
+    SHOW_MATCHED_BRACKET("show_matched_bracket_popup", "text_viewer.show_matched_bracket_popup", true, t -> t::showMatchedBracketPopup),
     // Whether to emulated tabs with spaces
-    TABS_EMULATED("tabs_emulated", "text_viewer.tabs_emulated", true,
-            (textEditorImpl, aBoolean) -> textEditorImpl.tabsEmulated(aBoolean), EditorViewerMode.EDITOR),
+    TABS_EMULATED("tabs_emulated", "text_viewer.tabs_emulated", true, t -> t::tabsEmulated, EditorViewerMode.EDITOR),
     // Whether to show whitespace chars
-    WHITESPACE_VISIBLE("whitespace_visible", "text_viewer.whitespace_visible", false,
-            (textEditorImpl, aBoolean) -> textEditorImpl.whitespaceVisible(aBoolean)),
+    WHITESPACE_VISIBLE("whitespace_visible", "text_viewer.whitespace_visible", false, t -> t::whitespaceVisible),
 
     ; // end of prefs (syntax sugar aka developer vanity marker)
 
@@ -97,26 +78,26 @@ enum TextViewerPreferences {
 
     String prefKey;
     String i18nKey;
-    boolean currentValue;
+    boolean value;
     EditorViewerMode mode;
 
-    BiConsumer<TextEditorImpl, Boolean> textEditorSetter;
+    Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter;
 
     TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue) {
         this(prefKey, i18nKey, defaultValue, null, EditorViewerMode.BOTH);
     }
 
     TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue,
-                          BiConsumer<TextEditorImpl, Boolean> textEditorSetter) {
+            Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter) {
         this(prefKey, i18nKey, defaultValue, textEditorSetter, EditorViewerMode.BOTH);
     }
 
     TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue,
-                          BiConsumer<TextEditorImpl, Boolean> textEditorSetter, EditorViewerMode mode) {
+            Function<TextEditorImpl, Consumer<Boolean>> textEditorSetter, EditorViewerMode mode) {
         this.prefKey = prefKey;
         this.i18nKey = i18nKey;
         this.textEditorSetter = textEditorSetter;
-        this.currentValue = defaultValue;
+        this.value = defaultValue;
         this.mode = mode;
     }
 
@@ -129,16 +110,16 @@ enum TextViewerPreferences {
     }
 
     public boolean getValue() {
-        return currentValue;
+        return value;
     }
 
     public void setValue(boolean value) {
-        currentValue = value;
+        this.value = value;
     }
 
     public void setValue(TextEditorImpl editorImpl, boolean value) {
         if (textEditorSetter != null) {
-            textEditorSetter.accept(editorImpl, value);
+            textEditorSetter.apply(editorImpl).accept(value);
         }
         setValue(value);
     }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
@@ -16,11 +16,8 @@
  */
 package com.mucommander.viewer.text;
 
-import com.mucommander.snapshot.MuSnapshot;
-
 import java.util.function.BiConsumer;
 
-import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
 /**
  * TextEditor preferences gluing visual aspects (like i18n, source of menu generation),
@@ -93,11 +90,6 @@ enum TextViewerPreferences {
 
     ; // end of prefs (syntax sugar aka developer vanity marker)
 
-    /**
-     * Section describing information specific to text file presenter.
-     */
-    public static final String TEXT_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "text";
-
     enum EditorViewerMode {
         BOTH,
         EDITOR
@@ -121,11 +113,10 @@ enum TextViewerPreferences {
 
     TextViewerPreferences(String prefKey, String i18nKey, boolean defaultValue,
                           BiConsumer<TextEditorImpl, Boolean> textEditorSetter, EditorViewerMode mode) {
-        this.prefKey = prefKey != null ? TEXT_FILE_PRESENTER_SECTION + "." + prefKey : null;
+        this.prefKey = prefKey;
         this.i18nKey = i18nKey;
         this.textEditorSetter = textEditorSetter;
-        this.currentValue = prefKey != null ?
-                MuSnapshot.getSnapshot().getVariable(this.prefKey, defaultValue) : false;
+        this.currentValue = defaultValue;
         this.mode = mode;
     }
 

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerPreferences.java
@@ -21,6 +21,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * TextEditor preferences gluing visual aspects (like i18n, source of menu generation),
@@ -128,6 +131,8 @@ enum TextViewerPreferences {
             value = metadata.value();
         } catch (NoSuchFieldException | SecurityException e) {
             // ignore, the properties are initialized with the annotation's default values
+            Logger LOGGER = LoggerFactory.getLogger(TextViewerPreferences.class);
+            LOGGER.trace("Failed to parse metadata of " + name(), e);
         }
     }
 
@@ -158,6 +163,5 @@ enum TextViewerPreferences {
         return textEditorSetter != null;
     }
 
-    public boolean isEditorOnly() { return mode == EditorViewerMode.EDITOR; };
-
+    public boolean isEditorOnly() { return mode == EditorViewerMode.EDITOR; }
 }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
@@ -16,7 +16,13 @@
  */
 package com.mucommander.viewer.text;
 
+import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.mucommander.commons.conf.Configuration;
+import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
@@ -25,12 +31,32 @@ import com.mucommander.snapshot.MuSnapshotable;
  * @author Miroslav Hajda, Piotr Skowronek
  */
 public final class TextViewerSnapshot implements MuSnapshotable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TextViewerSnapshot.class);
+
+    /**
+     * Section describing information specific to text file presenter.
+     */
+    public static final String TEXT_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "text";
+
+    @Override
+    public void read(Configuration configuration) {
+        LOGGER.info("Loading snapshot configuration for " + TextViewerPreferences.class);
+        for (var pref : TextViewerPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = TEXT_FILE_PRESENTER_SECTION + "." + prefKey;
+                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
+            }
+        }
+    }
 
     @Override
     public void write(Configuration configuration) {
-        for (TextViewerPreferences pref : TextViewerPreferences.values()) {
-            if (pref.getPrefKey() != null) {
-                configuration.setVariable(pref.getPrefKey(), pref.getValue());
+        for (var pref : TextViewerPreferences.values()) {
+            var prefKey = pref.getPrefKey();
+            if (prefKey != null) {
+                prefKey = TEXT_FILE_PRESENTER_SECTION + "." + prefKey;
+                configuration.setVariable(prefKey, pref.getValue());
             }
         }
     }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextViewerSnapshot.java
@@ -18,46 +18,23 @@ package com.mucommander.viewer.text;
 
 import static com.mucommander.snapshot.MuSnapshot.FILE_PRESENTER_SECTION;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.mucommander.commons.conf.Configuration;
-import com.mucommander.snapshot.MuSnapshot;
 import com.mucommander.snapshot.MuSnapshotable;
 
 /**
  * Snapshot preferences for text editor & viewer.
  *
- * @author Miroslav Hajda, Piotr Skowronek
+ * @author Miroslav Hajda, Piotr Skowronek, Arik Hadas
  */
-public final class TextViewerSnapshot implements MuSnapshotable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TextViewerSnapshot.class);
-
+public final class TextViewerSnapshot extends MuSnapshotable<TextViewerPreferences> {
     /**
      * Section describing information specific to text file presenter.
      */
     public static final String TEXT_FILE_PRESENTER_SECTION = FILE_PRESENTER_SECTION + "." + "text";
 
-    @Override
-    public void read(Configuration configuration) {
-        LOGGER.info("Loading snapshot configuration for " + TextViewerPreferences.class);
-        for (var pref : TextViewerPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = TEXT_FILE_PRESENTER_SECTION + "." + prefKey;
-                pref.setValue(MuSnapshot.getSnapshot().getVariable(prefKey, pref.getValue()));
-            }
-        }
-    }
-
-    @Override
-    public void write(Configuration configuration) {
-        for (var pref : TextViewerPreferences.values()) {
-            var prefKey = pref.getPrefKey();
-            if (prefKey != null) {
-                prefKey = TEXT_FILE_PRESENTER_SECTION + "." + prefKey;
-                configuration.setVariable(prefKey, pref.getValue());
-            }
-        }
+    TextViewerSnapshot() {
+        super(TextViewerPreferences::values,
+                pref -> Boolean.toString(pref.getValue()),
+                (pref, value) -> pref.setValue(Boolean.parseBoolean(value)),
+                pref -> pref.getPrefKey() != null ? TEXT_FILE_PRESENTER_SECTION + "." + pref.getPrefKey() : null);
     }
 }


### PR DESCRIPTION
Previously, with lazy loading, snapshot properties could have been dropped in the following flow:
1. Update a snapshot configuration
2. Quit the application so the snapshot configuration would be persisted to snapshot.xml
3. Start the application
4. Close the application
5. Start the application
6. The snapshot configuration was reverted to its default value

The reason why the snapshot configuration was removed is because it wasn't loaded between step 3 and step 4 and therefore when closing the application, we cleared the snapshot configuration that is going to be persisted (in order to get rid of properties that were dropped) and then, when updating the snapshot configuration, we didn't get updated value of the snapshot configuration from step 1.

The solution is to override the `read` method of `MuSnapshotable` to make sure the snapshot configuration are loaded on startup.