### PR TITLE
Terminal - fix for undesired beep and undesired character when leaving terminal

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTerminalAction.java
@@ -36,7 +36,8 @@ import com.mucommander.ui.terminal.TerminalIntegration;
  */
 public class ToggleTerminalAction extends ActiveTabAction {
 
-    private volatile TerminalIntegration terminalIntegration = null;
+    private volatile static TerminalIntegration terminalIntegration = null;
+    private final static Object LOCK = new Object();
 
     public ToggleTerminalAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
@@ -84,7 +85,7 @@ public class ToggleTerminalAction extends ActiveTabAction {
         var verticalSplit = mainFrame.getVerticalSplitPane();
         if (terminalIntegration == null && verticalSplit != null) {
             // doing it lazy, because in c-tor main frame might not be fully built (no vertical split pane yet)
-            synchronized (this) {
+            synchronized (LOCK) {
                 if (terminalIntegration == null) {
                     terminalIntegration = new TerminalIntegration(mainFrame, verticalSplit);
                 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/terminal/TerminalIntegration.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/terminal/TerminalIntegration.java
@@ -131,17 +131,18 @@ public class TerminalIntegration {
                 try {
                     mainFrame.getJFrame().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
                     terminal = getTerminal(newCwd);
+                    terminal.getTerminalPanel().addCustomKeyListener(termCloseKeyHandler());
+                    cwd = newCwd;
+                    // TODO do this better? For now 2 lines ~height + 20%
+                    terminal.setMinimumSize(new Dimension(-1,
+                            (int) (terminal.getFontMetrics(terminal.getFont()).getHeight() * 2 * 1.2)));
+                    verticalSplitPane.setBottomComponent(terminal);
+                    // don't know exactly why, but it should be after addCustomKeyListener (https://github.com/mucommander/mucommander/issues/1187)
                     terminal.getTerminalPanel().addFocusListener(new FocusAdapter() {
                         public void focusGained(FocusEvent e) {
                             syncCWD(mainFrame.getActivePanel().getCurrentFolder().getAbsolutePath());
                         }
                     });
-                    cwd = newCwd;
-                    terminal.getTerminalPanel().addCustomKeyListener(termCloseKeyHandler());
-                    // TODO do this better? For now 2 lines ~height + 20%
-                    terminal.setMinimumSize(new Dimension(-1,
-                            (int) (terminal.getFontMetrics(terminal.getFont()).getHeight() * 2 * 1.2)));
-                    verticalSplitPane.setBottomComponent(terminal);
                 } finally {
                     mainFrame.getJFrame().setCursor(orgCursor);
                 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -41,7 +41,7 @@ Localization:
 -
 
 Bug fixes:
--
+- Fixed undesired beep and undesired character when leaving terminal by pressing F12 (random behavior)
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
Terminal - fix for undesired beep and undesired character when leaving terminal #1187

There are 2 (or even 3 problems):
1) ToggleTerminalAction is constructed a couple of times, that could lead to creation of a couple of Terminal instances - this has been addressed by adding a static handler for keeping the instance plus a static LOCK. This ensures only one Terminal is out there. The case of multiple instances could be observed when using F12 to open terminal and leaving, then clicking on vertical bar to open the terminal - an old terminal was replaced with a new copy, which in turn had no problem with undesired beep and undesired character (!)

2) The root cause why multiple instantiations of ToggleTerminalAction happens has to be solved separately (partially due to bubbling up notifications while Main Menu and Toolbar items creation - it can be related to running Toolbar and MainMenu execution in parallel?) - it seems the multiple instantiations happen magically, see comment inside PR: https://github.com/mucommander/mucommander/pull/1190

3) Observation from 1) led me to check TerminalIntegration - some gut feeling told me that there might be some race condition within Terminal itself, so I decided to execute TerminalPanel.addCustomKeyListener  first and TerminalPanel.addFocusListener a bit later. This helped to the point I cannot reproduce it on my mac and pref & KB settings.

Pending verification from Andreas.
