### PR TITLE
Terminal - fix for themes switching, Menlo font added as default for Terminal

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/theme/SystemDefaultFont.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/theme/SystemDefaultFont.java
@@ -77,7 +77,7 @@ public class SystemDefaultFont extends DefaultFont implements PropertyChangeList
         if(font == null)
             // ... try to retrieve it from the UIManager.
             if((font = UIManager.getFont(property)) == null)
-                // If the current l&f didn't set the right propery, attempt to retrieve it from a component of the
+                // If the current l&f didn't set the right properly, attempt to retrieve it from a component of the
                 // desired type.
                 if((font = mapper.getComponent().getFont()) == null)
                     // If that failed, defaults to SansSerif (guaranteed to be supported by the VM).

--- a/mucommander-core/src/main/java/com/mucommander/ui/theme/SystemDefaultFont.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/theme/SystemDefaultFont.java
@@ -77,7 +77,7 @@ public class SystemDefaultFont extends DefaultFont implements PropertyChangeList
         if(font == null)
             // ... try to retrieve it from the UIManager.
             if((font = UIManager.getFont(property)) == null)
-                // If the current l&f didn't set the right properly, attempt to retrieve it from a component of the
+                // If the current l&f didn't set the right property, attempt to retrieve it from a component of the
                 // desired type.
                 if((font = mapper.getComponent().getFont()) == null)
                     // If that failed, defaults to SansSerif (guaranteed to be supported by the VM).

