### PR TITLE
Avoid using log4j 1.x

### DIFF
--- a/jetbrains-jediterm/build.gradle
+++ b/jetbrains-jediterm/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     runtimeOnly 'org.jetbrains.intellij.deps:trove4j:1.0.20200330'
 
     implementation 'org.apache.logging.log4j:log4j-1.2-api:2.22.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.22.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.22.0'
 }
 

--- a/jetbrains-jediterm/build.gradle
+++ b/jetbrains-jediterm/build.gradle
@@ -17,7 +17,9 @@ dependencies {
     implementation 'org.jetbrains:annotations:23.0.0'
     runtimeOnly 'org.jetbrains.intellij.deps:trove4j:1.0.20200330'
 
-    implementation 'log4j:log4j:1.2.17'
+    implementation 'org.apache.logging.log4j:log4j-1.2-api:2.22.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.22.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.22.0'
 }
 
 jar {


### PR DESCRIPTION
fixes #1084
used Log4j1.2Bridge instead of log4j:1.2.17