### PR TITLE
mv JRE for macOS to macOS/x64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,7 +389,7 @@ task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
                 '--icon', 'package/osx/icon.icns', \
                 '--main-jar', 'mucommander-'+project.version+'.jar', \
                 '--main-class', 'com.mucommander.main.muCommander', \
-                '--runtime-image', 'jre/macOS', \
+                '--runtime-image', 'jre/macOS/x64', \
                 '--java-options', '\
                         -Xshare:auto -XX:-UsePerfData -XX:+TieredCompilation -XX:TieredStopAtLevel=1 \
                         --add-exports java.desktop/com.apple.laf=ALL-UNNAMED \


### PR DESCRIPTION
it's done as a preparation for adding JRE for aarch64 (see #962)