### PR TITLE
fix(docs): Correct grammar errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Official website: https://www.mucommander.com
 There are several ways to contribute to muCommander:  
 
 - Found a bug or thinking about a useful feature that is missing? [File an issue](https://github.com/mucommander/mucommander/issues)
-- Want to fix a bug or implement a feature? We are using the standard [GitHub flow](https://guides.github.com/introduction/flow/): fork, make the changes and submit a pull request. Changes are merged to the *master* branch. See the next section for tips for developing muCommander.
-- If you happen to speak a language that muCommander is not available in or able to improve existing tranlations, you can help translate the interface using the [zanata platform](https://translate.zanata.org/project/view/mucommander).  
+- Want to fix a bug or implement a feature? We are using the standard [GitHub flow](https://guides.github.com/introduction/flow/): fork, make the changes, and submit a pull request. Changes are merged to the *master* branch. See the next section for tips for developing muCommander.
+- If you happen to speak a language that muCommander is not available in or able to improve existing translations, you can help translate the interface using the [zanata platform](https://translate.zanata.org/project/view/mucommander).  
 
 If you want to get involved in muCommander or have any question or issue to discuss, you are more than welcome to join our rooms on [Gitter](https://gitter.im/mucommander).  
 
@@ -33,7 +33,7 @@ If you want to get involved in muCommander or have any question or issue to disc
 ### Forks and pull requests
 
 If you would like to contribute code, it is required to fork the repository and submit a [pull request](https://help.github.com/en/articles/about-pull-requests).
-Within pull requests it is possible to review, discuss and improve the changes until they are ready for production. 
+Within pull requests, it is possible to review, discuss, and improve the changes until they are ready for production. 
 
 ### Code Editing  
 After cloning the source code repository from GitHub, you would probably want to import the project to an Integrated Development Environment (IDE) such as Eclipse or IntelliJ.
@@ -41,14 +41,14 @@ After cloning the source code repository from GitHub, you would probably want to
 The code repository of muCommander is comprised of a main project that contains its core functionality and several sub-projects. These projects are Gradle projects. Most of the popular IDEs today allow you to import Gradle projects out-of-the-box or via an IDE plugin. By importing the main project that is located at the root directory of the repository you will get all the required code in the IDE.
 
 ### How to Run  
-The use of Gradle wrapper significantly simplifies the build from the command line. The following commands can be invoked from the root directory of the repositoring with no further installation.
+The use of the Gradle wrapper significantly simplifies the build from the command line. The following commands can be invoked from the root directory of the repository with no further installation.
 
 You can run the application by typing:  
 ```
 ./gradlew run
 ```
 
-It is recommended that whenever you get unclear compilation error and before submitting your change you do:  
+It is recommended that whenever you get an unclear compilation error before submitting your change you do:  
 ```
 ./gradlew clean run
 ```    
@@ -63,7 +63,7 @@ The creation of a DMG file for MAC OS (produced in build/distributions):
 ./gradlew dmg
 ```
 
-Note: as the application is not signed, the following error may appear when trying to start is on macOS: "muCommander damaged and cannot be opened".  
+Note: as the application is not signed, the following error may appear when trying to start it on macOS: "muCommander damaged and cannot be opened".  
 This can be solved by executing: `sudo xattr -r -d com.apple.quarantine /Applications/muCommander.app`
 
 The creation of an EXE file for Windows (produced in build/launch4j):  


### PR DESCRIPTION
Addressed grammar and spelling mistakes. This commit ensures the README.md is free from errors and provides clear and accurate information.

Closes #1074