### PR TITLE
Fix incorrect block selection on native L&F

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
@@ -1388,7 +1388,16 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
         else if(DesktopManager.isLeftMouseButton(e)) {
             // Marks a group of rows, from last current row to clicked row (current row)
             if(e.isShiftDown()) {
-                setRangeMarked(currentRow, lastRow, !tableModel.isRowMarked(currentRow));
+                // Determine the end of the selection range:
+                // - If clickedRow == currentRow, that means changeSelection method was already called.
+                //   In this case, currentRow and lastRow are set correctly and already represents the selection range.
+                // - If not, that means changeSelection method was not called (and will be called later). In this case,
+                //   we cannot relay on lastRow - instead use currentRow (which is actually the previously selected row)
+                //   and clickedRow (which is the currently selected row) to define selection range
+                int clickedRow = rowAtPoint(new Point(e.getX(), e.getY()));
+                int endRow = currentRow == clickedRow ? lastRow : clickedRow;
+
+                setRangeMarked(currentRow, endRow, !tableModel.isRowMarked(currentRow));
             }
             // Marks the clicked row
             else if (e.isControlDown()) {


### PR DESCRIPTION
This PR address issue https://github.com/mucommander/mucommander/issues/1103, please read it for more details about the actual issue.

## Block select
In the context of this PR, a block select is defined as follows:

1. User clicks a _file a_ in `FileTable`
2. User holds the  <kbd>⇧ Shift</kbd> key and clicks _file b_
3. Now the range between _file a_ and _file b_ is selected/marked (if it was unselected, or vice versa).

## Root case
When a user is doing a block select, the expected sequence of events in `FileTable` after click number 2 (see above) is:

1. [`changeSelection`](https://github.com/mucommander/mucommander/blob/02bdb7444c8e330a8f8f114c4bb78d6505cfc985/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java#L1199) is invoked and maintains the values of `lastRow` and `currentRow`.
2. [`mousePressed`](https://github.com/mucommander/mucommander/blob/02bdb7444c8e330a8f8f114c4bb78d6505cfc985/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java#L1351) is invoked and uses those values in the call to [`setRangeMarked`](https://github.com/mucommander/mucommander/blob/02bdb7444c8e330a8f8f114c4bb78d6505cfc985/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java#L1391)

In practice, Swing does not guarantee the order of which UI events are fired, so in cases where the execution order is reversed (`mousePressed` is called before `changeSelection`) the range is incorrect. I reproduced this behavior on Windows using Windows L&F, and according to the original issue [it also happens on MacOS native L&F](https://github.com/mucommander/mucommander/issues/1103#issuecomment-1926096421),

## The fix
The fix itself is pretty simple - I added a check to determine if we are in case 1 or case 2 (see above) and set the end of the range accordingly. I tested this on my machine and it seems to be working as expected but I will appreciate if other people can take a look as well, preferably on MacOS.