### PR TITLE
image viewer - faster display of big images (esp JPGs), some smaller fixes, additional formats

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/Activator.java
+++ b/mucommander-core/src/main/java/com/mucommander/Activator.java
@@ -42,7 +42,6 @@ import com.mucommander.conf.MuConfigurations;
 import com.mucommander.conf.MuPreference;
 import com.mucommander.desktop.ActionType;
 import com.mucommander.os.api.CoreService;
-import com.mucommander.osgi.BrowsableItemsMenuService;
 import com.mucommander.osgi.BrowsableItemsMenuServiceTracker;
 import com.mucommander.osgi.FileEditorServiceTracker;
 import com.mucommander.osgi.FileViewerServiceTracker;
@@ -197,10 +196,6 @@ public class Activator implements BundleActivator {
         return context.getProperty("mucommander.keymap");
     }
 
-    public String shellHistory() {
-        return context.getProperty("mucommander.shellHistory");
-    }
-
     public String toolbar() {
         return context.getProperty("mucommander.toolbar");
     }
@@ -256,10 +251,15 @@ public class Activator implements BundleActivator {
 
                 AbstractFile file = FileFactory.getFile(path);
                 FolderPanel activePanel = WindowManager.getCurrentMainFrame().getActivePanel();
-                if (file.isBrowsable())
+                if (file == null) {
+                    LOGGER.error("Ignoring open file, as File is null for path: {}.", path);
+                    return;
+                }
+                if (file.isBrowsable()) {
                     activePanel.tryChangeCurrentFolder(file);
-                else
+                } else {
                     activePanel.tryChangeCurrentFolder(file.getParent(), file, false);
+                }
             }
         };
     }

--- a/mucommander-core/src/main/java/com/mucommander/ui/layout/AsyncPanel.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/layout/AsyncPanel.java
@@ -26,6 +26,7 @@ import java.awt.Window;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.AncestorEvent;
 import javax.swing.event.AncestorListener;
