### PR TITLE
Added -PskipDmgSign param for dmg task, readme.md updated/refreshed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are several ways to contribute to muCommander:
 
 - Found a bug or thinking about a useful feature that is missing? [File an issue](https://github.com/mucommander/mucommander/issues)
 - Want to fix a bug or implement a feature? We are using the standard [GitHub flow](https://guides.github.com/introduction/flow/): fork, make the changes, and submit a pull request. Changes are merged to the *master* branch. See the next section for tips for developing muCommander.
-- If you happen to speak a language that muCommander is not available in or able to improve existing translations, you can help translate the interface see [here](https://github.com/mucommander/mucommander/wiki/Translate) for more details.
+- If you happen to speak a language that muCommander is not available in or able to improve existing translations, you can help translate the interface, see more details [here](https://github.com/mucommander/mucommander/wiki/Translate).
 
 If you want to get involved in muCommander or have any question or issue to discuss, you are more than welcome to join our rooms on [Gitter](https://gitter.im/mucommander).  
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 [![Coverity Scan](https://scan.coverity.com/projects/3642/badge.svg)](https://scan.coverity.com/projects/3642)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/mucommander/Lobby)
 
-muCommander is a lightweight, cross-platform file manager with a dual-pane interface.  
+muCommander is a lightweight, cross-platform file manager with a dual-pane interface.
 It runs on any operating system with Java support (macOS, Windows, Linux, *BSD, Solaris...).
 
-Official website: https://www.mucommander.com  
+Official website: https://www.mucommander.com
 
 ## Contribution
 
 
-There are several ways to contribute to muCommander:  
+There are several ways to contribute to muCommander:
 
 - Found a bug or thinking about a useful feature that is missing? [File an issue](https://github.com/mucommander/mucommander/issues)
 - Want to fix a bug or implement a feature? We are using the standard [GitHub flow](https://guides.github.com/introduction/flow/): fork, make the changes, and submit a pull request. Changes are merged to the *master* branch. See the next section for tips for developing muCommander.
-- If you happen to speak a language that muCommander is not available in or able to improve existing translations, you can help translate the interface using the [zanata platform](https://translate.zanata.org/project/view/mucommander).  
+- If you happen to speak a language that muCommander is not available in or able to improve existing translations, you can help translate the interface see [here](https://github.com/mucommander/mucommander/wiki/Translate) for more details.
 
 If you want to get involved in muCommander or have any question or issue to discuss, you are more than welcome to join our rooms on [Gitter](https://gitter.im/mucommander).  
 
@@ -26,7 +26,7 @@ If you want to get involved in muCommander or have any question or issue to disc
 
 ### Prerequisites
 
-  - Java Development Kit (JDK) 11 or later  
+  - Java Development Kit (JDK) 11 or later
   - Git
 
 
@@ -35,50 +35,56 @@ If you want to get involved in muCommander or have any question or issue to disc
 If you would like to contribute code, it is required to fork the repository and submit a [pull request](https://help.github.com/en/articles/about-pull-requests).
 Within pull requests, it is possible to review, discuss, and improve the changes until they are ready for production. 
 
-### Code Editing  
+### Code Editing
 After cloning the source code repository from GitHub, you would probably want to import the project to an Integrated Development Environment (IDE) such as Eclipse or IntelliJ.
 
 The code repository of muCommander is comprised of a main project that contains its core functionality and several sub-projects. These projects are Gradle projects. Most of the popular IDEs today allow you to import Gradle projects out-of-the-box or via an IDE plugin. By importing the main project that is located at the root directory of the repository you will get all the required code in the IDE.
 
-### How to Run  
+### How to Run
 The use of the Gradle wrapper significantly simplifies the build from the command line. The following commands can be invoked from the root directory of the repository with no further installation.
 
-You can run the application by typing:  
+You can run the application by typing:
 ```
 ./gradlew run
 ```
 
-It is recommended to run the following command when getting an unclear compilation error:
+It is recommended to run the following command when getting an unclear compilation error, or to be sure running the just modified code:
 ```
 ./gradlew clean run
 ```    
 
-### How to Debug  
-In order to debug muCommander, you first need to configure a port using an environment variable named `DEBUG` (e.g., 5005). Then, you can run a debugger that connects to this port using your favorite IDE (see [an example for doing this with IntelliJ](https://github.com/mucommander/mucommander/wiki/Debug-from-IntelliJ)).
+### How to Debug
+In order to debug muCommander, you first need to configure a port using an environment variable named `DEBUG`.
+Example of running muCommander in debug mode:
+```
+export DEBUG=5005
+./gradlew run
+```
+Then, you can run a debugger that connects to this port using your favorite IDE (see [an example for doing this with IntelliJ](https://github.com/mucommander/mucommander/wiki/Debug-from-IntelliJ)).
 
 
 ### Packaging
-The creation of a DMG file for MAC OS (produced in build/distributions):  
+The creation of a DMG file for macOS (produced in build/distributions):
 ```
-./gradlew dmg
+./gradlew clean dmg -PskipDmgSign
 ```
 
-Note: as the application is not signed, the following error may appear when trying to start it on macOS: "muCommander damaged and cannot be opened".  
+Note: as the application is not signed, the following error may appear when trying to start it on macOS: "muCommander damaged and cannot be opened".
 This can be solved by executing: `sudo xattr -r -d com.apple.quarantine /Applications/muCommander.app`
 
-The creation of an EXE file for Windows (produced in build/launch4j):  
+The creation of an EXE file for Windows (produced in build/launch4j):
 ```
-./gradlew createExe
+./gradlew clean createExe
 ```
 
-The creation of a TGZ file for Linux/Unix (produced in build/distributions):  
+The creation of a TGZ file for Linux/Unix (produced in build/distributions):
 ```
-./gradlew tgz
+./gradlew clean tgz
 ```
 
 The creation of an RPM file:  
 ```
-./gradlew rpm
+./gradlew clean rpm
 ```
 
 More packaging options are described in [our wiki](https://github.com/mucommander/mucommander/wiki/Packaging).

--- a/build.gradle
+++ b/build.gradle
@@ -389,7 +389,10 @@ task(afterEclipseImport).doLast {
 
 task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
     workingDir "${projectDir}"
-    commandLine 'jpackage', \
+
+
+    def jpackageCommand = [
+                'jpackage', \
                 '--input', 'build/osgi/', \
                 '--name', 'muCommander', \
                 '--app-version', project.version, \
@@ -417,8 +420,18 @@ task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
                 '--mac-package-identifier', 'com.mucommander.muCommander', \
                 '--type', 'app-image', \
                 '--dest', "${buildDir}", \
-                '--mac-sign', '--mac-package-signing-prefix', 'com.mucommander.', \
-                '--verbose', '--mac-signing-key-user-name', project.ext.identity
+                '--mac-package-signing-prefix', 'com.mucommander.', \
+                '--mac-signing-key-user-name', project.ext.identity, \
+                '--verbose'
+    ]
+
+    // skip signing if gradle invoked with -PskipDmgSign (for dev purposes only)
+    if (!project.hasProperty('skipDmgSign')) {
+      jpackageCommand += '--mac-sign'
+    }
+
+    commandLine jpackageCommand
+
     doLast {
        copy {
           from "package"


### PR DESCRIPTION
- Added -PskipDmgSign param for `dmg` task (for dev purposes) + readme.md updated for it
- readme.md: 
  - removed trailing spaces
  - removed Zanata (since it doesn't work no more), replaced with Translation wiki page (which should be updated to remove Zanata from there also)
 