### PR TITLE
Debug console - using JTree + non-modal + autorefresh + fix for Bug Report

### DIFF
--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/dialog/FocusDialog.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/dialog/FocusDialog.java
@@ -191,29 +191,21 @@ public class FocusDialog extends JDialog implements WindowListener {
             DialogToolkit.fitToMinDimension(this, minimumDimension);
     }
 
-
     /**
      * Packs this dialog, makes it non-resizable and visible.
      */
     public void showDialog() {
         pack();
 
-        if(locationRelativeComp==null)
+        if (locationRelativeComp == null) {
             DialogToolkit.centerOnScreen(this);
-        else
-            setLocation(locationRelativeComp.getX()+(locationRelativeComp.getWidth()-getWidth())/2, locationRelativeComp.getY()+(locationRelativeComp.getHeight()-getHeight())/2);
+        } else {
+            setLocation(
+                    locationRelativeComp.getX() + (locationRelativeComp.getWidth() - getWidth()) / 2,
+                    locationRelativeComp.getY() + (locationRelativeComp.getHeight() - getHeight()) / 2);
+        }
         setVisible(true);
     }
-
-    /**
-     * Return <code>true</code> if the dialog has been activated (see WindowListener.windowActivated()).
-     *
-     * @return <code>true</code> if the dialog has been activated
-     */
-    public boolean isActivated() {
-        return firstTimeActivated;
-    }
-
 
     ////////////////////////////
     // WindowListener methods //
@@ -232,7 +224,7 @@ public class FocusDialog extends JDialog implements WindowListener {
             // "The focus behavior of this method can be implemented uniformly across platforms, and thus developers are
             // strongly encouraged to use this method over requestFocus when possible. Code which relies on requestFocus
             // may exhibit different focus behavior on different platforms."
-            if(!initialFocusComponent.requestFocusInWindow()) {
+            if (!initialFocusComponent.requestFocusInWindow()) {
                 LOGGER.trace("requestFocusInWindow failed, calling requestFocus");
                 FocusRequester.requestFocus(initialFocusComponent);
             }

--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/dialog/FocusDialog.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/dialog/FocusDialog.java
@@ -55,8 +55,8 @@ import com.mucommander.commons.util.ui.helper.FocusRequester;
  * @author Maxence Bernard
  */
 public class FocusDialog extends JDialog implements WindowListener {
-	private static final Logger LOGGER = LoggerFactory.getLogger(FocusDialog.class);
-	
+    private static final Logger LOGGER = LoggerFactory.getLogger(FocusDialog.class);
+
     /** Minimum dimensions of this dialog, may be null */
     private Dimension minimumDimension;
 
@@ -96,7 +96,7 @@ public class FocusDialog extends JDialog implements WindowListener {
 
         // Important: dispose (release resources) window on close, default is HIDE_ON_CLOSE
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-	
+
         // Catch escape key presses and have them close the dialog by mapping the escape keystroke to a custom dispose Action
         InputMap inputMap = contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         ActionMap actionMap = contentPane.getActionMap();
@@ -106,11 +106,11 @@ public class FocusDialog extends JDialog implements WindowListener {
                     cancel();
             }
         };
-	
+
         // Maps the dispose action to the 'Escape' keystroke
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CUSTOM_DISPOSE_EVENT);
         actionMap.put(CUSTOM_DISPOSE_EVENT, disposeAction);
-		
+
         // Maps the dispose action to the 'Apple+W' keystroke under Mac OS X
         if(OsFamily.MAC_OS.isCurrent())
             inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_W, ActionEvent.META_MASK), CUSTOM_DISPOSE_EVENT);
@@ -145,8 +145,8 @@ public class FocusDialog extends JDialog implements WindowListener {
         else
             addWindowListener(this);
     }
-	
-	
+
+
     /**
      * Sets a maximum width and height for this dialog.
      */
@@ -186,12 +186,12 @@ public class FocusDialog extends JDialog implements WindowListener {
             DialogToolkit.fitToMaxDimension(this, maximumDimension);
         else
             DialogToolkit.fitToScreen(this);
-		
+
         if(minimumDimension!=null)
             DialogToolkit.fitToMinDimension(this, minimumDimension);
     }
 