--- a/mucommander-core/src/main/java/com/mucommander/ui/theme/ThemeData.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/theme/ThemeData.java
@@ -1233,7 +1233,7 @@ public class ThemeData {
         DefaultColor defaultColor = COLORS.get(Integer.valueOf(id));
         if (defaultColor == null) {
             // see the first comment for this class
-            LOGGER.debug("Default color for id {} not found, using generic default");
+            LOGGER.debug("Default color for id {} not found, using a generic default", id);
             return Color.LIGHT_GRAY;
         }
 
@@ -1256,7 +1256,7 @@ public class ThemeData {
         DefaultFont defaultFont = FONTS.get(Integer.valueOf(id));
         if (defaultFont == null) {
             // see the first comment for this class
-            LOGGER.debug("Default font for id {} not found, using generic default");
+            LOGGER.debug("Default font for id {} not found, using a generic default", id);
             return Font.decode("SansSerif");
         }
         return defaultFont.getFont(data);

--- a/mucommander-core/src/main/java/com/mucommander/ui/theme/ThemeData.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/theme/ThemeData.java
@@ -17,6 +17,9 @@
 
  package com.mucommander.ui.theme;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.Color;
 import java.awt.Font;
 import java.util.Hashtable;
@@ -76,6 +79,11 @@ public class ThemeData {
     // For this reason, we've declared the number of font and colors as constants.
     // People are still going to forget to update these constants, but at least it'll be
     // a lot easier to fix.
+    //
+    // And if some font or color is not needed anymore then one must decrease all the indexes?
+    // TODO refactor this, get rid of indexes, arrays....
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThemeData.class);
 
     /**
      * Number of known fonts.
@@ -1222,7 +1230,14 @@ public class ThemeData {
         // Makes sure id is a legal color identifier.
         checkColorIdentifier(id);
 
-        return COLORS.get(Integer.valueOf(id)).getColor(data);
+        DefaultColor defaultColor = COLORS.get(Integer.valueOf(id));
+        if (defaultColor == null) {
+            // see the first comment for this class
+            LOGGER.debug("Default color for id {} not found, using generic default");
+            return Color.LIGHT_GRAY;
+        }
+
+        return defaultColor.getColor(data);
     }
 
     /**
@@ -1238,8 +1253,13 @@ public class ThemeData {
      */
     private static Font getDefaultFont(int id, ThemeData data) {
         checkFontIdentifier(id);
-
-        return FONTS.get(Integer.valueOf(id)).getFont(data);
+        DefaultFont defaultFont = FONTS.get(Integer.valueOf(id));
+        if (defaultFont == null) {
+            // see the first comment for this class
+            LOGGER.debug("Default font for id {} not found, using generic default");
+            return Font.decode("SansSerif");
+        }
+        return defaultFont.getFont(data);
     }
 
 

--- a/mucommander-core/src/main/resources/themes/ClassicCommander.xml
+++ b/mucommander-core/src/main/resources/themes/ClassicCommander.xml
@@ -135,7 +135,7 @@
   <!-- = Shell appearance ============================== -->
   <!-- ================================================= -->
   <shell>
-    <font family="Monospaced,Lucida Sans Typewriter" size ="12" bold="true"/>
+    <font family="Menlo,Monospaced,Lucida Sans Typewriter" size ="12"/>
 
     <!-- = Default appearance ========================== -->
     <!-- =============================================== -->
@@ -151,28 +151,6 @@
       <background color="3875d7"/>
     </selected>
   </shell>
-
-
-
-  <!-- = Shell history appearance ====================== -->
-  <!-- ================================================= -->
-  <shell_history>
-    <font family="Lucida Grande,Tahoma,Lucida Sans" size ="12"/>
-
-    <!-- = Default appearance ========================== -->
-    <!-- =============================================== -->
-    <normal>
-      <foreground color="000000"/>
-      <background color="ffffff"/>
-    </normal>
-
-    <!-- = Selected appearance ========================= -->
-    <!-- =============================================== -->
-    <selected>
-      <foreground color="ffffff"/>
-      <background color="3875d7"/>
-    </selected>
-  </shell_history>
 
 
 

--- a/mucommander-core/src/main/resources/themes/Native.xml
+++ b/mucommander-core/src/main/resources/themes/Native.xml
@@ -7,4 +7,15 @@
 <!-- look&feel.                                          -->
 <!-- =================================================== -->
 <theme>
+
+  <!-- = Shell appearance ============================== -->
+  <!-- ================================================= -->
+  <shell>
+    <font family="Menlo,Monospaced,Lucida Sans Typewriter" size ="12"/>
+    <normal>
+    </normal>
+    <selected>
+    </selected>
+  </shell>
+
 </theme>

--- a/mucommander-core/src/main/resources/themes/RetroCommander.xml
+++ b/mucommander-core/src/main/resources/themes/RetroCommander.xml
@@ -126,7 +126,7 @@
     <!-- = Shell appearance ============================== -->
     <!-- ================================================= -->
     <shell>
-        <font family="Monospaced,Lucida Sans Typewriter" size ="12" bold="true"/>
+        <font family="Menlo,Monospaced,Lucida Sans Typewriter" size ="12"/>
 
         <!-- = Default appearance ========================== -->
         <!-- =============================================== -->
@@ -142,28 +142,6 @@
             <foreground color="ffffff"/>
         </selected>
     </shell>
-
-
-
-    <!-- = Shell history appearance ====================== -->
-    <!-- ================================================= -->
-    <shell_history>
-        <font size="13" family="Lucida Grande,Arial,Lucida Sans"/>
-
-        <!-- = Default appearance ========================== -->
-        <!-- =============================================== -->
-        <normal>
-            <background color="ffffff"/>
-            <foreground color="000000"/>
-        </normal>
-
-        <!-- = Selected appearance ========================= -->
-        <!-- =============================================== -->
-        <selected>
-            <background color="b4d5ff"/>
-            <foreground color="000000"/>
-        </selected>
-    </shell_history>
 
 
 

--- a/mucommander-core/src/main/resources/themes/SolarizedDark.xml
+++ b/mucommander-core/src/main/resources/themes/SolarizedDark.xml
@@ -67,17 +67,12 @@
         </file>
     </file_table>
     <shell>
+        <font family="Menlo,Monospaced,Lucida Sans Typewriter" size ="12"/>
         <normal>
         </normal>
         <selected>
         </selected>
     </shell>
-    <shell_history>
-        <normal>
-        </normal>
-        <selected>
-        </selected>
-    </shell_history>
     <editor>
         <normal>
         </normal>

--- a/mucommander-core/src/main/resources/themes/SolarizedLight.xml
+++ b/mucommander-core/src/main/resources/themes/SolarizedLight.xml
@@ -103,17 +103,12 @@
         </group10>
     </file_groups>
     <shell>
+        <font family="Menlo,Monospaced,Lucida Sans Typewriter" size ="12"/>
         <normal>
         </normal>
         <selected>
         </selected>
     </shell>
-    <shell_history>
-        <normal>
-        </normal>
-        <selected>
-        </selected>
-    </shell_history>
     <terminal>
         <normal>
         </normal>

--- a/mucommander-core/src/main/resources/themes/Striped.xml
+++ b/mucommander-core/src/main/resources/themes/Striped.xml
@@ -133,7 +133,7 @@
     <!-- = Shell appearance ============================== -->
     <!-- ================================================= -->
     <shell>
-        <font family="Monospaced,Lucida Sans Typewriter" size ="12" bold="true"/>
+        <font family="Monospaced,Lucida Sans Typewriter" size ="12"/>
 
         <!-- = Default appearance ========================== -->
         <!-- =============================================== -->
@@ -149,28 +149,6 @@
             <background color="3875d7"/>
         </selected>
     </shell>
-
-
-
-    <!-- = Shell history appearance ====================== -->
-    <!-- ================================================= -->
-    <shell_history>
-        <font family="Lucida Grande,Tahoma,Lucida Sans" size ="12"/>
-
-        <!-- = Default appearance ========================== -->
-        <!-- =============================================== -->
-        <normal>
-            <foreground color="000000"/>
-            <background color="ffffff"/>
-        </normal>
-
-        <!-- = Selected appearance ========================= -->
-        <!-- =============================================== -->
-        <selected>
-            <foreground color="ffffff"/>
-            <background color="3875d7"/>
-        </selected>
-    </shell_history>
 
 
 

--- a/mucommander-core/src/main/resources/themes/Striped.xml
+++ b/mucommander-core/src/main/resources/themes/Striped.xml
@@ -133,7 +133,7 @@
     <!-- = Shell appearance ============================== -->
     <!-- ================================================= -->
     <shell>
-        <font family="Monospaced,Lucida Sans Typewriter" size ="12"/>
+        <font family="Menlo,Monospaced,Lucida Sans Typewriter" size ="12"/>
 
         <!-- = Default appearance ========================== -->
         <!-- =============================================== -->

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -1,5 +1,5 @@
 
-	   _____                           _
+           _____                           _
  _____ _ _|     |___ _____ _____ ___ ___ _| |___ ___
 |     | | |   --| . |     |     | .'|   | . | -_|  _|
 |_|_|_|___|_____|___|_|_|_|_|_|_|__,|_|_|___|___|_| 
@@ -47,11 +47,12 @@ New features:
 Improvements:
 - When sorting a file table by filenames, the sort operation performs a locale-sensitive String comparison.
 - When opening a result of a file search with text search using the internal viewer/editor, the caret is set on the first occurrence of the searched text.
-- The action categoties that are displayed in the shortcuts preferences tab are sorted by their name.
-- The row-filtering in the shortucts preferences tab now matches the specified input also against the tooltip of the row (the action's description).
+- The action categories that are displayed in the shortcuts preferences tab are sorted by their name.
+- The row-filtering in the shortcuts preferences tab now matches the specified input also against the tooltip of the row (the action's description).
 - Theme preferences for Shell renamed to Terminal and now both the Terminal and Run Command dialog use configured colors and font.
 - Google Drive: file queries can return up to 1000 files (was 100).
 - Set the 'File version' property of the 'mucommander.exe' file to the application version.
+- Menlo font added as one of defaults for Terminal for all themes (even native ones).
 
 Localization:
 -
@@ -64,7 +65,7 @@ Bug fixes:
 
 Known issues:
 - Some translations may not be up-to-date.
-- SMB support may not work properly on non multi-language JRE.
+- SMB support may not work properly on non-multi-language JRE.
 - 'Copy files to clipboard' not working with some applications (files are not pasted).
 - Authentication issues when using several sets of credentials (login/password) for the same server.
 - Untrusted HTTPS connections are allowed without a warning.


### PR DESCRIPTION
1) fix for themes switching (regression after _Shell history_ removal - NPE in logs causing theme not being applied dynamically)
2) _Menlo_ font added as a default for Terminal for all themes (even native one, apparently on macOS font for TextArea.font (via UIManager) is Lucida grande that looks bad (and is not mono-spaced) - #976.

