### PR TITLE
Bumped JediTerm to the newest version to address problem with decomposed chars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,11 +117,11 @@ dependencies {
 }
 
 createBundlesDir.doLast {
-   ant.move file: "${buildDir}/osgi/bundle/${project('mucommander-core').jar.archiveName}",
+   ant.move file: "${buildDir}/osgi/bundle/${project('mucommander-core').jar.archiveFileName.get()}",
             todir: "${buildDir}/osgi/app"
    copy {
        from "build/libs"
-       include project(':').jar.archiveName
+       include project(':').jar.archiveFileName.get()
        into "${buildDir}/osgi"
    }
    copy {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jetbrains-jediterm/build.gradle
+++ b/jetbrains-jediterm/build.gradle
@@ -7,22 +7,24 @@ repositories {
 
 dependencies {
     // The following libs are required by JediTerm.
-    // Since, I haven't found any repo where they are published,
-    // so they have been built from sources (https://github.com/JetBrains/jediterm, c21a2b27629dd3760c603edeb258f9a862e75d34)
-    // and placed directly into muC.
     implementation 'org.checkerframework:checker-qual:3.24.0'
 
-    comprise 'com.google.guava:guava:31.1-jre'
+    comprise 'org.jetbrains.jediterm:jediterm-core:3.17'
+    comprise 'org.jetbrains.jediterm:jediterm-core-pty:3.0'
     comprise 'org.jetbrains.jediterm:jediterm-typeahead:2.69'
-    comprise 'org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10'
-    implementation 'org.jetbrains:annotations:23.0.0'
-    comprise 'net.java.dev.jna:jna:5.10.0'
+    comprise 'org.jetbrains.jediterm:jediterm-ui:3.17'
     comprise 'org.jetbrains.pty4j:pty4j:0.12.3'
-    comprise 'net.java.dev.jna:jna-platform:5.10.0'
     comprise 'org.jetbrains.pty4j:purejavacomm:0.0.11.1'
+
+    implementation 'org.jetbrains:annotations:23.0.0'
     runtimeOnly 'org.jetbrains.intellij.deps:trove4j:1.0.20200330'
-    comprise 'org.jetbrains.jediterm:jediterm-pty:2.69'
     comprise 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10'
+    comprise 'org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10'
+
+    comprise 'com.google.guava:guava:31.1-jre'
+    comprise 'net.java.dev.jna:jna:5.10.0'
+    comprise 'net.java.dev.jna:jna-platform:5.10.0'
+
     implementation 'log4j:log4j:1.2.17'
 }
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -51,6 +51,7 @@ Localization:
 Bug fixes:
 - Fixed connection to SFTP servers using a private key.
 - The terminal accepts input that wasn't accepted before from German keyboard when disabling the setting 'Use Option as Meta key in Terminal'.
+- The terminal now properly displays diacritics when in a form of decomposed characters.
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
Bumped JediTerm to the newest version to address the problem with decomposed characters #940

This required bumping the version of Gradle to 8.1.1 since JediTerm jars are now built with Java 20.

