### PR TITLE
Open with App - faster loading (and a fix for slowish macbooks)

### DIFF
--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -479,9 +479,9 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
             BufferedReader stdInput = new BufferedReader(new InputStreamReader(
                     useStdErr ? proc.getErrorStream() : proc.getInputStream()));
             int exitCode = Integer.MIN_VALUE;
-            boolean timedOut;
-            if (!(timedOut = proc.waitFor(500, TimeUnit.MILLISECONDS)) || (exitCode = proc.exitValue()) != expectedExitCode) {
-                LOGGER.error("Unexpected result from running: '{}', timed out?: {}, exit code: {}", command, timedOut, exitCode);
+            boolean processExited;
+            if (!(processExited = proc.waitFor(1000, TimeUnit.MILLISECONDS)) || (exitCode = proc.exitValue()) != expectedExitCode) {
+                LOGGER.error("Unexpected result from running: '{}', timed out?: {}, exit code: {}", command, !processExited, exitCode);
                 return result;
             }
             String s;

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -442,25 +442,19 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
         if (dutiCmdPath != null) {
             return dutiCmdPath;
         }
-        // first try without '-l' - it is ~10x faster, may not have a proper env settings tho
-        runCommand(new String[]{getMacOsUserShell(), "-c", "which duti"}, false,0, s -> {
+        Predicate<String> linePredicate = line -> {
             // a simple sanity check of 'duti' command output
-            if (s.contains("duti")) {
-                dutiCmdPath = s;
+            if (line.contains("duti")) {
+                dutiCmdPath = line;
                 return true;    // we're good, no further searching needed
             }
             return false;       // continue searching
-        });
+        };
+        // first try without '-l' - it is ~10x faster, may not have a proper env settings tho
+        runCommand(new String[]{getMacOsUserShell(), "-c", "which duti"}, false,0, linePredicate);
         if (StringUtils.isNullOrEmpty(dutiCmdPath)) {
             // retry the proper way, i.e. with -l - it may take more time to execute, but may have better env settings
-            runCommand(new String[]{getMacOsUserShell(), "-l", "-c", "which duti"}, false,0, s -> {
-                // a simple sanity check of 'duti' command output
-                if (s.contains("duti")) {
-                    dutiCmdPath = s;
-                    return true;    // we're good, no further searching needed
-                }
-                return false;       // continue searching
-            });
+            runCommand(new String[]{getMacOsUserShell(), "-l", "-c", "which duti"}, false,0, linePredicate);
         }
 
         if (!StringUtils.isNullOrEmpty(dutiCmdPath)) {


### PR DESCRIPTION
Open with App - faster loading by first trying `bash|zsh -c "which duty"` and then `bash|zsh -l -c "which duty"`.

"-l" option is generally better, but is 10x slower than without it. I will first try without "-l" and then as a fallback with it.

Additionally, I've increased timeout for execution from 500ms to 1s. Surprisingly, on pretty new macbooks with A/V etc it may take more than 500s to execute the command when '-l' is present.