### PR TITLE
Added version information to exe file - issue #719

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,13 @@ launch4j {
     icon = "$projectDir/package/windows/mucommander.ico"
     mainClassName = "com.mucommander.main.muCommander"
     jar = "${project.tasks.jar.archiveFileName.get()}"
+    productName = "muCommander"
+    companyName = "Arik Hadas"
+    version = project.version
+    textVersion = project.version
+    copyright = "Arik Hadas"
+    fileDescription = "a lightweight, cross-platform file manager"
+
     dontWrapJar = true
     classpath = ['.']
     headerType = "gui"


### PR DESCRIPTION
Or recommend more fitting values. Result information from mucommander.exe:
```
1 VERSIONINFO
FILEVERSION 1,3,0,0
PRODUCTVERSION 1,3,0,0
FILEOS 0x40000
FILETYPE 0x1
{
BLOCK "StringFileInfo"
{
	BLOCK "040904E4"
	{
		VALUE "CompanyName", "Arik Hadas"
		VALUE "FileDescription", "a lightweight, cross-platform file manager"
		VALUE "FileVersion", "1.3.0"
		VALUE "InternalName", "mucommander"
		VALUE "LegalCopyright", "Arik Hadas"
		VALUE "LegalTrademarks", ""
		VALUE "OriginalFilename", "mucommander.exe"
		VALUE "ProductName", "muCommander"
		VALUE "ProductVersion", "1.3.0"
	}
}

BLOCK "VarFileInfo"
{
	VALUE "Translation", 0x0409 0x04E4  
}
}

```