### PR TITLE
dmg: sign the 'muCommander.app' folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -455,6 +455,11 @@ task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
            executable '/usr/bin/codesign'
            args '--entitlements', 'package/osx/mucommander-entitlements', '--options', 'runtime', '--deep', '--timestamp', '-s', project.ext.identity, '-f', "${buildDir}/muCommander.app/Contents/MacOS/muCommander"
          }
+         exec {
+           workingDir "${rootDir}"
+           executable '/usr/bin/codesign'
+           args '--entitlements', 'package/osx/mucommander-entitlements', '--options', 'runtime', '--deep', '--timestamp', '-s', project.ext.identity, '-f', "${buildDir}/muCommander.app"
+         }
        }
     }
 }


### PR DESCRIPTION
Not sure if it's really needed but as there's a report about issues with the signed dmg on macOS Catalina, it is worth a try.