### PR TITLE
Reset sort order when sort column changes

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
@@ -857,14 +857,11 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
     public void sortBy(Column criterion) {
         if (criterion==sortInfo.getCriterion()) {
             reverseSortOrder();
-            return;
         } else {
             // The selected column is different from the previously selected one.
             // In this case, default to ascending sort order
-            sortInfo.setAscendingOrder(true);
+            sortBy(criterion, true);
         }
-
-        sortBy(criterion, sortInfo.getAscendingOrder());
     }
 
     /**

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/table/FileTable.java
@@ -858,6 +858,10 @@ public class FileTable extends JTable implements MouseListener, MouseMotionListe
         if (criterion==sortInfo.getCriterion()) {
             reverseSortOrder();
             return;
+        } else {
+            // The selected column is different from the previously selected one.
+            // In this case, default to ascending sort order
+            sortInfo.setAscendingOrder(true);
         }
 
         sortBy(criterion, sortInfo.getAscendingOrder());

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -35,7 +35,7 @@ New features:
 -
 
 Improvements:
--
+- When sorting by any column, always start with ascending sort order
 
 Localization:
 -


### PR DESCRIPTION
This PR addresses issue #1165.

Original state: In the file table, when clicking `column A` after the table was already sorted by `column B`, the sort order is retained. This leads to an undesired result if `column B` is sorted in a descending order (since after clicking `column A`, its sort direction will also be descending and not ascending).

State after this change: If the current sort column is different then the previously selected sort column, reset the sort order to ascending.