### PR TITLE
Extended timestamp support for zip files

### DIFF
--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtendedTimestampExtraField.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtendedTimestampExtraField.java
@@ -1,0 +1,63 @@
+package com.mucommander.commons.file.archive.zip.provider;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+public class ExtendedTimestampExtraField implements ZipExtraField {
+
+    private static final ZipShort ID = new ZipShort(0x5455);
+    private static final byte FLAG_MODTIME_PRESENT = 0x01;
+
+    private byte[] localData;
+
+    private Long javaTime;
+
+    public Long getJavaTime() {
+        return javaTime;
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return ID;
+    }
+
+    @Override
+    public ZipShort getLocalFileDataLength() {
+        return new ZipShort(localData.length);
+    }
+
+    @Override
+    public ZipShort getCentralDirectoryLength() {
+        return new ZipShort(localData.length);
+    }
+
+    @Override
+    public byte[] getLocalFileDataData() {
+        return localData;
+    }
+
+    @Override
+    public byte[] getCentralDirectoryData() {
+        return localData;
+    }
+
+    @Override
+    public void parseFromLocalFileData(byte[] data, int offset, int length) {
+        byte[] tmp = new byte[length];
+        System.arraycopy(data, offset, tmp, 0, length);
+        this.localData = tmp;
+
+        if (this.localData.length == 5 && this.localData[0] == FLAG_MODTIME_PRESENT) {
+            this.javaTime = parseTimestamp(Arrays.copyOfRange(this.localData, 1, this.localData.length));
+        }
+    }
+
+    private Long parseTimestamp(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        int unixTimestamp = buffer.getInt();
+        return (long)unixTimestamp * 1_000;
+    }
+
+}

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtendedTimestampExtraField.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtendedTimestampExtraField.java
@@ -1,3 +1,21 @@
+/**
+ * This file is part of muCommander, http://www.mucommander.com
+ *
+ * muCommander is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * muCommander is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
 package com.mucommander.commons.file.archive.zip.provider;
 
 import java.nio.ByteBuffer;

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtraFieldUtils.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtraFieldUtils.java
@@ -44,6 +44,7 @@ public class ExtraFieldUtils {
         implementations = new Hashtable<>();
         register(AsiExtraField.class);
         register(JarMarker.class);
+        register(ExtendedTimestampExtraField.class);
     }
 
     /**

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
@@ -450,18 +450,18 @@ public class ZipEntry implements Cloneable {
      * @return this entry's date/time expressed in the Java time format
      */
     public long getTime() {
-        Optional<Long> timeExtended = getTimeExtended();
+        var timeExtended = getTimeExtended();
         return timeExtended.orElse(javaTime);
     }
 
-    public Optional<Long> getTimeExtended() {
+    private Optional<Long> getTimeExtended() {
         if (this.extraFields == null) {
             return null;
         }
         return this.extraFields.stream()
                         .filter(f -> f instanceof ExtendedTimestampExtraField)
                         .map(f -> (ExtendedTimestampExtraField)f)
-                        .map(t -> t.getJavaTime())
+                        .map(ExtendedTimestampExtraField::getJavaTime)
                         .findFirst();
     }
 

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
@@ -19,6 +19,7 @@
 package com.mucommander.commons.file.archive.zip.provider;
 
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Vector;
 import java.util.stream.Stream;
 import java.util.zip.ZipException;
@@ -449,21 +450,19 @@ public class ZipEntry implements Cloneable {
      * @return this entry's date/time expressed in the Java time format
      */
     public long getTime() {
-        Long timeExtended = getTimeExtended();
-        return timeExtended != null ? timeExtended : javaTime;
+        Optional<Long> timeExtended = getTimeExtended();
+        return timeExtended.orElse(javaTime);
     }
 
-    public Long getTimeExtended() {
+    public Optional<Long> getTimeExtended() {
         if (this.extraFields == null) {
             return null;
         }
-        ExtendedTimestampExtraField extendedTimestampExtraField =
-                this.extraFields.stream()
+        return this.extraFields.stream()
                         .filter(f -> f instanceof ExtendedTimestampExtraField)
                         .map(f -> (ExtendedTimestampExtraField)f)
-                        .findFirst()
-                        .orElse(null);
-        return extendedTimestampExtraField != null ? extendedTimestampExtraField.getJavaTime() : null;
+                        .map(t -> t.getJavaTime())
+                        .findFirst();
     }
 
     /**

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
@@ -455,12 +455,10 @@ public class ZipEntry implements Cloneable {
     }
 
     private Optional<Long> getTimeExtended() {
-        if (this.extraFields == null) {
-            return null;
-        }
-        return this.extraFields.stream()
+        return extraFields == null ? Optional.empty()
+                : extraFields.stream()
                         .filter(f -> f instanceof ExtendedTimestampExtraField)
-                        .map(f -> (ExtendedTimestampExtraField)f)
+                        .map(f -> (ExtendedTimestampExtraField) f)
                         .map(ExtendedTimestampExtraField::getJavaTime)
                         .findFirst();
     }

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
@@ -449,7 +449,21 @@ public class ZipEntry implements Cloneable {
      * @return this entry's date/time expressed in the Java time format
      */
     public long getTime() {
-        return javaTime;
+        Long timeExtended = getTimeExtended();
+        return timeExtended != null ? timeExtended : javaTime;
+    }
+
+    public Long getTimeExtended() {
+        if (this.extraFields == null) {
+            return null;
+        }
+        ExtendedTimestampExtraField extendedTimestampExtraField =
+                this.extraFields.stream()
+                        .filter(f -> f instanceof ExtendedTimestampExtraField)
+                        .map(f -> (ExtendedTimestampExtraField)f)
+                        .findFirst()
+                        .orElse(null);
+        return extendedTimestampExtraField != null ? extendedTimestampExtraField.getJavaTime() : null;
     }
 
     /**


### PR DESCRIPTION
This PR address issue #1203.

## Background
A zip archive contains a central directory record, which lists all files included in the archive file. For each file there is a modification time and date fields (in MS-DOS format, meaning offset in seconds from 1980-01-01).

In some modern zip implementation (for example, Google Drive generated files), instead of using the above fields, an extended timestamp field is being used. This field is included in the _Extra field_ of a file record (see [reference](https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html) and also on [libzip's website](https://libzip.org/specifications/extrafld.txt)). This field uses epoch time. In these cases, muC will show the file modification time as 1980-01-01, since the MS-DOS time offset is 0.

## Suggested change
muC uses custom code to parse zip files (based on Apache Ant). After investigating the code, I saw _Extra field_ values are already parsed in a generic manner (represented as `UnrecognizedExtraField`). I have created a new extra field implementation called `ExtendedTimestampExtraField` to represent the aforementioned extended timestamp field.

I then altered the `ZipEntry::getTime` method to use the extended time data if it is available. 

## Testing
Using a zip file generated by Google Drive and provided by @rhstanton [here](https://github.com/mucommander/mucommander/issues/1203#issuecomment-2141238123), here is a screenshot before the change (notice file dates):
![image](https://github.com/mucommander/mucommander/assets/7936008/4ba0fd43-3c98-4b55-a656-b9bbee3c740e)

and after the change:
![image](https://github.com/mucommander/mucommander/assets/7936008/0704a35b-65ca-48d2-95cf-34cc6a6178c3)
