### PR TITLE
Editor/Viewer Bumped verion of RSyntaxTextArea and removed workaround code

### DIFF
--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api project(":mucommander-preferences")
 
     compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
-    comprise group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.3.3'
+    comprise group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.3.4'
 
     testImplementation 'org.testng:testng:6.11'
 }

--- a/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
+++ b/mucommander-viewer-text/src/main/java/com/mucommander/viewer/text/TextEditorImpl.java
@@ -451,14 +451,7 @@ class TextEditorImpl implements ThemeListener {
         String mimeType = FileTypeUtil.get().guessContentType(
                 new File(file.getCanonicalPath()), true);
 
-        // TODO temporary fix with try/catch to address: https://github.com/mucommander/mucommander/issues/983, https://github.com/bobbylight/RSyntaxTextArea/issues/514
-        try {
-            textArea.setSyntaxEditingStyle(mimeType);
-        } catch (Exception e) {
-            LOGGER.error("Exception while trying to set syntax editing style - retrying with code folding disabled", e);
-            textArea.setCodeFoldingEnabled(false);
-            textArea.setSyntaxEditingStyle(mimeType);
-        }
+        textArea.setSyntaxEditingStyle(mimeType);
         if (syntaxChangeListener != null) {
             syntaxChangeListener.accept(mimeType);
         }


### PR DESCRIPTION
PR bumping version RSyntaxTextArea to the newest as it contains fix for #983 (https://github.com/bobbylight/RSyntaxTextArea/issues/514#issuecomment-1654835403). In PR I've also removed try/catch workaround.

