### PR TITLE
Improvements to shortcuts preferences tab

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/ActionProperties.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/ActionProperties.java
@@ -34,17 +34,17 @@ import java.util.*;
 public class ActionProperties {
 	
 	/* Maps action id -> action descriptor */
-	private static Map<String, ActionDescriptor> actionDescriptors = new Hashtable<String, ActionDescriptor>();
+	private static Map<String, ActionDescriptor> actionDescriptors = new Hashtable<>();
 
 	private static ActionDescriptor nullActionDescriptor = new NullActionDescriptor();
 	
 	/* Contains all used action categories (i.e for each category at least one action is registered) */
-	private static TreeSet<ActionCategory> ActionCategory = new TreeSet<ActionCategory>();
+	private static TreeSet<ActionCategory> nonEmptyActionCategories = new TreeSet<>();
 
 	/* Maps action id -> primary shortcut */
-	private static HashMap<String, KeyStroke> defaultPrimaryActionKeymap = new HashMap<String, KeyStroke>();
+	private static HashMap<String, KeyStroke> defaultPrimaryActionKeymap = new HashMap<>();
 	/* Maps action id -> alternative shortcut */
-	private static HashMap<String, KeyStroke> defaultAlternateActionKeymap = new HashMap<String, KeyStroke>();
+	private static HashMap<String, KeyStroke> defaultAlternateActionKeymap = new HashMap<>();
 	/* Maps shortcut -> action id */
 	private static AcceleratorMap defaultAcceleratorMap = new AcceleratorMap();
 	
@@ -62,7 +62,7 @@ public class ActionProperties {
 		// Add the category in the descriptor to the categories pool
 		ActionCategory category = actionDescriptor.getCategory();
 		if (category != null)
-			ActionCategory.add(category);
+		    nonEmptyActionCategories.add(category);
 		
 		// Add the shortcuts in the descriptor to the default keymap
 		KeyStroke defaultActionKeyStroke = actionDescriptor.getDefaultKeyStroke();
@@ -218,15 +218,15 @@ public class ActionProperties {
     }
 
 	/**
-	 * Getter for all existed categories.
-	 * Existed category means an actions category which at least one of its actions is registered.
+	 * Getter for all non-empty categories.
+	 * Non-empty category means an actions category which at least one of its actions is registered.
 	 * 
 	 * The categories are ordered based on the alphabet order of their descriptions (labels).
 	 * 
 	 * @return Set of existed action categories.
 	 */
-	public static Set<ActionCategory> getActionCategory() {
-		return ActionCategory;
+	public static Set<ActionCategory> getNonEmptyActionCategories() {
+		return nonEmptyActionCategories;
 	}
 	
 	private static ActionDescriptor getNullSafeActionDescriptor(String actionId) {

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/help/ShortcutsDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/help/ShortcutsDialog.java
@@ -114,10 +114,10 @@ public class ShortcutsDialog extends FocusDialog implements ActionListener {
 
     private Map<ActionCategory, LinkedList<String>> createCategoryToItsActionsWithShortcutsMap() {
         // Hashtable that maps actions-category to LinkedList of actions (Ids) from the category that have shortcuts assigned to them
-        Hashtable<ActionCategory, LinkedList<String>> categoryToItsActionsWithShortcutsIdsMap = new Hashtable<ActionCategory, LinkedList<String>>();
+        Hashtable<ActionCategory, LinkedList<String>> categoryToItsActionsWithShortcutsIdsMap = new Hashtable<>();
 
         // Initialize empty LinkedList for each category
-        for(ActionCategory category : ActionProperties.getActionCategory())
+        for (ActionCategory category : ActionProperties.getNonEmptyActionCategories())
             categoryToItsActionsWithShortcutsIdsMap.put(category, new LinkedList<String>());
 
         // Go over all action ids

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsPanel.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsPanel.java
@@ -190,7 +190,7 @@ public class ShortcutsPanel extends PreferencesPanel {
 
         final JComboBox<ActionCategory> combo = new JComboBox<>();
         combo.addItem(ActionCategory.ALL);
-        for(ActionCategory category : ActionProperties.getActionCategory())
+        for(ActionCategory category : ActionProperties.getNonEmptyActionCategories())
             combo.addItem(category);
 
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsPanel.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsPanel.java
@@ -27,6 +27,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.util.Arrays;
+import java.util.Comparator;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -190,9 +191,7 @@ public class ShortcutsPanel extends PreferencesPanel {
 
         final JComboBox<ActionCategory> combo = new JComboBox<>();
         combo.addItem(ActionCategory.ALL);
-        for(ActionCategory category : ActionProperties.getNonEmptyActionCategories())
-            combo.addItem(category);
-
+        ActionProperties.getNonEmptyActionCategories().stream().sorted(Comparator.comparing(ActionCategory::toString)).forEach(combo::addItem);
 
         final ActionListener filterActionListener = new ActionListener() {
             @Override

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsTable.java
@@ -125,6 +125,7 @@ public class ShortcutsTable extends PrefTable implements KeyListener, ListSelect
     public static final int ACTION_DESCRIPTION_COLUMN_INDEX = 0;
     public static final int ACCELERATOR_COLUMN_INDEX = 1;
     public static final int ALTERNATE_ACCELERATOR_COLUMN_INDEX = 2;
+    public static final int ACTION_TOOLTIP_COLUMN_INDEX = 3;
 
     /** Number of columns in the table */
     private static final int NUM_OF_COLUMNS = 3;
@@ -687,6 +688,9 @@ public class ShortcutsTable extends PrefTable implements KeyListener, ListSelect
                 case ALTERNATE_ACCELERATOR_COLUMN_INDEX:
                     final KeyStroke key = (KeyStroke) colValue;
                     rowTextValue = key == null ? "" : KeyStrokeUtils.getKeyStrokeDisplayableRepresentation(key);
+                    break;
+                case ACTION_TOOLTIP_COLUMN_INDEX:
+                    rowTextValue = (String) colValue;
                     break;
                 }
                 rowText.append(" ");

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/ShortcutsTable.java
@@ -531,7 +531,7 @@ public class ShortcutsTable extends PrefTable implements KeyListener, ListSelect
             Collections.sort(allActionIds, ACTIONS_COMPARATOR);
 
             final int nbActions = allActionIds.size();
-            db = new HashMap<String, HashMap<Integer, Object>>(nbActions);
+            db = new HashMap<>(nbActions);
 
             int nbRows = allActionIds.size();
             data = new Object[nbRows][NUM_OF_COLUMNS];

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -41,6 +41,7 @@ New features:
 Improvements:
 - When sorting a file table by filenames, the sort operation performs a locale-sensitive String comparison.
 - When opening a result of a file search with text search using the internal viewer/editor, the caret is set on the first occurrence of the searched text.
+- The action categoties that are displayed in the shortcuts preferences tab are sorted by their name.
 
 Localization:
 -

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -42,6 +42,7 @@ Improvements:
 - When sorting a file table by filenames, the sort operation performs a locale-sensitive String comparison.
 - When opening a result of a file search with text search using the internal viewer/editor, the caret is set on the first occurrence of the searched text.
 - The action categoties that are displayed in the shortcuts preferences tab are sorted by their name.
+- The row-filtering in the shortucts preferences tab now matches the specified input also against the tooltip of the row (the action's description).
 
 Localization:
 -


### PR DESCRIPTION
- The row-filtering also matches against the row's tooltip, which is set to the action description.
- The action categories in the combo-box are sorted by their name.
- Code cleanup