### PR TITLE
Support multi volume rar files

### DIFF
--- a/sevenzipjbindings/src/main/java/com/mucommander/sevenzipjbindings/multivolume/InArchiveWrapper.java
+++ b/sevenzipjbindings/src/main/java/com/mucommander/sevenzipjbindings/multivolume/InArchiveWrapper.java
@@ -1,0 +1,141 @@
+package com.mucommander.sevenzipjbindings.multivolume;
+
+import net.sf.sevenzipjbinding.*;
+import net.sf.sevenzipjbinding.simple.ISimpleInArchive;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+
+public class InArchiveWrapper implements IInArchive {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InArchiveWrapper.class);
+
+    private final IInArchive archive;
+
+    private final Closeable[] closeables;
+
+    public InArchiveWrapper(IInArchive archive, Closeable... closeables) {
+        this.archive = archive;
+        this.closeables = closeables;
+    }
+
+    @Override
+    public int getNumberOfItems() throws SevenZipException {
+        return getMainArchive().getNumberOfItems();
+    }
+
+    @Override
+    public Object getProperty(int index, PropID propID) throws SevenZipException {
+        return getMainArchive().getProperty(index, propID);
+    }
+
+    @Override
+    public String getStringProperty(int index, PropID propID) throws SevenZipException {
+        return getMainArchive().getStringProperty(index, propID);
+    }
+
+    @Override
+    public void extract(int[] indices, boolean testMode, IArchiveExtractCallback extractCallback) throws SevenZipException {
+        getMainArchive().extract(indices, testMode, extractCallback);
+    }
+
+    @Override
+    public ExtractOperationResult extractSlow(int index, ISequentialOutStream outStream) throws SevenZipException {
+        return getMainArchive().extractSlow(index, outStream);
+    }
+
+    @Override
+    public ExtractOperationResult extractSlow(int index, ISequentialOutStream outStream, String password) throws SevenZipException {
+        return getMainArchive().extractSlow(index, outStream, password);
+    }
+
+    @Override
+    public Object getArchiveProperty(PropID propID) throws SevenZipException {
+        return getMainArchive().getArchiveProperty(propID);
+    }
+
+    @Override
+    public String getStringArchiveProperty(PropID propID) throws SevenZipException {
+        return getMainArchive().getStringArchiveProperty(propID);
+    }
+
+    @Override
+    public int getNumberOfProperties() throws SevenZipException {
+        return getMainArchive().getNumberOfProperties();
+    }
+
+    @Override
+    public PropertyInfo getPropertyInfo(int index) throws SevenZipException {
+        return getMainArchive().getPropertyInfo(index);
+    }
+
+    @Override
+    public int getNumberOfArchiveProperties() throws SevenZipException {
+        return getMainArchive().getNumberOfArchiveProperties();
+    }
+
+    @Override
+    public PropertyInfo getArchivePropertyInfo(int index) throws SevenZipException {
+        return getMainArchive().getArchivePropertyInfo(index);
+    }
+
+    @Override
+    public ISimpleInArchive getSimpleInterface() {
+        return getMainArchive().getSimpleInterface();
+    }
+
+    @Override
+    public ArchiveFormat getArchiveFormat() {
+        return getMainArchive().getArchiveFormat();
+    }
+
+    @Override
+    public IOutUpdateArchive<IOutItemAllFormats> getConnectedOutArchive() throws SevenZipException {
+        return getMainArchive().getConnectedOutArchive();
+    }
+
+    @Override
+    public IOutUpdateArchive7z getConnectedOutArchive7z() throws SevenZipException {
+        return getMainArchive().getConnectedOutArchive7z();
+    }
+
+    @Override
+    public IOutUpdateArchiveZip getConnectedOutArchiveZip() throws SevenZipException {
+        return getMainArchive().getConnectedOutArchiveZip();
+    }
+
+    @Override
+    public IOutUpdateArchiveTar getConnectedOutArchiveTar() throws SevenZipException {
+        return getMainArchive().getConnectedOutArchiveTar();
+    }
+
+    @Override
+    public IOutUpdateArchiveGZip getConnectedOutArchiveGZip() throws SevenZipException {
+        return getMainArchive().getConnectedOutArchiveGZip();
+    }
+
+    @Override
+    public IOutUpdateArchiveBZip2 getConnectedOutArchiveBZip2() throws SevenZipException {
+        return getMainArchive().getConnectedOutArchiveBZip2();
+    }
+
+    @Override
+    public void close() throws SevenZipException {
+        getMainArchive().close();
+        if (closeables != null) {
+            for (Closeable c : closeables) {
+                try {
+                    c.close();
+                } catch (Exception e) {
+                    LOGGER.warn("Error closing: {}", c, e);
+                }
+            }
+        }
+
+    }
+
+    private IInArchive getMainArchive() {
+        return archive;
+    }
+}