@@ -103,19 +104,15 @@ public abstract class AsyncPanel extends JPanel {
      * Loads the target component by calling {@link #getTargetComponent()} and replace the wait component by it.
      */
     private void loadTargetComponent() {
-        new Thread() {
-            @Override
-            public void run() {
-                JComponent targetComponent = getTargetComponent();
-
+        new Thread(() -> {
+            JComponent targetComponent = getTargetComponent();
+            SwingUtilities.invokeLater(() -> {
                 remove(waitComponent);
                 setBorder(new EmptyBorder(0, 0, 0, 0));
-
                 add(targetComponent, BorderLayout.CENTER);
-
                 updateLayout();
-            }
-        }.start();
+            });
+        }).start();
     }
 
     /**

--- a/mucommander-viewer-image/build.gradle
+++ b/mucommander-viewer-image/build.gradle
@@ -6,17 +6,35 @@ dependencies {
     api project(':mucommander-viewer-api')
     api project(':mucommander-translator')
 
+    comprise 'com.twelvemonkeys.imageio:imageio-core:3.11.0'
+
+    // image plugins to handle additional types (like psd) or faster alternatives to built-in ones (jpeg)
+    comprise 'com.twelvemonkeys.imageio:imageio-jpeg:3.11.0'
+    comprise 'com.twelvemonkeys.imageio:imageio-tiff:3.11.0'
+    comprise 'com.twelvemonkeys.imageio:imageio-psd:3.11.0'
+    comprise 'com.twelvemonkeys.imageio:imageio-webp:3.11.0'
+    // requirements for plugins
+    comprise 'com.twelvemonkeys.common:common-lang:3.11.0'
+    comprise 'com.twelvemonkeys.common:common-io:3.11.0'
+    comprise 'com.twelvemonkeys.imageio:imageio-metadata:3.11.0'
+
+
     compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
 
     testImplementation 'org.testng:testng:7.10.2'
 }
 
 jar {
+   from configurations.comprise.collect { it.isDirectory() ? it : zipTree(it).matching {
+        exclude 'META-INF/**'
+   } }
+   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
    bnd ('Bundle-Name': 'muCommander-viewer-image',
         'Bundle-Vendor': 'muCommander',
-        'Bundle-Description': 'Library for hexadecimal viewer/editor',
+        'Bundle-Description': 'Library for previewing image files',
         'Bundle-DocURL': 'https://www.mucommander.com',
         'Export-Package': 'com.mucommander.viewer.image',
+        'Import-Package': '!magick,*',
         'Bundle-Activator': 'com.mucommander.viewer.image.Activator',
         'Specification-Title': "muCommander",
         'Specification-Vendor': "Arik Hadas",

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewer.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewer.java
@@ -26,25 +26,11 @@ import com.mucommander.viewer.FileViewer;
 import com.mucommander.viewer.ViewerPresenter;
 import com.mucommander.viewer.image.ui.ImageStatusPanel;
 import com.mucommander.viewer.image.ui.ImageViewerPanel;
+import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.swing.AbstractAction;
-import javax.swing.ButtonGroup;
-import javax.swing.JCheckBoxMenuItem;
-import javax.swing.JComponent;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JRadioButtonMenuItem;
-import javax.swing.JScrollPane;
-import javax.swing.JViewport;
-import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Cursor;
 import java.awt.Dimension;
@@ -63,13 +49,36 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Iterator;
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import javax.swing.AbstractAction;
+import javax.swing.ButtonGroup;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JComponent;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
 /**
- * A simple image viewer, capable of displaying <code>PNG</code>, <code>GIF</code> and <code>JPEG</code> images.
+ * A simple image viewer, capable of displaying the images supported natively by JRE
+ * or with help of TwelveMonkey plugins, most commonly: png, gif, jpeg, psd, webp, tiff, bmp/wbmp.
  *
  * @author Maxence Bernard, Arik Hadas
  */
@@ -86,7 +95,7 @@ class ImageViewer implements FileViewer, ActionListener {
     private JScrollPane scrollPane = new JScrollPane();
     private ImageStatusPanel statusPanel = new ImageStatusPanel();
 
-    private InitialZoom initialZoom = InitialZoom.RESIZE_WINDOW;
+    private InitialZoom initialZoom = InitialZoom.FIT_TO_WINDOW;
     private boolean firstZoomPerformed = false;
 
     /** Menu bar */
@@ -309,17 +318,33 @@ class ImageViewer implements FileViewer, ActionListener {
     private synchronized void loadImage(AbstractFile file) throws IOException {
         presenter.getWindowFrame().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 
-        Image image;
-        try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
-            try (InputStream in = file.getInputStream()) {
-                StreamUtils.copyStream(in, bout);
-                image = imageViewerPanel.getToolkit().createImage(bout.toByteArray());
+        long start = System.currentTimeMillis();
+        BufferedImage image;
+
+        try (ByteArrayOutputStream bout = new ByteArrayOutputStream();
+             InputStream in = file.getInputStream()) {
+
+            StreamUtils.copyStream(in, bout);
+            try (ImageInputStream input = new ByteArrayImageInputStream(bout.toByteArray())) {
+                Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+                if (!readers.hasNext()) {
+                    throw new IllegalArgumentException("No reader for a given file: " + file);
+                }
+                ImageReader reader = readers.next();
+                try {
+                    reader.setInput(input);
+                    image = reader.read(0);
+                } finally {
+                    reader.dispose();
+                }
             }
         }
 
         waitForImage(image);
         imageViewerPanel.setImage(image);
         initialZoom();
+        LOGGER.debug("Display of: {}, size: {} took: {} ms", file, file.getSize(),
+                System.currentTimeMillis() - start);
     }
 
     private void initialZoom() {

--- a/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerSnapshot.java
+++ b/mucommander-viewer-image/src/main/java/com/mucommander/viewer/image/ImageViewerSnapshot.java
@@ -33,6 +33,7 @@ public final class ImageViewerSnapshot extends MuSnapshotable<ImageViewerPrefere
         super(ImageViewerPreferences::values,
                 ImageViewerPreferences::getValue,
                 ImageViewerPreferences::setValue,
-                pref -> pref.getPrefKey() != null ? IMAGE_FILE_PRESENTER_SECTION + "." + pref.getPrefKey() : null);
+                pref -> pref.getPrefKey() != null ?
+                        IMAGE_FILE_PRESENTER_SECTION + "." + pref.getPrefKey() : null);
     }
 }

--- a/mucommander-viewer-pdf/build.gradle
+++ b/mucommander-viewer-pdf/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':mucommander-translator')
 
     comprise 'com.github.pcorless.icepdf:icepdf-viewer:7.1.3'
-    comprise 'com.twelvemonkeys.imageio:imageio-psd:3.9.4'
+    comprise 'com.twelvemonkeys.imageio:imageio-psd:3.11.0'
     comprise 'avalon-framework:avalon-framework-api:4.3'
     implementation 'org.jmdns:jmdns:3.5.5'
 

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -36,7 +36,7 @@ New features:
 
 Improvements:
 - Don't show warning message about too large file while previewing images files.
--
+- Image preview: faster display of large JPEG files, added support for the following image formats: webp, psd (and psb)
 
 Localization:
 -


### PR DESCRIPTION
- faster load of bigger JPGs (like 10MB+ - ~2-3x faster) - thanks to TwelveMonkeys and its `ByteArrayImageInputStream`, plus its JPEG/TIFF plugins 
- fix for JPEG orientation, apparently TwelveMonkeys JPEG plugin works better to determine the correct orientation
- fix for non-deterministic behavior when loading image and window was empty
- added TwelveMonkeys plugins for additional image formats that image viewer can display: webp, psd (and psb)
- the list of extensions supported by JRE TwelveMonkeys plugins is taken from ImageIO and not hardcoded

TwelveMonkeys could also be used for nice resampling for scaled images (TBD in future).