### PR TITLE
Attempt to fix launch fail

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/tabs/HideableTabbedPane.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/tabs/HideableTabbedPane.java
@@ -188,7 +188,10 @@ public class HideableTabbedPane<T extends Tab> extends JComponent implements Tab
 	 * @param updater - object that will be used to update the tab
 	 */
 	protected void updateCurrentTab(TabUpdater<T> updater) {
-		tabsCollection.updateTab(getSelectedIndex(), updater);
+		var idx = getSelectedIndex();
+		if (idx >= 0) {
+			tabsCollection.updateTab(idx, updater);
+		}
 	}
 
 	/* Actions that depended on the display type (single/multiple tabs) */

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -42,6 +42,8 @@ Localization:
 
 Bug fixes:
 -
+- Fix for random hangs while lauching muCommander
+-
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
Attempt to fix launch fail #1182

It might be related to recent update where things are run in parallel for faster startup, or it may not, or it may have start to manifest itself under such condition.

I was unable to reproduce, even having multiple tabs (this is only when this may occur), however I've spotted that JTabbedPane#getSelectedIndex may return -1 if no tab is selected. This index is being used in the HideableTabbedPane#updateTab (via update event).

@ahadas - I think you know the mechanics of those tabs better, can you take a look?