--- a/sevenzipjbindings/src/main/java/com/mucommander/sevenzipjbindings/multivolume/SevenZipRarMultiVolumeCallbackHandler.java
+++ b/sevenzipjbindings/src/main/java/com/mucommander/sevenzipjbindings/multivolume/SevenZipRarMultiVolumeCallbackHandler.java
@@ -1,0 +1,91 @@
+package com.mucommander.sevenzipjbindings.multivolume;
+
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.commons.file.FileFactory;
+import com.mucommander.commons.file.FileURL;
+import com.mucommander.sevenzipjbindings.SignatureCheckedRandomAccessFile;
+import net.sf.sevenzipjbinding.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SevenZipRarMultiVolumeCallbackHandler implements
+        IArchiveOpenVolumeCallback, IArchiveOpenCallback, ICryptoGetTextPassword, Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SevenZipRarMultiVolumeCallbackHandler.class);
+
+    private Map<String, SignatureCheckedRandomAccessFile> fileCache = new HashMap<>();
+
+    private String lastFileName;
+
+    private final byte[] signature;
+
+    private final String password;
+
+    public SevenZipRarMultiVolumeCallbackHandler(byte[] signature, String password) {
+        this.signature = signature;
+        this.password = password;
+    }
+
+    @Override
+    public void setTotal(Long files, Long bytes) throws SevenZipException {
+        // NO-OP
+    }
+
+    @Override
+    public void setCompleted(Long files, Long bytes) throws SevenZipException {
+        // NO-OP
+    }
+
+    @Override
+    public Object getProperty(PropID propID) throws SevenZipException {
+        switch (propID) {
+            case NAME:
+                return lastFileName;
+        }
+        return null;
+    }
+
+    @Override
+    public IInStream getStream(String filename) throws SevenZipException {
+        try {
+            SignatureCheckedRandomAccessFile stream = fileCache.get(filename);
+            if (stream != null) {
+                stream.seek(0, ISeekableStream.SEEK_SET);
+            } else {
+                AbstractFile abstractFile = FileFactory.getFile(filename);
+                stream = new SignatureCheckedRandomAccessFile(abstractFile, signature);
+                fileCache.put(filename, stream);
+            }
+
+            lastFileName = filename;
+            return stream;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String cryptoGetTextPassword() throws SevenZipException {
+        if (password == null) {
+            throw new SevenZipException("No password was provided for opening protected archive.");
+        }
+        return password;
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (SignatureCheckedRandomAccessFile f : fileCache.values()) {
+            try {
+                f.close();
+            } catch (Exception e) {
+                LOGGER.error("Error closing SignatureCheckedRandomAccessFile", e);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Hi @ahadas!

I'm creating this PR to discuss some of the challenges in implementing multi volume support. I'm starting with RAR file as the 7z implementation will be different.

Some points I'd like to get your thought on if possible:

1. I created `SevenZipRarMultiVolumeCallbackHandler` to handle multi volume archives and used a regular expression on the file name to detect when it's right to use it. This can be optimized by not compiling the pattern each time but keeping it as a field in the class. What do you think about that approach?
2. I wanted to make sure all volume streams are closed at the end of reading operation, so I created a wrapper class `InArchiveWrapper` that carries over the original `IInArchive` and the handler that references other volume streams.
3. I needed a way to create an `AbstractFile` without recursively calling `SevenZipRarMultiVolumeCallbackHandler::getStream`. I couldn't find a proper way to do it so I changed the modifier of `FileFactory::createRawFile` to `public`. I guess that's not ideal so I'm open to other suggestions (I wanted to reuse the existing `SignatureCheckedRandomAccessFile` class)

Here is a [reference](https://sevenzipjbind.sourceforge.net/extraction_snippets.html#open-multipart-rar-archives) from `sevenzipjbind`'s docs about opening multi volume archives.

Using the code in this PR, I was able to extract a multi-volume RAR archive successfully.

Thanks very much :)