### PR TITLE
Fix flakiness of AppleScriptTest#testScriptOutput

### DIFF
--- a/mucommander-os-macos/src/main/java/com/mucommander/ui/notifier/GrowlNotifier.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/ui/notifier/GrowlNotifier.java
@@ -148,7 +148,7 @@ public class GrowlNotifier extends AbstractNotifier {
 
     public static boolean isGrowlRunning() {
         StringBuilder outputBuffer = new StringBuilder();
-        return AppleScript.execute(IS_GROWL_RUNNING_APPLESCRIPT, outputBuffer) && outputBuffer.toString().equals("true");
+        return AppleScript.execute(IS_GROWL_RUNNING_APPLESCRIPT, outputBuffer) && outputBuffer.toString().trim().equals("true");
     }
 
     @Override

--- a/mucommander-os-macos/src/test/java/com/mucommander/ui/macos/AppleScriptTest.java
+++ b/mucommander-os-macos/src/test/java/com/mucommander/ui/macos/AppleScriptTest.java
@@ -43,7 +43,7 @@ public class AppleScriptTest {
         if(OsFamily.MAC_OS.isCurrent()) {
             // Assert that the script was executed successfully and that the output matches what is expected
             assert success;
-            assert "6".equals(output.toString());
+            assert "6".equals(output.toString().trim());
         }
         else {
             // We're not running Mac OS X, assert that execute returns false


### PR DESCRIPTION
the test compares the received output against the expected output "6", however, the 'osascript' command returns a new line at the end of the generated output that we trim on ScriptOutputListener#processDied. it could be that ScriptOutputListener#processDied would run after the above mentioned comparison and then we get: "6" != "6\n".

we can wait for ScriptOutputListener#processDied to be completed before handling the output, but we already trim the output to resolve this issue elsewhere (in OSXTrash#getItemCount) so we rather apply the same approach to AppleScriptTest#testScriptOutput.

this PR also trims the output of osascript in GrowlNotifier#isGrowlRunning