### PR TITLE
Updated bug_report.yml to encourage ppl for searching similar bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,14 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+    id: exisitng-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please [search](https://github.com/mucommander/mucommander/issues?q=) to see if an issue already exists for the bug you encountered, including the closed ones.
+      options:
+      - label: I have searched the existing issues (including the closed ones)
+        required: true
   - type: textarea
     id: what-happend
     attributes:


### PR DESCRIPTION
Updated bug_report.yml to encourage ppl for searching similar bugs (like for crashes on Ventura :) ).

I haven't tested this change, however I followed github docs regarding `checkboxes` ([see](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)).