### PR TITLE
Bump RSyntaxTextArea version to 3.5.0

### DIFF
--- a/mucommander-viewer-text/build.gradle
+++ b/mucommander-viewer-text/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api project(":mucommander-preferences")
 
     compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
-    comprise group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.4.0'
+    comprise group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.5.0'
 
     testImplementation 'org.testng:testng:7.10.2'
 }


### PR DESCRIPTION
Bump RSyntaxTextArea version to 3.5.0

https://github.com/bobbylight/RSyntaxTextArea/milestone/14?closed=1