### PR TITLE
Viewer/Editor Fix for NPE when opening certain python files

### DIFF
--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
@@ -450,7 +450,15 @@ class TextEditorImpl implements ThemeListener {
     public void setSyntaxStyle(AbstractFile file) {
         String mimeType = FileTypeUtil.get().guessContentType(
                 new File(file.getCanonicalPath()), true);
-        textArea.setSyntaxEditingStyle(mimeType);
+
+        // TODO temporary fix with try/catch to address: https://github.com/mucommander/mucommander/issues/983, https://github.com/bobbylight/RSyntaxTextArea/issues/514
+        try {
+            textArea.setSyntaxEditingStyle(mimeType);
+        } catch (Exception e) {
+            LOGGER.error("Exception while trying to set syntax editing style - retrying with code folding disabled", e);
+            textArea.setCodeFoldingEnabled(false);
+            textArea.setSyntaxEditingStyle(mimeType);
+        }
         if (syntaxChangeListener != null) {
             syntaxChangeListener.accept(mimeType);
         }


### PR DESCRIPTION
Viewer/Editor Fix for NPE when opening certain python files while code folding is enabled #983