### PR TITLE
Bumped RSyntaxTextArea to v3.4.0

### DIFF
--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api project(":mucommander-preferences")
 
     compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
-    comprise group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.3.4'
+    comprise group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.4.0'
 
     testImplementation 'org.testng:testng:6.11'
 }


### PR DESCRIPTION
Bumped RSyntaxTextArea to v3.4.0 

Doesn't fix #1197, but at least sync with the most current version of RSyntaxTextArea