### PR TITLE
Patch sevenzipbindings for M1 Mac

### DIFF
--- a/sevenzipjbindings/build.gradle
+++ b/sevenzipjbindings/build.gradle
@@ -1,6 +1,8 @@
 repositories {
     repositories.mavenCentral()
     maven {
+        // To be able to use a patched version of sevenzipjbinding-all-platforms
+        // From the following repo: https://gitlab.com/shayartzi/sevenzipjbinding/-/packages/27273903
         url = uri("https://gitlab.com/api/v4/projects/59936705/packages/maven")
     }
 }
@@ -9,7 +11,9 @@ dependencies {
     api project(':mucommander-commons-file')
 
     comprise 'net.sf.sevenzipjbinding:sevenzipjbinding:16.02-2.01'
-    // comprise 'net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01'
+
+    // Use a patched version of sevenzipjbinding-all-platforms for Mac M1 support.
+    // See https://github.com/mucommander/mucommander/pull/1237
     comprise 'com.github.shayartzi.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01'
 
     testImplementation 'org.testng:testng:7.10.2'

--- a/sevenzipjbindings/build.gradle
+++ b/sevenzipjbindings/build.gradle
@@ -1,7 +1,6 @@
 repositories {
     repositories.mavenCentral()
     maven {
-        // To be able to use a patched version of sevenzipjbinding-all-platforms
         url = uri("https://www.mucommander.com/maven/")
     }
 }

--- a/sevenzipjbindings/build.gradle
+++ b/sevenzipjbindings/build.gradle
@@ -2,8 +2,7 @@ repositories {
     repositories.mavenCentral()
     maven {
         // To be able to use a patched version of sevenzipjbinding-all-platforms
-        // From the following repo: https://gitlab.com/shayartzi/sevenzipjbinding/-/packages/27273903
-        url = uri("https://gitlab.com/api/v4/projects/59936705/packages/maven")
+        url = uri("https://www.mucommander.com/maven/")
     }
 }
 
@@ -14,7 +13,7 @@ dependencies {
 
     // Use a patched version of sevenzipjbinding-all-platforms for Mac M1 support.
     // See https://github.com/mucommander/mucommander/pull/1237
-    comprise 'com.github.shayartzi.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01'
+    comprise 'com.mucommander:sevenzipjbinding-all-platforms:16.02-2.01'
 
     testImplementation 'org.testng:testng:7.10.2'
 }

--- a/sevenzipjbindings/build.gradle
+++ b/sevenzipjbindings/build.gradle
@@ -1,10 +1,16 @@
-repositories.mavenCentral()
+repositories {
+    repositories.mavenCentral()
+    maven {
+        url = uri("https://gitlab.com/api/v4/projects/59936705/packages/maven")
+    }
+}
 
 dependencies {
     api project(':mucommander-commons-file')
 
     comprise 'net.sf.sevenzipjbinding:sevenzipjbinding:16.02-2.01'
-    comprise 'net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01'
+    // comprise 'net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01'
+    comprise 'com.github.shayartzi.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01'
 
     testImplementation 'org.testng:testng:7.10.2'
 }


### PR DESCRIPTION
This PR adds M1 support for `sevenzipbindings`. It's a kind of non-traditional short-term fix, I would appreciate any feedback/suggestions for improvement.

## The problem
 `sevenzipbindings` did not have a new release for quite some time. The [last release](https://github.com/borisbrodski/sevenzipjbinding/releases/tag/Release-16.02-2.01) was in the beginning of 2020, and this is what muC is currently using.

In this release, the `sevenzipjbinding-all-platforms` artifact does not contain a native library for M1 Mac (`Mac-aarch64` support).

This impacts muC's ability to open `rar` and `7z` files under M1.

## Temporary solution
Since it does not look like a new release is coming anytime soon (see [this issue](https://github.com/borisbrodski/sevenzipjbinding/issues/63)), I wanted to try and patch the latest release to include `Mac-aarch64` support.

I compiled `sevenzipbindings` on an M1 Mac according to the instructions [here](https://github.com/borisbrodski/sevenzipjbinding/issues/47#issuecomment-2037593450). Then, I patched the original `sevenzipjbinding-all-platforms` to include the compiled artifact. I was then able to confirm 7z and rar files are working as expected on M1. I also got a positive feedback from @Andreas0602 [here](https://github.com/mucommander/mucommander/issues/1218#issuecomment-2227761018).

The next thing I did was to look for a way to easily publish a maven package. I cloned [szb](https://github.com/ShayArtzi/sevenzipjbinding) and was hoping to use github packages to serve the patched jar, but unfortunately it looks like it's not possible to have a public facing package registry that does not require any authentication.

I then created a mirror [gitlab repository](https://gitlab.com/shayartzi/sevenzipjbinding) for the above repo, and was able to [publish the package over there](https://gitlab.com/shayartzi/sevenzipjbinding/-/packages/27273903).

Finally, I changed the dependency in the relevant grade file, and I was able to build the application and confirm the patched file is being pulled from gitlab.

## Long term solution
Once szb will have a new release, we can just go back to use its releases, since the only change in the patched version is the native library addition (no java code changes at all).