### PR TITLE
Fix for Erratic behavior(s) after launch

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/AppearancePanel.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dialog/pref/general/AppearancePanel.java
@@ -633,6 +633,11 @@ class AppearancePanel extends PreferencesPanel implements ActionListener, Runnab
      * Initialises the list of available look&feels.
      */
     private void initializeAvailableLookAndFeels() {
+        while (!WindowManager.getInstance().isAdditionalLafsLoaded()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {}
+        }
         // Loads all available look and feels.
         lookAndFeels = UIManager.getInstalledLookAndFeels();
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/MainFrame.java
@@ -44,6 +44,7 @@ import javax.swing.JFrame;
 import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.table.TableColumnModel;
 
@@ -205,8 +206,16 @@ public class MainFrame implements LocationListener {
 
         executor.execute(() -> {
             // Create menu bar (has to be created after toolbar) - ok, but why?
+            // PSko - I guess it is related to loading Actions and that icons
+            // for toolbar action should have icons, but in menu they should not.
+            // However, still I don't get how setting the icon to null here in MenuToolkit#addMenuItem
+            // impacts menu icons....... if nullify is commented-out there, then icons all of sudden
+            // show in the menu causing this: https://github.com/mucommander/mucommander/issues/1178
             MainMenuBar menuBar = new MainMenuBar(this);
-            getJFrame().setJMenuBar(menuBar);
+            SwingUtilities.invokeLater(() -> {
+                getJFrame().setJMenuBar(menuBar);
+                getJFrame().revalidate();
+            });
         });
 
         // Create the split pane that separates folder panels and allows to resize how much space is allocated to the

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/WindowManager.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/WindowManager.java
@@ -426,4 +426,8 @@ public class WindowManager implements WindowListener, ConfigurationListener {
     			setLookAndFeel(lnfName);
     	}
     }
+
+    public boolean isAdditionalLafsLoaded() {
+        return additionalLafsLoaded;
+    }
 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -45,6 +45,7 @@ Localization:
 
 Bug fixes:
 - Fix occasional hangs when lauching muCommander
+- Fix for erratic behavior(s) after launch (unstable Preferences window, no Menu until switching panels etc)
 - Fixed undesired beep and undesired character when leaving terminal by pressing F12 (random behavior)
 - Fixed a bug in Report Bug where too much logs could cause to fallback to a simple bug reporting on GitHub
 - Fix for losing keyboard focus in modals when Keyboard Hints turned on


### PR DESCRIPTION
Fix for Erratic behavior(s) after launch #1179:
- ad bug 1 - the problem is caused by menu items being constructed in the background for a faster muC launch. The JFrame was not "revalidated" after updating the menu items
- ad bug 2 - the problem was kinda race condition related, caused by loading additional L&Fs in the background (deferred loading) for a faster muC launch. When Preferences were opened and L&Fs loading finished just after that, the L&Fs dropdown was in unstable condition. The bug has nothing to do with custom theme etc.

It contains additional comment that may help solving #1178
@ahadas - let's continue conversation in #1178  