-	
+
     /**
      * Packs this dialog, makes it non-resizable and visible.
      */

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ReportBugAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ReportBugAction.java
@@ -83,14 +83,13 @@ public class ReportBugAction extends OpenURLInBrowserAction {
             var logRecords = new StringBuilder();
             for (LoggingEvent record : lastNRecords) {
                 logRecords.append(record.toString());
-                logRecords.append(System.lineSeparator());
             }
             var newBugUrl = String.format(NEW_BUG_FORMAT, url,
                     URLEncoder.encode(muCVersion, "UTF-8"),
                     URLEncoder.encode(javaVersion, "UTF-8"),
                     URLEncoder.encode(osVersion, "UTF-8"),
-                    URLEncoder.encode(logRecords.toString()
-                            .substring(0, Math.min(MAX_REPORTED_LOG_SIZE, logRecords.length())) + "[...]","UTF-8"));
+                    URLEncoder.encode("[✂]\n" + logRecords.toString()
+                            .substring(0, Math.min(MAX_REPORTED_LOG_SIZE, logRecords.length())) + "\n[✂]","UTF-8"));
             putValue(URL_PROPERTY_KEY, newBugUrl);
         } catch (Exception e) {
             LOGGER.error("Error while preparing a bug report, falling back to generic one", e);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowDebugConsoleAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowDebugConsoleAction.java
@@ -32,13 +32,18 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class ShowDebugConsoleAction extends MuAction {
 
+    private DebugConsoleDialog dialog;
+
     public ShowDebugConsoleAction(MainFrame mainFrame, Map<String,Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-        new DebugConsoleDialog(mainFrame).showDialog();
+        if (dialog == null || !dialog.isVisible()) {
+            dialog = new DebugConsoleDialog(mainFrame);
+        }
+        dialog.showDialog();
     }
 
     @Override

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowDebugConsoleAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowDebugConsoleAction.java
@@ -41,14 +41,14 @@ public class ShowDebugConsoleAction extends MuAction {
         new DebugConsoleDialog(mainFrame).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowDebugConsole.getId(); }
+        public String getId() { return ActionType.ShowDebugConsole.getId(); }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+        public ActionCategory getCategory() { return ActionCategory.MISC; }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/debug/DebugConsoleDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/debug/DebugConsoleDialog.java
@@ -133,11 +133,12 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
         LogLevel logLevel = MuLogging.getLogLevel();
 
         levelComboBox = new JComboBox<>();
-        for(LogLevel level:LogLevel.values())
+        for (LogLevel level:LogLevel.values()) {
             levelComboBox.addItem(level);
-        		
+        }
+
         levelComboBox.setSelectedItem(logLevel);
-        		
+
         levelComboBox.addItemListener(this);
 
         comboPanel.add(levelComboBox);
@@ -149,15 +150,16 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
      * Refreshes the JList with the log records contained by {@link DebugConsoleAppender}.
      */
     private void refreshLogRecords() {
-    	DefaultListModel<LoggingEvent> listModel = new DefaultListModel<>();
+        DefaultListModel<LoggingEvent> listModel = new DefaultListModel<>();
         DebugConsoleAppender handler = MuLogging.getDebugConsoleAppender();
 
         final LoggingEvent[] records = handler.getLogRecords();
         final LogLevel currentLogLevel = MuLogging.getLogLevel();
         
         for (LoggingEvent record : records) {
-        	if (record.isLevelEqualOrHigherThan(currentLogLevel))
-        		listModel.addElement(record);
+            if (record.isLevelEqualOrHigherThan(currentLogLevel)) {
+                listModel.addElement(record);
+            }
         }
 
         loggingEventsList.setModel(listModel);
@@ -182,10 +184,9 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
     public void actionPerformed(ActionEvent e) {
         Object source = e.getSource();
 
-        if(source==refreshButton) {
+        if (source == refreshButton) {
             refreshLogRecords();
-        }
-        else if(source==closeButton) {
+        } else if( source == closeButton) {
             dispose();
         }
     }
@@ -198,7 +199,7 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
     public void itemStateChanged(ItemEvent e) {
         // Refresh the log records displayed in the JList whenever the selected level has been changed.
         int selectedIndex = levelComboBox.getSelectedIndex();
-        if(selectedIndex!=-1) {
+        if (selectedIndex != -1) {
             updateLogLevel();
             refreshLogRecords();
         }
@@ -216,8 +217,9 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
 
         @Override
         public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-            if(value==null)
+            if (value == null) {
                 return null;
+            }
 
             // TODO: line-wrap log items when the text is too long to fit on a single line
             // A single-column JTable may be the easiest way to go, see:
@@ -230,23 +232,31 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
             JLabel label = (JLabel)super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             
             // Change the label's foreground color to match the level of the log record
-            if(!isSelected) {
+            if (!isSelected) {
                 LogLevel level = ((LoggingEvent)value).getLevel();
                 Color color;
 
-                if(level.equals(LogLevel.SEVERE))
-                    color = Color.RED;
-                else if(level.equals(LogLevel.WARNING))
-                    color = new Color(255, 100, 0);     // Dark orange
-                else if(level.equals(LogLevel.CONFIG))
-                    color = Color.BLUE;
-                else if(level.equals(LogLevel.INFO))
-                    color = Color.BLACK;
-                else if(level.equals(LogLevel.FINE))
-                    color = Color.DARK_GRAY;
-                else
-                    color = new Color(110, 110, 110);    // Between Color.GRAY and Color.DARK_GRAY
-
+                switch (level) {
+                    case SEVERE:
+                        color = Color.RED;
+                        break;
+                    case WARNING:
+                        // Dark orange
+                        color = new Color(255, 100, 0);
+                        break;
+                    case CONFIG:
+                        color = Color.BLUE;
+                        break;
+                    case INFO:
+                        color = Color.BLACK;
+                        break;
+                    case FINE:
+                        color = Color.DARK_GRAY;
+                        break;
+                    default:
+                        // Between Color.GRAY and Color.DARK_GRAY
+                        color = new Color(110, 110, 110);
+                };
                 label.setForeground(color);
             }
 
@@ -254,11 +264,12 @@ public class DebugConsoleDialog extends FocusDialog implements ActionListener, I
             // If component's preferred width is larger than the list's width then the component is not entirely
             // visible. In that case, we set a tooltip text that will display the whole text when mouse is over the
             // component
-            if (loggingEventsList.getVisibleRect().getWidth() < label.getPreferredSize().getWidth())
+            if (loggingEventsList.getVisibleRect().getWidth() < label.getPreferredSize().getWidth()) {
                 label.setToolTipText(label.getText());
-            // Have to set it to null because of the rubber-stamp rendering scheme (last value is kept)
-            else
+            } else {
+                // Have to set it to null because of the rubber-stamp rendering scheme (last value is kept)
                 label.setToolTipText(null);
+            }
             
             return label;
         }

--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/debug/DebugConsoleDialog.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/debug/DebugConsoleDialog.java
@@ -83,7 +83,7 @@ public class DebugConsoleDialog extends FocusDialog implements ItemListener {
     /** Refreshes the tree with the latest log records when pressed */
     private JButton refreshButton;
 
-    /** To control periodical auto-refresh */
+    /** To control periodic auto-refresh */
     private JCheckBox autoRefreshCheckBox;
 
     private ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
@@ -155,18 +155,11 @@ public class DebugConsoleDialog extends FocusDialog implements ItemListener {
         buttonPanel.add(autoRefreshCheckBox);
 
         refreshButton = new JButton(Translator.get(new RefreshAction.Descriptor().getLabel()));
-        refreshButton.addActionListener((e) -> refreshLogRecords());
+        refreshButton.addActionListener(e -> refreshLogRecords());
         buttonPanel.add(refreshButton);
 
         closeButton = new JButton(Translator.get("close"));
-        closeButton.addActionListener((e) -> {
-            if (periodicUpdater != null) {
-                periodicUpdater.cancel(false);
-                periodicUpdater = null;
-            }
-            executorService.shutdown();
-            dispose();
-        });
+        closeButton.addActionListener(e -> dispose());
         buttonPanel.add(closeButton);
 
         southPanel.add(buttonPanel, BorderLayout.EAST);
@@ -259,6 +252,15 @@ public class DebugConsoleDialog extends FocusDialog implements ItemListener {
         }
     }
 
+    @Override
+    public void dispose() {
+        if (periodicUpdater != null) {
+            periodicUpdater.cancel(false);
+            periodicUpdater = null;
+        }
+        executorService.shutdown();
+        super.dispose();
+    }
 
     ///////////////////
     // Inner classes //

--- a/mucommander-core/src/main/java/com/mucommander/ui/icon/IconManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/icon/IconManager.java
@@ -104,7 +104,7 @@ public class IconManager {
     public static ImageIcon getIcon(String iconPath, float scaleFactor) {
         URL resourceURL = ResourceLoader.getResourceAsURL(iconPath);
         if(resourceURL==null) {
-            LOGGER.debug("Warning: attempt to load non-existing icon: {}, icon missing?", iconPath);
+            LOGGER.trace("Warning: attempt to load non-existing icon: {}, icon missing?", iconPath);
             return null;
         }
 

--- a/mucommander-translator/src/main/resources/dictionary.properties
+++ b/mucommander-translator/src/main/resources/dictionary.properties
@@ -871,6 +871,7 @@ prefs_dialog.open_with_viewer_on_error = Open the file with the viewer in case o
 prefs_dialog.set_drop_action_to_copy = Set default file drag and drop action to 'COPY'
 prefs_dialog.no_quick_search_timeout = None
 prefs_dialog.quick_search_timeout_sec = Quick search timeout (seconds)
+debug_console_dialog.auto_refresh = Auto refresh
 debug_console_dialog.level = Level
 unit.byte = byte
 unit.bytes = bytes

--- a/mucommander-translator/src/main/resources/dictionary_en.properties
+++ b/mucommander-translator/src/main/resources/dictionary_en.properties
@@ -770,7 +770,6 @@ prefs_dialog.open_with_viewer_on_error = Open the file with the viewer in case o
 prefs_dialog.set_drop_action_to_copy = Set default file drag and drop action to 'COPY'
 prefs_dialog.no_quick_search_timeout = None
 prefs_dialog.quick_search_timeout_sec = Quick search timeout (seconds)
-debug_console_dialog.auto_refresh = Auto refresh
 debug_console_dialog.level = Level
 unit.byte = byte
 unit.bytes = bytes

--- a/mucommander-translator/src/main/resources/dictionary_en.properties
+++ b/mucommander-translator/src/main/resources/dictionary_en.properties
@@ -770,6 +770,7 @@ prefs_dialog.open_with_viewer_on_error = Open the file with the viewer in case o
 prefs_dialog.set_drop_action_to_copy = Set default file drag and drop action to 'COPY'
 prefs_dialog.no_quick_search_timeout = None
 prefs_dialog.quick_search_timeout_sec = Quick search timeout (seconds)
+debug_console_dialog.auto_refresh = Auto refresh
 debug_console_dialog.level = Level
 unit.byte = byte
 unit.bytes = bytes

--- a/mucommander-translator/src/main/resources/dictionary_pl.properties
+++ b/mucommander-translator/src/main/resources/dictionary_pl.properties
@@ -585,6 +585,7 @@ prefs_dialog.default_shell = Użyj domylnego systemowego shella
 prefs_dialog.custom_shell = Użyj shella użytkownika
 prefs_dialog.enable_bonjour_discovery = Uaktywnij odkrywanie usług Bonjour
 prefs_dialog.enable_system_notifications = Włącz powiadomienia
+debug_console_dialog.auto_refresh = Automatyczne odświeżanie
 debug_console_dialog.level = Poziom
 unit.byte = bajt
 unit.bytes = bajty

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -38,6 +38,7 @@ Improvements:
 - When sorting by any column, always start with ascending sort order
 - Faster way of finding applications for Open With context menu (macOS)
 - Debug Console is able to show logs with stacktraces (if present)
+- Improved Debug Console to display logs using tree view with folded stacktraces and it can be opened in background (non-modal) with logs autorefresh
 
 Localization:
 -


### PR DESCRIPTION
Debug console 
- now using JTree so it can display stacktraces if present #1170 - stacktraces part extracted to: #1192
  - copy to clipboards works good when entry or entries selected
- made it non-modal #1170 - see below
- added option (checkbox) for autorefresh
  - updated every 500ms, Debug Dialog can be placed behind the main window to observe if a given functionality works or how it works
- fix for Bug Report #1174 - extracted to: #1191
- the 'problem' with too lengthy log entries that don't wrap still persists, but I guess it is a minor issue 

Screenshots:
![d1](https://github.com/mucommander/mucommander/assets/360665/54923065-1b4a-430b-8679-fed2c50c76c6)
![d2](https://github.com/mucommander/mucommander/assets/360665/1db7d30d-68b4-415a-a33d-6819670fe21c)
![d3](https://github.com/mucommander/mucommander/assets/360665/9bad012c-8b08-4437-b018-0021f3a7c97b)


