### PR TITLE
Drop 'attempt to load non-existing icon' log for actions without icons

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/action/AbstractActionDescriptor.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/AbstractActionDescriptor.java
@@ -17,14 +17,13 @@
 
 package com.mucommander.ui.action;
 
-import com.mucommander.commons.file.util.ResourceLoader;
+import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
+
 import com.mucommander.core.desktop.DesktopManager;
 import com.mucommander.desktop.ActionType;
 import com.mucommander.text.Translator;
 import com.mucommander.ui.icon.IconManager;
-
-import javax.swing.ImageIcon;
-import javax.swing.KeyStroke;
 
 /**
  * AbstractActionDescriptor is an abstract class which implements ActionDescriptor interface.
@@ -50,7 +49,7 @@ public abstract class AbstractActionDescriptor implements ActionDescriptor {
     }
 
     public ImageIcon getIcon() {
-        return getStandardIcon(ActionId.asGenericAction(getId()));
+        return this.getClass().isAnnotationPresent(NoIcon.class) ? null : getStandardIcon(ActionId.asGenericAction(getId()));
     }
     
     public String getTooltip() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/NoIcon.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/NoIcon.java
@@ -1,0 +1,9 @@
+package com.mucommander.ui.action;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoIcon {
+
+}

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/TerminalActions.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/TerminalActions.java
@@ -53,6 +53,7 @@ public class TerminalActions {
         }
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
 
         private final Action action;

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/BatchRenameAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/BatchRenameAction.java
@@ -29,28 +29,26 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.BatchRenameDialog;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action invokes the 'Batch-Rename' dialog which allows to
- * rename selected files.
+ * This action invokes the 'Batch-Rename' dialog which allows to rename selected files.
  *
  * @author Mariusz Jakubowski
  */
 @InvokesDialog
 public class BatchRenameAction extends SelectedFilesAction {
 
-    public BatchRenameAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public BatchRenameAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setSelectedFileFilter(new OrFileFilter(
-            new FileOperationFilter(FileOperation.RENAME),
-            new AndFileFilter(
-                new FileOperationFilter(FileOperation.READ_FILE),
-                new FileOperationFilter(FileOperation.WRITE_FILE)
-            )
-        ));
+                new FileOperationFilter(FileOperation.RENAME),
+                new AndFileFilter(
+                        new FileOperationFilter(FileOperation.READ_FILE),
+                        new FileOperationFilter(FileOperation.WRITE_FILE))));
     }
 
     @Override
@@ -58,14 +56,19 @@ public class BatchRenameAction extends SelectedFilesAction {
         new BatchRenameDialog(mainFrame, files).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.BatchRename.getId(); }
+        public String getId() {
+            return ActionType.BatchRename.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/BringAllToFrontAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/BringAllToFrontAction.java
@@ -25,27 +25,27 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.WindowManager;
 
 /**
- * Brings all MainFrame windows to front, from the last window index to the first, except for the current
- * (or last active) MainFrame which is brought to the front last. .
- * After this action has been performed, minimized windows will return to a normal state and windows will be stacked
- * in the following order:
+ * Brings all MainFrame windows to front, from the last window index to the first, except for the current (or last
+ * active) MainFrame which is brought to the front last. . After this action has been performed, minimized windows will
+ * return to a normal state and windows will be stacked in the following order:
  * <ul>
- *  <li>Current MainFrame
- *  <li>MainFrame #1
- *  <li>MainFrame #2
- *  <li>...
- *  <li>MainFrame #N
+ * <li>Current MainFrame
+ * <li>MainFrame #1
+ * <li>MainFrame #2
+ * <li>...
+ * <li>MainFrame #N
  * </ul>
  *
  * @author Maxence Bernard
  */
 public class BringAllToFrontAction extends MuAction {
 
-    public BringAllToFrontAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public BringAllToFrontAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -56,9 +56,9 @@ public class BringAllToFrontAction extends MuAction {
 
         int nbMainFrames = mainFrames.size();
         MainFrame mainFrame;
-        for(int i=nbMainFrames-1; i>=0; i--) {
+        for (int i = nbMainFrames - 1; i >= 0; i--) {
             mainFrame = mainFrames.get(i);
-            if(mainFrame!=currentMainFrame) {
+            if (mainFrame != currentMainFrame) {
                 mainFrame.toFront();
             }
         }
@@ -66,14 +66,19 @@ public class BringAllToFrontAction extends MuAction {
         currentMainFrame.toFront();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.BringAllToFront.getId(); }
+        public String getId() {
+            return ActionType.BringAllToFront.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.WINDOW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.WINDOW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CalculateChecksumAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CalculateChecksumAction.java
@@ -27,19 +27,20 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.CalculateChecksumDialog;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action invokes the {@link com.mucommander.ui.dialog.file.CalculateChecksumDialog} which allows to calculate
- * the checksum of the selected files and store the results in a pseudo-standard checksum file. 
+ * This action invokes the {@link com.mucommander.ui.dialog.file.CalculateChecksumDialog} which allows to calculate the
+ * checksum of the selected files and store the results in a pseudo-standard checksum file.
  *
  * @author Maxence Bernard
  */
 @InvokesDialog
-public class CalculateChecksumAction extends SelectedFilesAction  {
+public class CalculateChecksumAction extends SelectedFilesAction {
 
-    public CalculateChecksumAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CalculateChecksumAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setSelectedFileFilter(new FileOperationFilter(FileOperation.READ_FILE));
@@ -50,14 +51,19 @@ public class CalculateChecksumAction extends SelectedFilesAction  {
         new CalculateChecksumDialog(mainFrame, files).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CalculateChecksum.getId(); }
+        public String getId() {
+            return ActionType.CalculateChecksum.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ChangeDateAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ChangeDateAction.java
@@ -27,6 +27,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.ChangeDateDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -38,26 +39,30 @@ import com.mucommander.ui.main.MainFrame;
 @InvokesDialog
 public class ChangeDateAction extends SelectedFilesAction {
 
-    public ChangeDateAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ChangeDateAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setSelectedFileFilter(new FileOperationFilter(FileOperation.CHANGE_DATE));
     }
-
 
     @Override
     public void performAction(FileSet files) {
         new ChangeDateDialog(mainFrame, files).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ChangeDate.getId(); }
+        public String getId() {
+            return ActionType.ChangeDate.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ChangeLocationAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ChangeLocationAction.java
@@ -23,43 +23,48 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action transfers focus to the location field of the currently active FolderPanel to edit or type in
- * a new folder location.
+ * This action transfers focus to the location field of the currently active FolderPanel to edit or type in a new folder
+ * location.
  *
  * @author Maxence Bernard
  */
 public class ChangeLocationAction extends ActiveTabAction {
 
-    public ChangeLocationAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ChangeLocationAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     /**
-     * Enables or disables this action based on the currently active folder's
-     * current tab is not locked, this action will be enabled,
-     * if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's current tab is not locked, this action
+     * will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked());
     }
-    
+
     @Override
     public void performAction() {
         mainFrame.getActivePanel().getLocationTextField().requestFocus();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ChangeLocation.getId(); }
+        public String getId() {
+            return ActionType.ChangeLocation.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ChangePermissionsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ChangePermissionsAction.java
@@ -27,6 +27,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.ChangePermissionsDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -38,7 +39,7 @@ import com.mucommander.ui.main.MainFrame;
 @InvokesDialog
 public class ChangePermissionsAction extends SelectedFilesAction {
 
-    public ChangePermissionsAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ChangePermissionsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setSelectedFileFilter(new FileOperationFilter(FileOperation.CHANGE_PERMISSION));
@@ -49,14 +50,19 @@ public class ChangePermissionsAction extends SelectedFilesAction {
         new ChangePermissionsDialog(mainFrame, files).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ChangePermissions.getId(); }
+        public String getId() {
+            return ActionType.ChangePermissions.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CheckForUpdatesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CheckForUpdatesAction.java
@@ -25,6 +25,7 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.startup.CheckVersionDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -36,7 +37,7 @@ import com.mucommander.ui.main.MainFrame;
 @InvokesDialog
 public class CheckForUpdatesAction extends MuAction {
 
-    public CheckForUpdatesAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CheckForUpdatesAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -45,14 +46,19 @@ public class CheckForUpdatesAction extends MuAction {
         new CheckVersionDialog(mainFrame, true);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CheckForUpdates.getId(); }
+        public String getId() {
+            return ActionType.CheckForUpdates.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloneTabToOtherPanelAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloneTabToOtherPanelAction.java
@@ -25,6 +25,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -34,25 +35,29 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class CloneTabToOtherPanelAction extends MuAction {
 
-    public CloneTabToOtherPanelAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CloneTabToOtherPanelAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	AbstractFile currentLocation = mainFrame.getActivePanel().getCurrentFolder();
-    	mainFrame.getInactivePanel().getTabs().add(currentLocation);
+        AbstractFile currentLocation = mainFrame.getActivePanel().getCurrentFolder();
+        mainFrame.getInactivePanel().getTabs().add(currentLocation);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CloneTabToOtherPanel.getId(); }
+        public String getId() {
+            return ActionType.CloneTabToOtherPanel.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }
-

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloseDuplicateTabsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloseDuplicateTabsAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -32,24 +33,29 @@ import com.mucommander.ui.main.MainFrame;
  * @author Arik Hadas
  */
 public class CloseDuplicateTabsAction extends MuAction {
-	
-	public CloseDuplicateTabsAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public CloseDuplicateTabsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	mainFrame.getActivePanel().getTabs().closeDuplicateTabs();
+        mainFrame.getActivePanel().getTabs().closeDuplicateTabs();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CloseDuplicateTabs.getId(); }
+        public String getId() {
+            return ActionType.CloseDuplicateTabs.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloseOtherTabsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloseOtherTabsAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -32,24 +33,29 @@ import com.mucommander.ui.main.MainFrame;
  * @author Arik Hadas
  */
 public class CloseOtherTabsAction extends MuAction {
-	
-	public CloseOtherTabsAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public CloseOtherTabsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	mainFrame.getActivePanel().getTabs().closeOtherTabs();
+        mainFrame.getActivePanel().getTabs().closeOtherTabs();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CloseOtherTabs.getId(); }
+        public String getId() {
+            return ActionType.CloseOtherTabs.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloseTabAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CloseTabAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -32,35 +33,39 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class CloseTabAction extends ActiveTabAction {
 
-    public CloseTabAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CloseTabAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
-    
+
     /**
-     * Enables or disables this action based on the currently active folder's
-     * current tab is not locked and is not the only tab in the panel,
-     * this action will be enabled, if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's current tab is not locked and is not the
+     * only tab in the panel, this action will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked() &&
-        		    mainFrame.getActivePanel().getTabs().getTabsCount() > 1);
+                mainFrame.getActivePanel().getTabs().getTabsCount() > 1);
     }
 
     @Override
     public void performAction() {
         // Changes the current folder to make it the user home folder
-    	mainFrame.getActivePanel().getTabs().closeCurrentTab();
+        mainFrame.getActivePanel().getTabs().closeCurrentTab();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CloseTab.getId(); }
+        public String getId() {
+            return ActionType.CloseTab.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CombineFilesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CombineFilesAction.java
@@ -31,6 +31,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.CombineFilesDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -41,8 +42,8 @@ import com.mucommander.ui.main.MainFrame;
  */
 @InvokesDialog
 public class CombineFilesAction extends SelectedFilesAction {
-	
-    public CombineFilesAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public CombineFilesAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setSelectedFileFilter(new FileOperationFilter(FileOperation.READ_FILE));
@@ -54,21 +55,26 @@ public class CombineFilesAction extends SelectedFilesAction {
         FileFilter filter = new AttributeFileFilter(FileAttribute.FILE);
         filter.filter(files);
 
-    	if (files.size()==0)
-    		return;
+        if (files.size() == 0)
+            return;
 
         AbstractFile destFolder = mainFrame.getInactivePanel().getCurrentFolder();
         new CombineFilesDialog(mainFrame, files, destFolder).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CombineFiles.getId(); }
+        public String getId() {
+            return ActionType.CombineFiles.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CompareFoldersAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CompareFoldersAction.java
@@ -25,6 +25,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 import com.mucommander.ui.main.table.FileTableModel;
@@ -36,7 +37,7 @@ import com.mucommander.ui.main.table.FileTableModel;
  */
 public class CompareFoldersAction extends MuAction {
 
-    public CompareFoldersAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CompareFoldersAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -53,37 +54,37 @@ public class CompareFoldersAction extends MuAction {
         int fileIndex;
         String tempFileName;
         AbstractFile tempFile;
-        for(int i=0; i<nbFilesLeft; i++) {
+        for (int i = 0; i < nbFilesLeft; i++) {
             tempFile = leftTableModel.getFileAt(i);
-            if(tempFile.isDirectory())
+            if (tempFile.isDirectory())
                 continue;
 
             tempFileName = tempFile.getName();
             fileIndex = -1;
-            for(int j=0; j<nbFilesRight; j++)
+            for (int j = 0; j < nbFilesRight; j++)
                 if (rightTableModel.getFileAt(j).getName().equals(tempFileName)) {
                     fileIndex = j;
                     break;
                 }
-            if (fileIndex==-1 || rightTableModel.getFileAt(fileIndex).getDate()<tempFile.getDate()) {
+            if (fileIndex == -1 || rightTableModel.getFileAt(fileIndex).getDate() < tempFile.getDate()) {
                 leftTableModel.setFileMarked(tempFile, true);
                 leftTable.repaint();
             }
         }
 
-        for(int i=0; i<nbFilesRight; i++) {
+        for (int i = 0; i < nbFilesRight; i++) {
             tempFile = rightTableModel.getFileAt(i);
-            if(tempFile.isDirectory())
+            if (tempFile.isDirectory())
                 continue;
 
             tempFileName = tempFile.getName();
             fileIndex = -1;
-            for(int j=0; j<nbFilesLeft; j++)
+            for (int j = 0; j < nbFilesLeft; j++)
                 if (leftTableModel.getFileAt(j).getName().equals(tempFileName)) {
                     fileIndex = j;
                     break;
                 }
-            if (fileIndex==-1 || leftTableModel.getFileAt(fileIndex).getDate()<tempFile.getDate()) {
+            if (fileIndex == -1 || leftTableModel.getFileAt(fileIndex).getDate() < tempFile.getDate()) {
                 rightTableModel.setFileMarked(tempFile, true);
                 rightTable.repaint();
             }
@@ -94,14 +95,19 @@ public class CompareFoldersAction extends MuAction {
         rightTable.fireMarkedFilesChangedEvent();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CompareFolders.getId(); }
+        public String getId() {
+            return ActionType.CompareFolders.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFileBaseNamesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFileBaseNamesAction.java
@@ -24,23 +24,25 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dnd.ClipboardSupport;
 import com.mucommander.ui.dnd.TransferableFileSet;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action copies the file base name(s) (without extension) of the currently selected / marked files(s) to the system clipboard.
+ * This action copies the file base name(s) (without extension) of the currently selected / marked files(s) to the
+ * system clipboard.
  *
  * @author Chen Rozenes
  */
 public class CopyFileBaseNamesAction extends SelectedFilesAction {
 
-	public CopyFileBaseNamesAction(MainFrame mainFrame, Map<String, Object> properties) {
-		super(mainFrame, properties);
-	}
+    public CopyFileBaseNamesAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
 
-	@Override
-	public void performAction(FileSet files) {
+    @Override
+    public void performAction(FileSet files) {
         // Create a TransferableFileSet and make DataFlavour.stringFlavor (text) the only DataFlavour supported
         TransferableFileSet tfs = new TransferableFileSet(files);
 
@@ -52,23 +54,28 @@ public class CopyFileBaseNamesAction extends SelectedFilesAction {
 
         // Transfer filenames, not file paths
         tfs.setStringDataFlavourTransfersFilename(true);
-        
+
         // Transfer base names (filename without its extension)
         tfs.setStringDataFlavourTransfersFileBaseName(true);
 
         ClipboardSupport.setClipboardContents(tfs);
 
-	}
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() {	return ActionType.CopyFileBaseNames.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.CopyFileBaseNames.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
-	}
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
+    }
 
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFileNamesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFileNamesAction.java
@@ -24,10 +24,10 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dnd.ClipboardSupport;
 import com.mucommander.ui.dnd.TransferableFileSet;
 import com.mucommander.ui.main.MainFrame;
-
 
 /**
  * This action copies the filename(s) of the currently selected / marked files(s) to the system clipboard.
@@ -36,7 +36,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class CopyFileNamesAction extends SelectedFilesAction {
 
-    public CopyFileNamesAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CopyFileNamesAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -57,14 +57,19 @@ public class CopyFileNamesAction extends SelectedFilesAction {
         ClipboardSupport.setClipboardContents(tfs);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CopyFileNames.getId(); }
+        public String getId() {
+            return ActionType.CopyFileNames.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFilePathsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFilePathsAction.java
@@ -24,6 +24,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dnd.ClipboardSupport;
 import com.mucommander.ui.dnd.TransferableFileSet;
 import com.mucommander.ui.main.MainFrame;
@@ -35,7 +36,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class CopyFilePathsAction extends SelectedFilesAction {
 
-    public CopyFilePathsAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CopyFilePathsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -53,14 +54,19 @@ public class CopyFilePathsAction extends SelectedFilesAction {
         ClipboardSupport.setClipboardContents(tfs);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CopyFilePaths.getId(); }
+        public String getId() {
+            return ActionType.CopyFilePaths.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFilesToClipboardAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CopyFilesToClipboardAction.java
@@ -24,18 +24,19 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dnd.ClipboardSupport;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action copies the selected / marked files to the system clipboard, allowing to paste
- * them to muCommander or another application.
+ * This action copies the selected / marked files to the system clipboard, allowing to paste them to muCommander or
+ * another application.
  *
  * @author Maxence Bernard
  */
 public class CopyFilesToClipboardAction extends SelectedFilesAction {
 
-    public CopyFilesToClipboardAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public CopyFilesToClipboardAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -44,14 +45,19 @@ public class CopyFilesToClipboardAction extends SelectedFilesAction {
         ClipboardSupport.setClipboardFiles(files);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CopyFilesToClipboard.getId(); }
+        public String getId() {
+            return ActionType.CopyFilesToClipboard.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CustomizeCommandBarAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/CustomizeCommandBarAction.java
@@ -25,6 +25,7 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.customization.CommandBarDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -35,22 +36,29 @@ import com.mucommander.ui.main.MainFrame;
  */
 @InvokesDialog
 public class CustomizeCommandBarAction extends MuAction {
-	
-	public CustomizeCommandBarAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public CustomizeCommandBarAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
-    public void performAction() { new CommandBarDialog(mainFrame).showDialog(); }
+    public void performAction() {
+        new CommandBarDialog(mainFrame).showDialog();
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.CustomizeCommandBar.getId(); }
+        public String getId() {
+            return ActionType.CustomizeCommandBar.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/DonateAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/DonateAction.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -31,15 +32,20 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class DonateAction extends OpenURLInBrowserAction {
 
-    public DonateAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public DonateAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         putValue(URL_PROPERTY_KEY, com.mucommander.RuntimeConstants.DONATION_URL);
     }
-    
-    public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.Donate.getId(); }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.Donate.getId();
+        }
+
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/DuplicateTabAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/DuplicateTabAction.java
@@ -41,6 +41,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -49,24 +50,29 @@ import com.mucommander.ui.main.MainFrame;
  * @author Arik Hadas
  */
 public class DuplicateTabAction extends MuAction {
-	
-	public DuplicateTabAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public DuplicateTabAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	mainFrame.getActivePanel().getTabs().duplicate();
+        mainFrame.getActivePanel().getTabs().duplicate();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.DuplicateTab.getId(); }
+        public String getId() {
+            return ActionType.DuplicateTab.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/EmptyTrashAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/EmptyTrashAction.java
@@ -26,22 +26,23 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * Empties the system trash. This action is enabled only if the current platform has an
- * {@link com.mucommander.desktop.AbstractTrash} implementation and if it is capable of emptying the trash,
- * as reported by {@link com.mucommander.desktop.AbstractTrash#canEmpty()}.
+ * {@link com.mucommander.desktop.AbstractTrash} implementation and if it is capable of emptying the trash, as reported
+ * by {@link com.mucommander.desktop.AbstractTrash#canEmpty()}.
  *
  * @author Maxence Bernard
  */
 public class EmptyTrashAction extends MuAction {
 
-    public EmptyTrashAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public EmptyTrashAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         AbstractTrash trash = DesktopManager.getTrash();
-        setEnabled(trash!=null && trash.canEmpty());
+        setEnabled(trash != null && trash.canEmpty());
     }
 
     @Override
@@ -49,14 +50,19 @@ public class EmptyTrashAction extends MuAction {
         DesktopManager.getTrash().empty();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.EmptyTrash.getId(); }
+        public String getId() {
+            return ActionType.EmptyTrash.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ExploreBookmarksAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ExploreBookmarksAction.java
@@ -23,17 +23,19 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * This action changes the current folder of the currently active {@link com.mucommander.ui.main.FolderPanel} to
- * <code>bookmark://</code> which is the root of bookmark filesystem, allowing to explore all the bookmarks the user has.
+ * <code>bookmark://</code> which is the root of bookmark filesystem, allowing to explore all the bookmarks the user
+ * has.
  *
  * @author Nicolas Rinaudo
  */
 public class ExploreBookmarksAction extends ActiveTabAction {
 
-    public ExploreBookmarksAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ExploreBookmarksAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -42,24 +44,28 @@ public class ExploreBookmarksAction extends ActiveTabAction {
         mainFrame.getActivePanel().tryChangeCurrentFolder("bookmark://");
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
     /**
-     * Enables or disables this action based on the currently active folder's
-     * current tab is not locked, this action will be enabled,
-     * if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's current tab is not locked, this action
+     * will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked());
     }
-    
-    public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ExploreBookmarks.getId(); }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ExploreBookmarks.getId();
+        }
+
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/FocusNextAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/FocusNextAction.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.awt.Component;
 import java.util.Map;
 
+import javax.swing.ImageIcon;
 import javax.swing.JTextField;
 import javax.swing.JTree;
 
@@ -29,6 +30,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.FolderPanel;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
@@ -41,7 +43,7 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class FocusNextAction extends MuAction {
 
-    public FocusNextAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public FocusNextAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         // Perform the action also when in 'no events' mode
@@ -53,7 +55,7 @@ public class FocusNextAction extends MuAction {
         Component focusOwner = mainFrame.getJFrame().getFocusOwner();
 
         // Abort if the focus is not in the MainFrame this action is tied to
-        if(focusOwner==null)
+        if (focusOwner == null)
             return;
 
         FolderPanel folderPanel = mainFrame.getActivePanel();
@@ -63,11 +65,11 @@ public class FocusNextAction extends MuAction {
 
         // Request focus on the 'next' component, the cycle order being from left to right, top to bottom.
         Component nextComponent;
-        if(focusOwner==locationField)
-            nextComponent = folderPanel.isTreeVisible()?tree:fileTable;
-        else if(focusOwner==tree)
+        if (focusOwner == locationField)
+            nextComponent = folderPanel.isTreeVisible() ? tree : fileTable;
+        else if (focusOwner == tree)
             nextComponent = fileTable;
-        else if(focusOwner==fileTable)
+        else if (focusOwner == fileTable)
             nextComponent = locationField;
         else
             return;
@@ -75,14 +77,19 @@ public class FocusNextAction extends MuAction {
         FocusRequester.requestFocusInWindow(nextComponent);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.FocusNext.getId(); }
+        public String getId() {
+            return ActionType.FocusNext.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/FocusPreviousAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/FocusPreviousAction.java
@@ -29,6 +29,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.FolderPanel;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
@@ -42,7 +43,7 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class FocusPreviousAction extends MuAction {
 
-    public FocusPreviousAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public FocusPreviousAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         // Perform the action also when in 'no events' mode
@@ -54,7 +55,7 @@ public class FocusPreviousAction extends MuAction {
         Component focusOwner = mainFrame.getJFrame().getFocusOwner();
 
         // Abort if the focus is not in the MainFrame this action is tied to
-        if(focusOwner==null)
+        if (focusOwner == null)
             return;
 
         FolderPanel folderPanel = mainFrame.getActivePanel();
@@ -64,11 +65,11 @@ public class FocusPreviousAction extends MuAction {
 
         // Request focus on the 'previous' component, the cycle order being from right to left, bottom to top.
         Component previousComponent;
-        if(focusOwner==fileTable)
-            previousComponent = folderPanel.isTreeVisible()?tree:locationField;
-        else if(focusOwner==tree)
+        if (focusOwner == fileTable)
+            previousComponent = folderPanel.isTreeVisible() ? tree : locationField;
+        else if (focusOwner == tree)
             previousComponent = locationField;
-        else if(focusOwner==locationField)
+        else if (focusOwner == locationField)
             previousComponent = fileTable;
         else
             return;
@@ -76,14 +77,19 @@ public class FocusPreviousAction extends MuAction {
         FocusRequester.requestFocusInWindow(previousComponent);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.FocusPrevious.getId(); }
+        public String getId() {
+            return ActionType.FocusPrevious.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToForumsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToForumsAction.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -31,15 +32,20 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class GoToForumsAction extends OpenURLInBrowserAction {
 
-    public GoToForumsAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public GoToForumsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         putValue(URL_PROPERTY_KEY, com.mucommander.RuntimeConstants.FORUMS_URL);
     }
-    
-    public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.GoToForums.getId(); }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.GoToForums.getId();
+        }
+
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToParentInBothPanelsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToParentInBothPanelsAction.java
@@ -24,22 +24,24 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * Changes the current directory to its parent and tries to do the same in the inactive panel.
  * <p>
- * When possible, this action will open the active panel's current folder's parent. Additionally,
- * if the inactive panel's current folder has a parent, it will open that one as well.
+ * When possible, this action will open the active panel's current folder's parent. Additionally, if the inactive
+ * panel's current folder has a parent, it will open that one as well.
  * </p>
  * <p>
- * Note that this action's behavior is strictly equivalent to that of {@link GoToParentAction} in the
- * active panel. Differences will only occur in the inactive panel, and then again only when possible.
+ * Note that this action's behavior is strictly equivalent to that of {@link GoToParentAction} in the active panel.
+ * Differences will only occur in the inactive panel, and then again only when possible.
  * </p>
  * <p>
- * This action opens both files synchronously: it will wait for the active panel location change confirmation
- * before performing the inactive one.
+ * This action opens both files synchronously: it will wait for the active panel location change confirmation before
+ * performing the inactive one.
  * </p>
+ * 
  * @author Nicolas Rinaudo
  */
 public class GoToParentInBothPanelsAction extends ActiveTabAction {
@@ -47,10 +49,13 @@ public class GoToParentInBothPanelsAction extends ActiveTabAction {
     // -----------------------------------------------------------------------------------
     /**
      * Creates a new <code>GoToParentInBothPanelsAction</code> instance with the specified parameters.
-     * @param mainFrame  frame to which the action is attached.
-     * @param properties action's properties.
+     * 
+     * @param mainFrame
+     *            frame to which the action is attached.
+     * @param properties
+     *            action's properties.
      */
-    public GoToParentInBothPanelsAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public GoToParentInBothPanelsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         // Perform this action in a separate thread, to avoid locking the event thread
@@ -58,15 +63,14 @@ public class GoToParentInBothPanelsAction extends ActiveTabAction {
     }
 
     /**
-     * Enables or disables this action based on the currently active folder's
-     * has a parent and both tabs in the two panel are not locked,
-     * this action will be enabled, if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's has a parent and both tabs in the two
+     * panel are not locked, this action will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked() &&
-        		   !mainFrame.getInactivePanel().getTabs().getCurrentTab().isLocked() &&
-        		    mainFrame.getActivePanel().getCurrentFolder().getParent()!=null);
+                !mainFrame.getInactivePanel().getTabs().getCurrentTab().isLocked() &&
+                mainFrame.getActivePanel().getCurrentFolder().getParent() != null);
     }
 
     // - Action code ---------------------------------------------------------------------
@@ -76,20 +80,22 @@ public class GoToParentInBothPanelsAction extends ActiveTabAction {
      */
     @Override
     public void performAction() {
-        Thread       openThread;
+        Thread openThread;
         AbstractFile parent;
 
         // If the current panel has a parent file, navigate to it.
-        if((parent = mainFrame.getActivePanel().getCurrentFolder().getParent()) != null) {
+        if ((parent = mainFrame.getActivePanel().getCurrentFolder().getParent()) != null) {
             openThread = mainFrame.getActivePanel().tryChangeCurrentFolder(parent);
 
             // If the inactive panel has a parent file, wait for the current panel change to be complete and navigate
             // to it.
-            if((parent = mainFrame.getInactivePanel().getCurrentFolder().getParent()) != null) {
-                if(openThread != null) {
-                    while(openThread.isAlive()) {
-                        try {openThread.join();}
-                        catch(InterruptedException e) {}
+            if ((parent = mainFrame.getInactivePanel().getCurrentFolder().getParent()) != null) {
+                if (openThread != null) {
+                    while (openThread.isAlive()) {
+                        try {
+                            openThread.join();
+                        } catch (InterruptedException e) {
+                        }
                     }
                 }
                 mainFrame.getInactivePanel().tryChangeCurrentFolder(parent);
@@ -97,14 +103,19 @@ public class GoToParentInBothPanelsAction extends ActiveTabAction {
         }
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.GoToParentInBothPanels.getId(); }
+        public String getId() {
+            return ActionType.GoToParentInBothPanels.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToParentInOtherPanelAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToParentInOtherPanelAction.java
@@ -24,24 +24,29 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.FolderPanel;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * Opens the active panel's parent in the inactive panel.
  * <p>
- * This action is only enabled when the active panel has a parent,
- * and the selected tab in the other panel is not locked.
+ * This action is only enabled when the active panel has a parent, and the selected tab in the other panel is not
+ * locked.
  * </p>
+ * 
  * @author Nicolas Rinaudo
  */
 public class GoToParentInOtherPanelAction extends ParentFolderAction {
     /**
      * Creates a new <code>GoToParentInOtherPanelAction</code> with the specified parameters.
-     * @param mainFrame  frame to which the action is attached.
-     * @param properties action's properties.
+     * 
+     * @param mainFrame
+     *            frame to which the action is attached.
+     * @param properties
+     *            action's properties.
      */
-    public GoToParentInOtherPanelAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public GoToParentInOtherPanelAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -50,47 +55,54 @@ public class GoToParentInOtherPanelAction extends ParentFolderAction {
      * <p>
      * If <code>sourcePanel</code> doesn't have a parent, nothing will happen.
      * </p>
-     * @param  sourcePanel panel whose parent should be used.
-     * @param  destPanel   panel in which to change the location.
-     * @return             <code>true</code> if <code>sourcePanel</code> has a parent, <code>false</code> otherwise.
+     * 
+     * @param sourcePanel
+     *            panel whose parent should be used.
+     * @param destPanel
+     *            panel in which to change the location.
+     * @return <code>true</code> if <code>sourcePanel</code> has a parent, <code>false</code> otherwise.
      */
     private boolean goToParent(FolderPanel sourcePanel, FolderPanel destPanel) {
         AbstractFile parent;
 
-        if((parent = sourcePanel.getCurrentFolder().getParent()) != null) {
+        if ((parent = sourcePanel.getCurrentFolder().getParent()) != null) {
             destPanel.tryChangeCurrentFolder(parent, null, true);
             return true;
         }
         return false;
     }
-    
+
     /**
-     * Enables or disables this action based on the currently active folder's
-     * has a parent and selected tab in the other panel is not locked,
-     * this action will be enabled, if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's has a parent and selected tab in the other
+     * panel is not locked, this action will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getInactivePanel().getTabs().getCurrentTab().isLocked() &&
-        		    mainFrame.getActivePanel().getCurrentFolder().getParent()!=null);
+                mainFrame.getActivePanel().getCurrentFolder().getParent() != null);
     }
-    
+
     /**
      * Opens the active panel's parent in the inactive panel.
      */
     @Override
     public void performAction() {
-    	goToParent(mainFrame.getActivePanel(), mainFrame.getInactivePanel());
+        goToParent(mainFrame.getActivePanel(), mainFrame.getInactivePanel());
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.GoToParentInOtherPanel.getId(); }
+        public String getId() {
+            return ActionType.GoToParentInOtherPanel.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToRootAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToRootAction.java
@@ -24,32 +24,32 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.FolderPanel;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action changes the current folder of the currently active FolderPanel to the current folder's root.
- * This action only gets enabled when the current folder has a parent.
+ * This action changes the current folder of the currently active FolderPanel to the current folder's root. This action
+ * only gets enabled when the current folder has a parent.
  *
  * @author Maxence Bernard
  */
 public class GoToRootAction extends ActiveTabAction {
 
-    public GoToRootAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public GoToRootAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     /**
-     * Enables or disables this action based on the currently active folder's
-     * has a parent and current tab is not locked, this action will be enabled,
-     * if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's has a parent and current tab is not
+     * locked, this action will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked() &&
-        		    mainFrame.getActivePanel().getCurrentFolder().getParent()!=null);
+                mainFrame.getActivePanel().getCurrentFolder().getParent() != null);
     }
-    
+
     @Override
     public void performAction() {
         // Changes the current folder to make it the current folder's root folder.
@@ -59,14 +59,19 @@ public class GoToRootAction extends ActiveTabAction {
         folderPanel.tryChangeCurrentFolder(currentFolder.getRoot());
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.GoToRoot.getId(); }
+        public String getId() {
+            return ActionType.GoToRoot.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToWebsiteAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/GoToWebsiteAction.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -31,15 +32,20 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class GoToWebsiteAction extends OpenURLInBrowserAction {
 
-    public GoToWebsiteAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public GoToWebsiteAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         putValue(URL_PROPERTY_KEY, com.mucommander.RuntimeConstants.HOMEPAGE_URL);
     }
-    
-    public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.GoToWebsite.getId(); }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.GoToWebsite.getId();
+        }
+
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/InvertSelectionAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/InvertSelectionAction.java
@@ -25,6 +25,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 import com.mucommander.ui.main.table.FileTableModel;
@@ -36,7 +37,7 @@ import com.mucommander.ui.main.table.FileTableModel;
  */
 public class InvertSelectionAction extends MuAction {
 
-    public InvertSelectionAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public InvertSelectionAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -48,7 +49,7 @@ public class InvertSelectionAction extends MuAction {
         // Starts at 1 if current folder is not root so that '..' is not marked
         AbstractFile file;
         int nbRows = tableModel.getRowCount();
-        for(int i=tableModel.getFirstMarkableRow(); i<nbRows; i++) {
+        for (int i = tableModel.getFirstMarkableRow(); i < nbRows; i++) {
             file = tableModel.getFileAtRow(i);
             tableModel.setRowMarked(i, !tableModel.isRowMarked(i));
         }
@@ -58,14 +59,19 @@ public class InvertSelectionAction extends MuAction {
         fileTable.fireMarkedFilesChangedEvent();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.InvertSelection.getId(); }
+        public String getId() {
+            return ActionType.InvertSelection.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkAllAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkAllAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 import com.mucommander.ui.main.table.FileTableModel;
@@ -36,12 +37,12 @@ import com.mucommander.ui.main.table.FileTableModel;
 public class MarkAllAction extends MuAction {
     private boolean mark;
 
-    protected MarkAllAction(MainFrame mainFrame, Map<String,Object> properties, boolean mark) {
+    protected MarkAllAction(MainFrame mainFrame, Map<String, Object> properties, boolean mark) {
         super(mainFrame, properties);
         this.mark = mark;
     }
 
-    public MarkAllAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkAllAction(MainFrame mainFrame, Map<String, Object> properties) {
         this(mainFrame, properties, true);
     }
 
@@ -51,7 +52,7 @@ public class MarkAllAction extends MuAction {
         FileTableModel tableModel = fileTable.getFileTableModel();
 
         int nbRows = tableModel.getRowCount();
-        for(int i=tableModel.getFirstMarkableRow(); i<nbRows; i++)
+        for (int i = tableModel.getFirstMarkableRow(); i < nbRows; i++)
             tableModel.setRowMarked(i, mark);
         fileTable.repaint();
 
@@ -59,14 +60,19 @@ public class MarkAllAction extends MuAction {
         fileTable.fireMarkedFilesChangedEvent();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkAll.getId(); }
+        public String getId() {
+            return ActionType.MarkAll.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkExtensionAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkExtensionAction.java
@@ -28,6 +28,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 import com.mucommander.ui.main.table.FileTableModel;
@@ -37,70 +38,64 @@ import com.mucommander.ui.main.table.FileTableModel;
  * <p>
  * Marking behaves as follows:
  * <ul>
- *   <li>
- *     If the current selection is marked, all files whose extension matches that of the current selection will
- *     be unmarked.
- *   </li>
- *   <li>
- *     If the current selection isn't marked, all files whose extension matches that of the current selection will
- *     be marked.
- *   </li>
+ * <li>If the current selection is marked, all files whose extension matches that of the current selection will be
+ * unmarked.</li>
+ * <li>If the current selection isn't marked, all files whose extension matches that of the current selection will be
+ * marked.</li>
  * </ul>
  * </p>
  * <p>
- * By default, this action will mark all files whose extension match that of the current selection in a case-insensitive fashion.
- * It can, however, be configured:
+ * By default, this action will mark all files whose extension match that of the current selection in a case-insensitive
+ * fashion. It can, however, be configured:
  * <ul>
- *   <li>
- *     If the <code>extension</code> property is set, its value prepended by a <code>.</code> is always going to be used regardless of the
- *     current selection.
- *   </li>
- *   <li>
- *     If the <code>case_sensitive</code> property is set to <code>true</code>, extension matching will be done in a case sensitive fashion.
- *   </li>
+ * <li>If the <code>extension</code> property is set, its value prepended by a <code>.</code> is always going to be used
+ * regardless of the current selection.</li>
+ * <li>If the <code>case_sensitive</code> property is set to <code>true</code>, extension matching will be done in a
+ * case sensitive fashion.</li>
  * </ul>
  * </p>
+ * 
  * @author Nicolas Rinaudo
  */
 public class MarkExtensionAction extends MuAction {
     // - Property names ------------------------------------------------------------------
     // -----------------------------------------------------------------------------------
     /** Key that controls which extension should be matched. */
-    public static final String EXTENSION_PROPERTY_KEY      = "extension";
+    public static final String EXTENSION_PROPERTY_KEY = "extension";
     /** Key that controls whether extension matching should be done in a case sensitive fashion (defaults to false). */
     public static final String CASE_SENSITIVE_PROPERTY_KEY = "case_sensitive";
-
-
 
     // - Initialization ------------------------------------------------------------------
     // -----------------------------------------------------------------------------------
     /**
      * Creates a new <code>MarkExtensionAction</code> with the specified parameters.
-     * @param mainFrame  frame to which the action is attached.
-     * @param properties action's properties.
+     * 
+     * @param mainFrame
+     *            frame to which the action is attached.
+     * @param properties
+     *            action's properties.
      */
-    public MarkExtensionAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkExtensionAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
-
-
 
     // - Properties retrieval ------------------------------------------------------------
     // -----------------------------------------------------------------------------------
     /**
      * Returns the extension that was configured in the action's properties.
+     * 
      * @return the extension that was configured in the action's properties, <code>null</code> if none.
      */
     private String getExtension() {
         Object o;
 
         // If the key wasn't set, return null.
-        if((o = getValue(EXTENSION_PROPERTY_KEY)) == null)
+        if ((o = getValue(EXTENSION_PROPERTY_KEY)) == null)
             return null;
 
         // If the value is a string, return it.
-        if(o instanceof String)
-            return (String)o;
+        if (o instanceof String)
+            return (String) o;
 
         // Otherwise, return null.
         return null;
@@ -108,52 +103,55 @@ public class MarkExtensionAction extends MuAction {
 
     /**
      * Returns <code>true</code> if the action must compare string in a case-sensitive fashion.
-     * @return <code>true</code> if the action must compare string in a case-sensitive fashion, <code>false</code> otherwise.
+     * 
+     * @return <code>true</code> if the action must compare string in a case-sensitive fashion, <code>false</code>
+     *         otherwise.
      */
     private boolean isCaseSensitive() {
         Object o;
 
         // If the action hasn't been configured, defaults to false.
-        if((o = getValue(CASE_SENSITIVE_PROPERTY_KEY)) == null)
+        if ((o = getValue(CASE_SENSITIVE_PROPERTY_KEY)) == null)
             return false;
 
         // Returns the configured value if it's a string, false otherwise.
-        if(o instanceof String)
+        if (o instanceof String)
             return o.equals("true");
         return false;
     }
-
-
 
     // - Action code ---------------------------------------------------------------------
     // -----------------------------------------------------------------------------------
     /**
      * Creates a {@link com.mucommander.commons.file.filter.FilenameFilter} that should be applied to all current files.
      * <p>
-     * If the action has been configured using the <code>file.extension</code> property, the returned filter
-     * will match that extension. Otherwise, the currently selected file's extension will be used. If it doesn't
-     * have one, the returned filter will match all files such that 
-     * <code>file.getExtension() == null</code>.
+     * If the action has been configured using the <code>file.extension</code> property, the returned filter will match
+     * that extension. Otherwise, the currently selected file's extension will be used. If it doesn't have one, the
+     * returned filter will match all files such that <code>file.getExtension() == null</code>.
      * </p>
-     * @param  file currently selected file.
-     * @return      the filter that should be applied by this action.
+     * 
+     * @param file
+     *            currently selected file.
+     * @return the filter that should be applied by this action.
      */
     private FilenameFilter getFilter(AbstractFile file) {
-        String                  ext;
+        String ext;
         ExtensionFilenameFilter filter;
 
         // If no extension has been configured, analyse the current selection.
-        if((ext = getExtension()) == null) {
+        if ((ext = getExtension()) == null) {
 
             // If there is no current selection, abort.
-            if(file == null)
+            if (file == null)
                 return null;
 
             // If the current file doesn't have an extension, return a filename filter that
             // match null extensions.
-            if((ext = file.getExtension()) == null)
+            if ((ext = file.getExtension()) == null)
                 return new AbstractFilenameFilter() {
-                    public boolean accept(String name) {return AbstractFile.getExtension(name) == null;}
+                    public boolean accept(String name) {
+                        return AbstractFile.getExtension(name) == null;
+                    }
                 };
         }
 
@@ -171,23 +169,23 @@ public class MarkExtensionAction extends MuAction {
      */
     @Override
     public void performAction() {
-        FileTable      fileTable;
+        FileTable fileTable;
         FileTableModel tableModel;
         FilenameFilter filter;
-        int            rowCount;
-        boolean        mark;
+        int rowCount;
+        boolean mark;
 
         // Initialization. Aborts if there is no selected file.
-        fileTable  = mainFrame.getActiveTable();
-        if((filter = getFilter(fileTable.getSelectedFile(false, true))) == null)
+        fileTable = mainFrame.getActiveTable();
+        if ((filter = getFilter(fileTable.getSelectedFile(false, true))) == null)
             return;
         tableModel = fileTable.getFileTableModel();
-        rowCount   = tableModel.getRowCount();
-        mark       = !tableModel.isRowMarked(fileTable.getSelectedRow());
+        rowCount = tableModel.getRowCount();
+        mark = !tableModel.isRowMarked(fileTable.getSelectedRow());
 
         // Goes through all files in the active table, marking all that match 'filter'.
-        for(int i = tableModel.getFirstMarkableRow(); i < rowCount; i++)
-            if(filter.accept(tableModel.getCachedFileAtRow(i)))
+        for (int i = tableModel.getFirstMarkableRow(); i < rowCount; i++)
+            if (filter.accept(tableModel.getCachedFileAtRow(i)))
                 tableModel.setRowMarked(i, mark);
         fileTable.repaint();
 
@@ -195,14 +193,19 @@ public class MarkExtensionAction extends MuAction {
         fileTable.fireMarkedFilesChangedEvent();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkExtension.getId(); }
+        public String getId() {
+            return ActionType.MarkExtension.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkNextBlockAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkNextBlockAction.java
@@ -23,12 +23,13 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
 /**
- * Marks/unmarks the previous block's rows in the current {@link FileTable}, starting with the
- * current row, and moves the selected row right before the last marked/unmarked row.
+ * Marks/unmarks the previous block's rows in the current {@link FileTable}, starting with the current row, and moves
+ * the selected row right before the last marked/unmarked row.
  *
  * @author Maxence Bernard
  */
@@ -38,7 +39,7 @@ public class MarkNextBlockAction extends MarkForwardAction {
     // TODO: make this value configurable
     private static final int BLOCK_SIZE = 5;
 
-    public MarkNextBlockAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkNextBlockAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -47,14 +48,19 @@ public class MarkNextBlockAction extends MarkForwardAction {
         return BLOCK_SIZE;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkNextBlock.getId(); }
+        public String getId() {
+            return ActionType.MarkNextBlock.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkNextPageAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkNextPageAction.java
@@ -23,35 +23,41 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
 /**
- * Marks/unmarks the next page's rows in the current {@link FileTable}, starting with the
- * current row, and moves the selected row right after the last marked/unmarked row.
+ * Marks/unmarks the next page's rows in the current {@link FileTable}, starting with the current row, and moves the
+ * selected row right after the last marked/unmarked row.
  *
  * @author Maxence Bernard
  */
 public class MarkNextPageAction extends MarkForwardAction {
 
-    public MarkNextPageAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkNextPageAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     protected int getRowIncrement() {
         // Note: the page row increment varies with the file table's height
-        return mainFrame.getActiveTable().getPageRowIncrement()+1;
+        return mainFrame.getActiveTable().getPageRowIncrement() + 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkNextPage.getId(); }
+        public String getId() {
+            return ActionType.MarkNextPage.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkNextRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkNextRowAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -32,7 +33,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class MarkNextRowAction extends MarkForwardAction {
 
-    public MarkNextRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkNextRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -41,14 +42,19 @@ public class MarkNextRowAction extends MarkForwardAction {
         return 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkNextRow.getId(); }
+        public String getId() {
+            return ActionType.MarkNextRow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkPreviousBlockAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkPreviousBlockAction.java
@@ -23,12 +23,13 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
 /**
- * Marks/unmarks the previous block's rows in the current {@link FileTable}, starting with the
- * current row, and moves the selected row right before the last marked/unmarked row.
+ * Marks/unmarks the previous block's rows in the current {@link FileTable}, starting with the current row, and moves
+ * the selected row right before the last marked/unmarked row.
  *
  * @author Maxence Bernard
  */
@@ -38,7 +39,7 @@ public class MarkPreviousBlockAction extends MarkBackwardAction {
     // TODO: make this value configurable
     private static final int BLOCK_SIZE = 5;
 
-    public MarkPreviousBlockAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkPreviousBlockAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -47,14 +48,19 @@ public class MarkPreviousBlockAction extends MarkBackwardAction {
         return BLOCK_SIZE;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkPreviousBlock.getId(); }
+        public String getId() {
+            return ActionType.MarkPreviousBlock.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkPreviousPageAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkPreviousPageAction.java
@@ -23,35 +23,41 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
 /**
- * Marks/unmarks the previous page's rows in the current {@link FileTable}, starting with the
- * current row, and moves the selected row right before the last marked/unmarked row.
+ * Marks/unmarks the previous page's rows in the current {@link FileTable}, starting with the current row, and moves the
+ * selected row right before the last marked/unmarked row.
  *
  * @author Maxence Bernard
  */
 public class MarkPreviousPageAction extends MarkBackwardAction {
 
-    public MarkPreviousPageAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkPreviousPageAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     protected int getRowDecrement() {
         // Note: the page row increment varies with the file table's height
-        return mainFrame.getActiveTable().getPageRowIncrement()+1;
+        return mainFrame.getActiveTable().getPageRowIncrement() + 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkPreviousPage.getId(); }
+        public String getId() {
+            return ActionType.MarkPreviousPage.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkPreviousRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkPreviousRowAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -32,7 +33,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class MarkPreviousRowAction extends MarkBackwardAction {
 
-    public MarkPreviousRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkPreviousRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -41,14 +42,19 @@ public class MarkPreviousRowAction extends MarkBackwardAction {
         return 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkPreviousRow.getId(); }
+        public String getId() {
+            return ActionType.MarkPreviousRow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkSelectedFileAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkSelectedFileAction.java
@@ -24,40 +24,45 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Marks or unmarks the current selected file (current row) and advance current row to the next one,
- * with the following exceptions:
+ * Marks or unmarks the current selected file (current row) and advance current row to the next one, with the following
+ * exceptions:
  * <ul>
  * <li>if quick search is active, this method does nothing
  * <li>if '..' file is selected, file is not marked but current row is still advanced to the next one
- * <li>if the {@link com.mucommander.ui.action.impl.MarkSelectedFileAction} key event is repeated and the last file has already
- * been marked/unmarked since the key was last released, the file is not marked in order to avoid
+ * <li>if the {@link com.mucommander.ui.action.impl.MarkSelectedFileAction} key event is repeated and the last file has
+ * already been marked/unmarked since the key was last released, the file is not marked in order to avoid
  * marked/unmarked flaps when the mark key is kept pressed.
  *
  * @author Maxence Bernard
  */
 public class MarkSelectedFileAction extends MuAction {
 
-    public MarkSelectedFileAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkSelectedFileAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
-
 
     @Override
     public void performAction() {
         mainFrame.getActiveTable().markSelectedFile();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkSelectedFile.getId(); }
+        public String getId() {
+            return ActionType.MarkSelectedFile.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkToFirstRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkToFirstRowAction.java
@@ -23,20 +23,22 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Marks/unmarks files in the active FileTable, from the currently selected row to the first row (inclusive).
- * The first row will also become the currently selected row.
+ * Marks/unmarks files in the active FileTable, from the currently selected row to the first row (inclusive). The first
+ * row will also become the currently selected row.
  *
- * <p>The currently selected row's marked state determines whether the rows will be marked or unmarked : if the selected
+ * <p>
+ * The currently selected row's marked state determines whether the rows will be marked or unmarked : if the selected
  * row is marked, the rows will be unmarked and vice-versa.
  *
  * @author Maxence Bernard
  */
 public class MarkToFirstRowAction extends MarkBackwardAction {
 
-    public MarkToFirstRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkToFirstRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -45,14 +47,19 @@ public class MarkToFirstRowAction extends MarkBackwardAction {
         return mainFrame.getActiveTable().getSelectedRow();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkToFirstRow.getId(); }
+        public String getId() {
+            return ActionType.MarkToFirstRow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkToLastRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MarkToLastRowAction.java
@@ -23,21 +23,23 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
 /**
- * Marks/unmarks files in the active FileTable, from the currently selected row to the last row (inclusive).
- * The last row will also become the currently selected row.
+ * Marks/unmarks files in the active FileTable, from the currently selected row to the last row (inclusive). The last
+ * row will also become the currently selected row.
  *
- * <p>The currently selected row's marked state determines whether the rows will be marked or unmarked : if the selected
+ * <p>
+ * The currently selected row's marked state determines whether the rows will be marked or unmarked : if the selected
  * row is marked, the rows will be unmarked and vice-versa.
  *
  * @author Maxence Bernard
  */
 public class MarkToLastRowAction extends MarkForwardAction {
 
-    public MarkToLastRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MarkToLastRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -45,17 +47,22 @@ public class MarkToLastRowAction extends MarkForwardAction {
     protected int getRowIncrement() {
         FileTable activeTable = mainFrame.getActiveTable();
 
-        return activeTable.getRowCount()-activeTable.getSelectedRow();
+        return activeTable.getRowCount() - activeTable.getSelectedRow();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MarkToLastRow.getId(); }
+        public String getId() {
+            return ActionType.MarkToLastRow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MaximizeWindowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MaximizeWindowAction.java
@@ -29,6 +29,7 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.ActionProperties;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -39,7 +40,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class MaximizeWindowAction extends MuAction {
 
-    public MaximizeWindowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MaximizeWindowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -48,21 +49,26 @@ public class MaximizeWindowAction extends MuAction {
         mainFrame.getJFrame().setExtendedState(JFrame.MAXIMIZED_BOTH);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MaximizeWindow.getId(); }
+        public String getId() {
+            return ActionType.MaximizeWindow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.WINDOW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.WINDOW;
+        }
 
         @Override
         public String getLabel() {
             // Use a special label for Mac OS X, if it exists, use the standard action label otherwise
-            String macLabelKey = ActionProperties.getActionLabelKey(ActionType.MaximizeWindow)+".mac_os_x";
-            if(OsFamily.MAC_OS.isCurrent() && Translator.hasValue(macLabelKey, false))
+            String macLabelKey = ActionProperties.getActionLabelKey(ActionType.MaximizeWindow) + ".mac_os_x";
+            if (OsFamily.MAC_OS.isCurrent() && Translator.hasValue(macLabelKey, false))
                 return Translator.get(macLabelKey);
 
             return super.getLabel();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MinimizeWindowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MinimizeWindowAction.java
@@ -29,6 +29,7 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.ActionProperties;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -39,7 +40,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class MinimizeWindowAction extends MuAction {
 
-    public MinimizeWindowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MinimizeWindowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -48,21 +49,26 @@ public class MinimizeWindowAction extends MuAction {
         mainFrame.getJFrame().setExtendedState(JFrame.ICONIFIED);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MinimizeWindow.getId(); }
+        public String getId() {
+            return ActionType.MinimizeWindow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.WINDOW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.WINDOW;
+        }
 
         @Override
         public String getLabel() {
             // Use a special label for Mac OS X, if it exists, use the standard action label otherwise
-            String macLabelKey = ActionProperties.getActionLabelKey(ActionType.MinimizeWindow)+".mac_os_x";
-            if(OsFamily.MAC_OS.isCurrent() && Translator.hasValue(macLabelKey, false))
+            String macLabelKey = ActionProperties.getActionLabelKey(ActionType.MinimizeWindow) + ".mac_os_x";
+            if (OsFamily.MAC_OS.isCurrent() && Translator.hasValue(macLabelKey, false))
                 return Translator.get(macLabelKey);
 
             return super.getLabel();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MoveTabToOtherPanelAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/MoveTabToOtherPanelAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.tabs.FileTableTab;
 
@@ -33,36 +34,39 @@ import com.mucommander.ui.main.tabs.FileTableTab;
  */
 public class MoveTabToOtherPanelAction extends ActiveTabAction {
 
-    public MoveTabToOtherPanelAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public MoveTabToOtherPanelAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
-    
+
     /**
-     * Enables or disables this action based on the currently active folder's
-     * current tab is not locked and is not the only tab in the panel,
-     * this action will be enabled, if not it will be disabled.
+     * Enables or disables this action based on the currently active folder's current tab is not locked and is not the
+     * only tab in the panel, this action will be enabled, if not it will be disabled.
      */
     @Override
     protected void toggleEnabledState() {
         setEnabled(!mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked() &&
-        		    mainFrame.getActivePanel().getTabs().getTabsCount() > 1);
+                mainFrame.getActivePanel().getTabs().getTabsCount() > 1);
     }
 
     @Override
     public void performAction() {
-    	FileTableTab tab = mainFrame.getActivePanel().getTabs().closeCurrentTab();
-    	mainFrame.getInactivePanel().getTabs().add(tab);
+        FileTableTab tab = mainFrame.getActivePanel().getTabs().closeCurrentTab();
+        mainFrame.getInactivePanel().getTabs().add(tab);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.MoveTabToOtherPanel.getId(); }
+        public String getId() {
+            return ActionType.MoveTabToOtherPanel.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }
-

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/NextTabAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/NextTabAction.java
@@ -41,33 +41,39 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Change the selected tab to the tab which is located to the right of the current displayed tab.
- * If the current displayed tab is the rightmost tab, the leftmost tab will be displayed.
+ * Change the selected tab to the tab which is located to the right of the current displayed tab. If the current
+ * displayed tab is the rightmost tab, the leftmost tab will be displayed.
  * 
  * @author Arik Hadas
  */
 public class NextTabAction extends MuAction {
-	
-	public NextTabAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public NextTabAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	mainFrame.getActivePanel().getTabs().nextTab();
+        mainFrame.getActivePanel().getTabs().nextTab();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.NextTab.getId(); }
+        public String getId() {
+            return ActionType.NextTab.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenAction.java
@@ -39,6 +39,7 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.ActionManager;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.InformationDialog;
 import com.mucommander.ui.dialog.file.ProgressDialog;
 import com.mucommander.ui.main.FolderPanel;
@@ -47,12 +48,13 @@ import com.mucommander.ui.main.quicklist.RecentExecutedFilesQL;
 import com.mucommander.ui.main.tabs.FileTableTabs;
 
 /**
- * This action 'opens' the currently selected file or folder in the active FileTable.
- * This means different things depending on the kind of file that is currently selected:
+ * This action 'opens' the currently selected file or folder in the active FileTable. This means different things
+ * depending on the kind of file that is currently selected:
  * <ul>
  * <li>For browsable files (directory, archive...): shows file contents
  * <li>For local file that are not an archive or archive entry: executes file with native file associations
- * <li>For any other file type, remote or local: copies file to a temporary local file and executes it with native file associations
+ * <li>For any other file type, remote or local: copies file to a temporary local file and executes it with native file
+ * associations
  * </ul>
  *
  * @author Maxence Bernard, Nicolas Rinaudo
@@ -60,10 +62,13 @@ import com.mucommander.ui.main.tabs.FileTableTabs;
 public class OpenAction extends MuAction {
     /**
      * Creates a new <code>OpenAction</code> with the specified parameters.
-     * @param mainFrame  frame to which the action is attached.
-     * @param properties action's properties.
+     * 
+     * @param mainFrame
+     *            frame to which the action is attached.
+     * @param properties
+     *            action's properties.
      */
-    public OpenAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public OpenAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -72,70 +77,68 @@ public class OpenAction extends MuAction {
      * <p>
      * <code>file</code> will be opened using the following rules:
      * <ul>
-     *   <li>
-     *     If <code>file</code> is {@link com.mucommander.commons.file.AbstractFile#isBrowsable() browsable},
-     *     it will be opened in <code>destination</code>.
-     *   </li>
-     *   <li>
-     *     If <code>file</code> is local, it will be opened using its native associations.
-     *   </li>
-     *   <li>
-     *     If <code>file</code> is remote, it will first be copied in a temporary local file and
-     *     then opened using its native association.
-     *   </li>
+     * <li>If <code>file</code> is {@link com.mucommander.commons.file.AbstractFile#isBrowsable() browsable}, it will be
+     * opened in <code>destination</code>.</li>
+     * <li>If <code>file</code> is local, it will be opened using its native associations.</li>
+     * <li>If <code>file</code> is remote, it will first be copied in a temporary local file and then opened using its
+     * native association.</li>
      * </ul>
      * </p>
-     * @param file        file to open.
-     * @param destination if <code>file</code> is browsable, folder panel in which to open the file.
+     * 
+     * @param file
+     *            file to open.
+     * @param destination
+     *            if <code>file</code> is browsable, folder panel in which to open the file.
      */
     protected void open(AbstractFile file, FolderPanel destination) {
-    	AbstractFile resolvedFile;
-    	if (file.isSymlink()) {
-    		resolvedFile = resolveSymlink(file);
+        AbstractFile resolvedFile;
+        if (file.isSymlink()) {
+            resolvedFile = resolveSymlink(file);
 
-    		if (resolvedFile == null) {
-    			InformationDialog.showErrorDialog(mainFrame.getJFrame(), Translator.get("cannot_open_cyclic_symlink"));
-    			return;
-    		}
-    	}
-    	else
-    		resolvedFile = file;
+            if (resolvedFile == null) {
+                InformationDialog.showErrorDialog(mainFrame.getJFrame(), Translator.get("cannot_open_cyclic_symlink"));
+                return;
+            }
+        } else
+            resolvedFile = file;
 
         // Opens browsable files in the destination FolderPanel.
-        if(resolvedFile.isBrowsable()) {
-        	resolvedFile = MuConfigurations.getPreferences().getVariable(MuPreference.CD_FOLLOWS_SYMLINKS, MuPreferences.DEFAULT_CD_FOLLOWS_SYMLINKS) ? resolvedFile : file;
-        	FileTableTabs tabs = destination.getTabs();
+        if (resolvedFile.isBrowsable()) {
+            resolvedFile = MuConfigurations.getPreferences()
+                    .getVariable(MuPreference.CD_FOLLOWS_SYMLINKS, MuPreferences.DEFAULT_CD_FOLLOWS_SYMLINKS)
+                            ? resolvedFile
+                            : file;
+            FileTableTabs tabs = destination.getTabs();
 
-        	if (BookmarkManager.isBookmark(resolvedFile.getURL())) {
-        		String bookmarkLocation = BookmarkManager.getBookmark(resolvedFile.getName()).getLocation();
-        		FileURL bookmarkURL;
-				try {
-					bookmarkURL = FileURL.getFileURL(bookmarkLocation);
-				} catch (MalformedURLException e) {
-					LOGGER.error("Failed to resolve bookmark's location: " + bookmarkLocation);
-					return;
-				}
+            if (BookmarkManager.isBookmark(resolvedFile.getURL())) {
+                String bookmarkLocation = BookmarkManager.getBookmark(resolvedFile.getName()).getLocation();
+                FileURL bookmarkURL;
+                try {
+                    bookmarkURL = FileURL.getFileURL(bookmarkLocation);
+                } catch (MalformedURLException e) {
+                    LOGGER.error("Failed to resolve bookmark's location: " + bookmarkLocation);
+                    return;
+                }
 
-        		if (tabs.getCurrentTab().isLocked())
-        			tabs.add(bookmarkURL);
-        		else
-        			destination.tryChangeCurrentFolder(bookmarkURL);
-        	}
-        	else {
-        		if (tabs.getCurrentTab().isLocked())
-        			tabs.add(resolvedFile);
-        		else
-        			destination.tryChangeCurrentFolder(resolvedFile);
-        	}
+                if (tabs.getCurrentTab().isLocked())
+                    tabs.add(bookmarkURL);
+                else
+                    destination.tryChangeCurrentFolder(bookmarkURL);
+            } else {
+                if (tabs.getCurrentTab().isLocked())
+                    tabs.add(resolvedFile);
+                else
+                    destination.tryChangeCurrentFolder(resolvedFile);
+            }
         }
 
         // Opens local files using their native associations.
-        else if(resolvedFile.getURL().getScheme().equals(LocalFile.SCHEMA) && (resolvedFile.hasAncestor(LocalFile.class))) {
+        else if (resolvedFile.getURL().getScheme().equals(LocalFile.SCHEMA)
+                && (resolvedFile.hasAncestor(LocalFile.class))) {
             try {
                 OpenAction.openFile(getMainFrame(), resolvedFile);
                 RecentExecutedFilesQL.addFile(resolvedFile);
-            }
-            catch(IOException e) {
+            } catch (IOException e) {
                 InformationDialog.showErrorDialog(mainFrame.getJFrame());
             }
         }
@@ -149,16 +152,16 @@ public class OpenAction extends MuAction {
     }
 
     protected AbstractFile resolveSymlink(AbstractFile symlink) {
-    	return resolveSymlink(symlink, new HashSet<AbstractFile>());
+        return resolveSymlink(symlink, new HashSet<AbstractFile>());
     }
 
     private AbstractFile resolveSymlink(AbstractFile file, Set<AbstractFile> visitedFiles) {
-    	if (visitedFiles.contains(file))
-    		return null;
-    	else {
-    		visitedFiles.add(file);
-    		return file.isSymlink() ? resolveSymlink(file.getCanonicalFile(), visitedFiles) : file;
-    	}
+        if (visitedFiles.contains(file))
+            return null;
+        else {
+            visitedFiles.add(file);
+            return file.isSymlink() ? resolveSymlink(file.getCanonicalFile(), visitedFiles) : file;
+        }
     }
 
     /**
@@ -179,39 +182,48 @@ public class OpenAction extends MuAction {
 
     }
 
-	/**
-	 * Brings up an opening file error dialog with the output message and a generic localized title if and only
-	 * if the task that opens the given file provides an output message and the user preference
-	 * {@code MuPreference.VIEW_ON_ERROR} has not been enabled.
-	 * <p>
-	 * In case the user preference {@code MuPreference.VIEW_ON_ERROR} has been enabled, the viewer will automatically
-	 * be launched to open the file.
-	 *
-	 * @param mainFrame determines the <code>Frame</code> in which the dialog is displayed
-	 * @param file the file to open.
-	 */
-	public static void openFile(MainFrame mainFrame, AbstractFile file) throws IOException, UnsupportedOperationException {
-		DesktopManager.open(file).thenAccept(
-			outputMessages -> outputMessages.ifPresent(
-				s -> {
-					if (MuConfigurations.getPreferences().getVariable(MuPreference.VIEW_ON_ERROR, MuPreferences.DEFAULT_VIEW_ON_ERROR)) {
-						ActionManager.getActionInstance(ActionType.View, mainFrame).performAction();
-					} else {
-						InformationDialog.showErrorDialog(mainFrame.getJFrame(), s);
-					}
-				}
-			)
-		);
-	}
+    /**
+     * Brings up an opening file error dialog with the output message and a generic localized title if and only if the
+     * task that opens the given file provides an output message and the user preference
+     * {@code MuPreference.VIEW_ON_ERROR} has not been enabled.
+     * <p>
+     * In case the user preference {@code MuPreference.VIEW_ON_ERROR} has been enabled, the viewer will automatically be
+     * launched to open the file.
+     *
+     * @param mainFrame
+     *            determines the <code>Frame</code> in which the dialog is displayed
+     * @param file
+     *            the file to open.
+     */
+    public static void openFile(MainFrame mainFrame, AbstractFile file)
+            throws IOException, UnsupportedOperationException {
+        DesktopManager.open(file)
+                .thenAccept(
+                        outputMessages -> outputMessages.ifPresent(
+                                s -> {
+                                    if (MuConfigurations.getPreferences()
+                                            .getVariable(MuPreference.VIEW_ON_ERROR,
+                                                    MuPreferences.DEFAULT_VIEW_ON_ERROR)) {
+                                        ActionManager.getActionInstance(ActionType.View, mainFrame).performAction();
+                                    } else {
+                                        InformationDialog.showErrorDialog(mainFrame.getJFrame(), s);
+                                    }
+                                }));
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.Open.getId(); }
+        public String getId() {
+            return ActionType.Open.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenAsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenAsAction.java
@@ -27,13 +27,15 @@ import com.mucommander.text.Translator;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.InformationDialog;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * Open a file as if it has the specified file extension.
+ * 
  * @author Arik Hadas
-*/
+ */
 public class OpenAsAction extends OpenAction {
 
     private String extension;
@@ -63,8 +65,7 @@ public class OpenAsAction extends OpenAction {
                 InformationDialog.showErrorDialog(mainFrame.getJFrame(), Translator.get("cannot_open_cyclic_symlink"));
                 return;
             }
-        }
-        else
+        } else
             resolvedFile = file;
 
         try {
@@ -85,10 +86,15 @@ public class OpenAsAction extends OpenAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-        public String getId() { return ActionType.OpenAs.getId(); }
+        public String getId() {
+            return ActionType.OpenAs.getId();
+        }
 
-        public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenCommandPromptAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenCommandPromptAction.java
@@ -12,12 +12,13 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.ActionProperties;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.InformationDialog;
 import com.mucommander.ui.main.MainFrame;
 
 public class OpenCommandPromptAction extends ParentFolderAction {
 
-    public OpenCommandPromptAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public OpenCommandPromptAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setEnabled(DesktopManager.canOpenInFileManager());
@@ -28,16 +29,14 @@ public class OpenCommandPromptAction extends ParentFolderAction {
         AbstractFile currentFolder = mainFrame.getActivePanel().getCurrentFolder();
         setEnabled(currentFolder.getURL().getScheme().equals(FileProtocols.FILE)
                 && !currentFolder.isArchive()
-                && !currentFolder.hasAncestor(AbstractArchiveEntryFile.class)
-        );
+                && !currentFolder.hasAncestor(AbstractArchiveEntryFile.class));
     }
 
     @Override
     public void performAction() {
         try {
             DesktopManager.openCommandPrompt(mainFrame.getActivePanel().getCurrentFolder());
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             InformationDialog.showErrorDialog(mainFrame.getJFrame());
         }
     }
@@ -47,12 +46,17 @@ public class OpenCommandPromptAction extends ParentFolderAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         @Override
-        public String getId() { return ActionType.OpenCommandPrompt.getId(); }
+        public String getId() {
+            return ActionType.OpenCommandPrompt.getId();
+        }
 
         @Override
-        public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
 
         @Override
         public String getLabel() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenInNewTabAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenInNewTabAction.java
@@ -27,6 +27,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -36,56 +37,62 @@ import com.mucommander.ui.main.table.FileTable;
  * This action is only enabled if the current selection is browsable as defined by
  * {@link com.mucommander.commons.file.AbstractFile#isBrowsable()}.
  * </p>
+ * 
  * @author Arik Hadas
  */
 public class OpenInNewTabAction extends SelectedFileAction {
 
-	public OpenInNewTabAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public OpenInNewTabAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
-	
-	/**
+
+    /**
      * This method is overridden to enable this action when the parent folder is selected.
      */
     @Override
     protected boolean getFileTableCondition(FileTable fileTable) {
         AbstractFile selectedFile = fileTable.getSelectedFile(true, true);
 
-        return selectedFile!=null && selectedFile.isBrowsable();
+        return selectedFile != null && selectedFile.isBrowsable();
     }
-    
-	@Override
-	public void performAction() {
-		AbstractFile file = mainFrame.getActiveTable().getSelectedFile(true, true);
+
+    @Override
+    public void performAction() {
+        AbstractFile file = mainFrame.getActiveTable().getSelectedFile(true, true);
 
         // Retrieves the currently selected file, aborts if none (should not normally happen).
-        if(file == null || !file.isBrowsable())
+        if (file == null || !file.isBrowsable())
             return;
 
         FileURL fileURL = file.getURL();
 
         if (BookmarkManager.isBookmark(fileURL)) {
-        	String bookmarkLocation = BookmarkManager.getBookmark(file.getName()).getLocation();
-        	try {
-        		fileURL = FileURL.getFileURL(bookmarkLocation);
-        	} catch (MalformedURLException e) {
-        		LOGGER.error("Failed to resolve bookmark's location: " + bookmarkLocation);
-        		return;
-        	}
+            String bookmarkLocation = BookmarkManager.getBookmark(file.getName()).getLocation();
+            try {
+                fileURL = FileURL.getFileURL(bookmarkLocation);
+            } catch (MalformedURLException e) {
+                LOGGER.error("Failed to resolve bookmark's location: " + bookmarkLocation);
+                return;
+            }
         }
 
         // Opens the currently selected file in a new tab
         mainFrame.getActivePanel().getTabs().add(fileURL);
-	}
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.OpenInNewTab.getId(); }
+        public String getId() {
+            return ActionType.OpenInNewTab.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenInOtherPanelAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenInOtherPanelAction.java
@@ -24,6 +24,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.FolderPanel;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
@@ -34,26 +35,30 @@ import com.mucommander.ui.main.table.FileTable;
  * This action is only enabled if the current selection is browsable as defined by
  * {@link com.mucommander.commons.file.AbstractFile#isBrowsable()}.
  * </p>
+ * 
  * @author Nicolas Rinaudo
  */
 public class OpenInOtherPanelAction extends SelectedFileAction {
     /**
      * Creates a new <code>OpenInOtherPanelAction</code> with the specified parameters.
-     * @param mainFrame  frame to which the action is attached.
-     * @param properties action's properties.
+     * 
+     * @param mainFrame
+     *            frame to which the action is attached.
+     * @param properties
+     *            action's properties.
      */
-    public OpenInOtherPanelAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public OpenInOtherPanelAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void activePanelChanged(FolderPanel folderPanel) {
         super.activePanelChanged(folderPanel);
-        
+
         if (mainFrame.getInactivePanel().getTabs().getCurrentTab().isLocked())
-        	setEnabled(false);
+            setEnabled(false);
     }
-    
+
     /**
      * This method is overridden to enable this action when the parent folder is selected.
      */
@@ -61,7 +66,7 @@ public class OpenInOtherPanelAction extends SelectedFileAction {
     protected boolean getFileTableCondition(FileTable fileTable) {
         AbstractFile selectedFile = fileTable.getSelectedFile(true, true);
 
-        return selectedFile!=null && selectedFile.isBrowsable();
+        return selectedFile != null && selectedFile.isBrowsable();
     }
 
     /**
@@ -72,21 +77,26 @@ public class OpenInOtherPanelAction extends SelectedFileAction {
         AbstractFile file;
 
         // Retrieves the currently selected file, aborts if none (should not normally happen).
-        if((file = mainFrame.getActiveTable().getSelectedFile(true, true)) == null || !file.isBrowsable())
+        if ((file = mainFrame.getActiveTable().getSelectedFile(true, true)) == null || !file.isBrowsable())
             return;
 
         // Opens the currently selected file in the inactive panel.
         mainFrame.getInactivePanel().tryChangeCurrentFolder(file);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.OpenInOtherPanel.getId(); }
+        public String getId() {
+            return ActionType.OpenInOtherPanel.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenNativelyAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenNativelyAction.java
@@ -30,6 +30,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.InformationDialog;
 import com.mucommander.ui.dialog.file.ProgressDialog;
 import com.mucommander.ui.main.MainFrame;
@@ -42,7 +43,7 @@ import com.mucommander.ui.main.quicklist.RecentExecutedFilesQL;
  */
 public class OpenNativelyAction extends MuAction {
 
-    public OpenNativelyAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public OpenNativelyAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -50,36 +51,40 @@ public class OpenNativelyAction extends MuAction {
     public void performAction() {
         AbstractFile selectedFile = mainFrame.getActiveTable().getSelectedFile(true, true);
 
-        if(selectedFile==null)
+        if (selectedFile == null)
             return;
 
         // Copy file to a temporary local file and execute it with native file associations if
         // file is not on a local filesystem or file is an archive entry
-        if(!LocalFile.SCHEMA.equals(selectedFile.getURL().getScheme()) || selectedFile.hasAncestor(AbstractArchiveEntryFile.class)) {
+        if (!LocalFile.SCHEMA.equals(selectedFile.getURL().getScheme())
+                || selectedFile.hasAncestor(AbstractArchiveEntryFile.class)) {
             ProgressDialog progressDialog = new ProgressDialog(mainFrame, Translator.get("copy_dialog.copying"));
             TempExecJob job = new TempExecJob(progressDialog, mainFrame, selectedFile);
             progressDialog.start(job);
-        }
-        else {
+        } else {
             // Tries to execute file with native file associations
             try {
                 OpenAction.openFile(getMainFrame(), selectedFile);
                 RecentExecutedFilesQL.addFile(selectedFile);
-        	}
-            catch (IOException | UnsupportedOperationException e) {
+            } catch (IOException | UnsupportedOperationException e) {
                 InformationDialog.showErrorDialog(mainFrame.getJFrame());
             }
         }
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.OpenNatively.getId(); }
+        public String getId() {
+            return ActionType.OpenNatively.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenTrashAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/OpenTrashAction.java
@@ -26,12 +26,13 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Opens the trash in the default file manager of the current OS/Desktop manager. This action is enabled only
- * if the current platform has an {@link com.mucommander.desktop.AbstractTrash} implementation and if it is capable
- * of opening the trash, as reported by {@link com.mucommander.desktop.AbstractTrash#canOpen()}.
+ * Opens the trash in the default file manager of the current OS/Desktop manager. This action is enabled only if the
+ * current platform has an {@link com.mucommander.desktop.AbstractTrash} implementation and if it is capable of opening
+ * the trash, as reported by {@link com.mucommander.desktop.AbstractTrash#canOpen()}.
  *
  * @author Maxence Bernard
  */
@@ -57,6 +58,7 @@ public class OpenTrashAction extends MuAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.OpenTrash.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PasteClipboardFilesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PasteClipboardFilesAction.java
@@ -29,6 +29,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.FileCollisionDialog;
 import com.mucommander.ui.dialog.file.ProgressDialog;
 import com.mucommander.ui.dnd.ClipboardNotifier;
@@ -36,17 +37,18 @@ import com.mucommander.ui.dnd.ClipboardSupport;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action pastes the files contained by the system clipboard to the currently active folder.
- * Does nothing if the clipboard doesn't contain any file.
+ * This action pastes the files contained by the system clipboard to the currently active folder. Does nothing if the
+ * clipboard doesn't contain any file.
  *
- * <p>Under Java 1.5 and up, this action gets automatically enabled/disabled when files are present/not present
- * in the clipboard.
+ * <p>
+ * Under Java 1.5 and up, this action gets automatically enabled/disabled when files are present/not present in the
+ * clipboard.
  *
  * @author Maxence Bernard
  */
 public class PasteClipboardFilesAction extends MuAction {
 
-    public PasteClipboardFilesAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public PasteClipboardFilesAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
         new ClipboardNotifier(this);
     }
@@ -55,24 +57,35 @@ public class PasteClipboardFilesAction extends MuAction {
     public void performAction() {
         // Retrieve clipboard files
         FileSet clipboardFiles = ClipboardSupport.getClipboardFiles();
-        if(clipboardFiles==null || clipboardFiles.isEmpty())
+        if (clipboardFiles == null || clipboardFiles.isEmpty())
             return;
 
         // Start copying files
         ProgressDialog progressDialog = new ProgressDialog(mainFrame, Translator.get("copy_dialog.copying"));
         AbstractFile destFolder = mainFrame.getActivePanel().getCurrentFolder();
-        CopyJob job = new CopyJob(progressDialog, mainFrame, clipboardFiles, destFolder, null, TransferMode.COPY, FileCollisionDialog.FileCollisionAction.ASK);
+        CopyJob job = new CopyJob(progressDialog,
+                mainFrame,
+                clipboardFiles,
+                destFolder,
+                null,
+                TransferMode.COPY,
+                FileCollisionDialog.FileCollisionAction.ASK);
         progressDialog.start(job);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.PasteClipboardFiles.getId(); }
+        public String getId() {
+            return ActionType.PasteClipboardFiles.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PopupLeftDriveButtonAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PopupLeftDriveButtonAction.java
@@ -24,46 +24,52 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.tabs.ActiveTabListener;
 
 /**
- * Pops up the DrivePopupButton (the drop down button that allows to quickly select a volume or bookmark)
- * of the left FolderPanel.
+ * Pops up the DrivePopupButton (the drop down button that allows to quickly select a volume or bookmark) of the left
+ * FolderPanel.
  *
  * @author Maxence Bernard
  */
 public class PopupLeftDriveButtonAction extends MuAction implements ActiveTabListener {
 
-    public PopupLeftDriveButtonAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public PopupLeftDriveButtonAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
-        
+
         mainFrame.getLeftPanel().getTabs().addActiveTabListener(this);
-        
+
         activeTabChanged();
     }
 
     /**
-     * Enables or disables this action based on the current tab is not locked, 
-     * this action will be enabled, if not it will be disabled.
+     * Enables or disables this action based on the current tab is not locked, this action will be enabled, if not it
+     * will be disabled.
      */
-	public void activeTabChanged() {
-		setEnabled(!mainFrame.getLeftPanel().getTabs().getCurrentTab().isLocked());
-	}
+    public void activeTabChanged() {
+        setEnabled(!mainFrame.getLeftPanel().getTabs().getCurrentTab().isLocked());
+    }
 
     @Override
     public void performAction() {
         mainFrame.getLeftPanel().getDriveButton().popupMenu();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.PopupLeftDriveButton.getId(); }
+        public String getId() {
+            return ActionType.PopupLeftDriveButton.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PopupRightDriveButtonAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PopupRightDriveButtonAction.java
@@ -24,46 +24,52 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.tabs.ActiveTabListener;
 
 /**
- * Pops up the DrivePopupButton (the drop down button that allows to quickly select a volume or bookmark)
- * of the left FolderPanel.
+ * Pops up the DrivePopupButton (the drop down button that allows to quickly select a volume or bookmark) of the left
+ * FolderPanel.
  *
  * @author Maxence Bernard
  */
 public class PopupRightDriveButtonAction extends MuAction implements ActiveTabListener {
 
-    public PopupRightDriveButtonAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public PopupRightDriveButtonAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
-        
+
         mainFrame.getRightPanel().getTabs().addActiveTabListener(this);
-        
+
         activeTabChanged();
     }
 
     /**
-     * Enables or disables this action based on the current tab is not locked, 
-     * this action will be enabled, if not it will be disabled.
+     * Enables or disables this action based on the current tab is not locked, this action will be enabled, if not it
+     * will be disabled.
      */
     public void activeTabChanged() {
-    	setEnabled(!mainFrame.getRightPanel().getTabs().getCurrentTab().isLocked());
-	}
+        setEnabled(!mainFrame.getRightPanel().getTabs().getCurrentTab().isLocked());
+    }
 
     @Override
     public void performAction() {
         mainFrame.getRightPanel().getDriveButton().popupMenu();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.PopupRightDriveButton.getId(); }
+        public String getId() {
+            return ActionType.PopupRightDriveButton.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PreviousTabAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/PreviousTabAction.java
@@ -41,33 +41,39 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Change the selected tab to the tab which is located to the left of the current displayed tab.
- * If the current displayed tab is the leftmost tab, the rightmost tab will be displayed.
+ * Change the selected tab to the tab which is located to the left of the current displayed tab. If the current
+ * displayed tab is the leftmost tab, the rightmost tab will be displayed.
  * 
  * @author Arik Hadas
  */
 public class PreviousTabAction extends MuAction {
-	
-	public PreviousTabAction(MainFrame mainFrame, Map<String,Object> properties) {
+
+    public PreviousTabAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	mainFrame.getActivePanel().getTabs().previousTab();
+        mainFrame.getActivePanel().getTabs().previousTab();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.PreviousTab.getId(); }
+        public String getId() {
+            return ActionType.PreviousTab.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/QuickFindAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/QuickFindAction.java
@@ -27,6 +27,7 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.LocationTextField;
 import com.mucommander.ui.main.MainFrame;
 
@@ -56,9 +57,14 @@ public class QuickFindAction extends MuAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-        public String getId() { return ActionType.QuickFind.getId(); }
+        public String getId() {
+            return ActionType.QuickFind.getId();
+        }
 
-        public ActionCategory getCategory() { return ActionCategory.FILES; }
+        public ActionCategory getCategory() {
+            return ActionCategory.FILES;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/QuitAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/QuitAction.java
@@ -25,35 +25,41 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.shutdown.QuitDialog;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * This action pops up the Quit confirmation dialog (if it hasn't been disabled) and if quit has been confirmed,
- * quits the application.
+ * This action pops up the Quit confirmation dialog (if it hasn't been disabled) and if quit has been confirmed, quits
+ * the application.
  *
  * @author Maxence Bernard
  */
 public class QuitAction extends MuAction {
 
-    public QuitAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public QuitAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-        if(QuitDialog.confirmQuit())
+        if (QuitDialog.confirmQuit())
             Application.initiateShutdown();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.Quit.getId(); }
+        public String getId() {
+            return ActionType.Quit.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.WINDOW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.WINDOW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallNextWindowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallNextWindowAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.WindowManager;
 
@@ -34,7 +35,7 @@ import com.mucommander.ui.main.WindowManager;
  */
 public class RecallNextWindowAction extends MuAction {
 
-    public RecallNextWindowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallNextWindowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -43,14 +44,19 @@ public class RecallNextWindowAction extends MuAction {
         WindowManager.switchToNextWindow();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.RecallNextWindow.getId(); }
+        public String getId() {
+            return ActionType.RecallNextWindow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.WINDOW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.WINDOW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallPreviousWindowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallPreviousWindowAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.WindowManager;
 
@@ -34,7 +35,7 @@ import com.mucommander.ui.main.WindowManager;
  */
 public class RecallPreviousWindowAction extends MuAction {
 
-    public RecallPreviousWindowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallPreviousWindowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -43,14 +44,19 @@ public class RecallPreviousWindowAction extends MuAction {
         WindowManager.switchToPreviousWindow();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.RecallPreviousWindow.getId(); }
+        public String getId() {
+            return ActionType.RecallPreviousWindow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.WINDOW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.WINDOW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow10Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow10Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow10Action extends RecallWindowAction {
 
-    public RecallWindow10Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow10Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 10);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(10);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow1Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow1Action.java
@@ -20,24 +20,26 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Recalls window number 1 (brings it to the front). 
+ * Recalls window number 1 (brings it to the front).
  *
  * @author Maxence Bernard
  */
 public class RecallWindow1Action extends RecallWindowAction {
 
-    public RecallWindow1Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow1Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 1);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(1);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow2Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow2Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow2Action extends RecallWindowAction {
 
-    public RecallWindow2Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow2Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 2);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(2);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow3Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow3Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow3Action extends RecallWindowAction {
 
-    public RecallWindow3Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow3Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 3);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(3);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow4Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow4Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow4Action extends RecallWindowAction {
 
-    public RecallWindow4Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow4Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 4);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(4);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow5Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow5Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow5Action extends RecallWindowAction {
 
-    public RecallWindow5Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow5Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 5);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(5);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow6Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow6Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow6Action extends RecallWindowAction {
 
-    public RecallWindow6Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow6Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 6);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(6);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow7Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow7Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow7Action extends RecallWindowAction {
 
-    public RecallWindow7Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow7Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 7);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(7);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow8Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow8Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow8Action extends RecallWindowAction {
 
-    public RecallWindow8Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow8Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 8);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(8);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow9Action.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/RecallWindow9Action.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -29,15 +30,16 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class RecallWindow9Action extends RecallWindowAction {
 
-    public RecallWindow9Action(MainFrame mainFrame, Map<String,Object> properties) {
+    public RecallWindow9Action(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, 9);
     }
-    
+
     @Override
     public ActionDescriptor getDescriptor() {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends RecallWindowAction.Descriptor {
         public Descriptor() {
             super(9);

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ReverseSortOrderAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ReverseSortOrderAction.java
@@ -24,8 +24,8 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
-
 
 /**
  * This action reverses the sort order of the currently active FileTable.
@@ -34,7 +34,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class ReverseSortOrderAction extends MuAction {
 
-    public ReverseSortOrderAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ReverseSortOrderAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -43,14 +43,19 @@ public class ReverseSortOrderAction extends MuAction {
         mainFrame.getActiveTable().reverseSortOrder();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ReverseSortOrder.getId(); }
+        public String getId() {
+            return ActionType.ReverseSortOrder.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectFirstRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectFirstRowAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -33,7 +34,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class SelectFirstRowAction extends MuAction {
 
-    public SelectFirstRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectFirstRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -42,14 +43,19 @@ public class SelectFirstRowAction extends MuAction {
         mainFrame.getActiveTable().selectRow(0);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SelectFirstRow.getId(); }
+        public String getId() {
+            return ActionType.SelectFirstRow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectLastRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectLastRowAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -34,24 +35,29 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class SelectLastRowAction extends MuAction {
 
-    public SelectLastRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectLastRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
         FileTable fileTable = mainFrame.getActiveTable();
-        fileTable.selectRow(fileTable.getFileTableModel().getRowCount()-1);
+        fileTable.selectRow(fileTable.getFileTableModel().getRowCount() - 1);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SelectLastRow.getId(); }
+        public String getId() {
+            return ActionType.SelectLastRow.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectNextBlockAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectNextBlockAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -37,7 +38,7 @@ public class SelectNextBlockAction extends SelectForwardAction {
     // TODO: make this value configurable
     private static final int BLOCK_SIZE = 5;
 
-    public SelectNextBlockAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectNextBlockAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -46,11 +47,12 @@ public class SelectNextBlockAction extends SelectForwardAction {
         return BLOCK_SIZE;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.SelectNextBlock.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectNextPageAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectNextPageAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -33,21 +34,22 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class SelectNextPageAction extends SelectForwardAction {
 
-    public SelectNextPageAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectNextPageAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     protected int getRowIncrement() {
         // Note: the page row increment varies with the file table's height
-        return mainFrame.getActiveTable().getPageRowIncrement()+1;
+        return mainFrame.getActiveTable().getPageRowIncrement() + 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.SelectNextPage.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectNextRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectNextRowAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -33,7 +34,7 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class SelectNextRowAction extends SelectForwardAction {
 
-    public SelectNextRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectNextRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -42,11 +43,12 @@ public class SelectNextRowAction extends SelectForwardAction {
         return 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.SelectNextRow.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectPreviousBlockAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectPreviousBlockAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -37,7 +38,7 @@ public class SelectPreviousBlockAction extends SelectBackwardAction {
     // TODO: make this value configurable
     private static final int BLOCK_SIZE = 5;
 
-    public SelectPreviousBlockAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectPreviousBlockAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -46,11 +47,12 @@ public class SelectPreviousBlockAction extends SelectBackwardAction {
         return BLOCK_SIZE;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.SelectPreviousBlock.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectPreviousPageAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectPreviousPageAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -33,21 +34,22 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class SelectPreviousPageAction extends SelectBackwardAction {
 
-    public SelectPreviousPageAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectPreviousPageAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     protected int getRowDecrement() {
         // Note: the page row increment varies with the file table's height
-        return mainFrame.getActiveTable().getPageRowIncrement()+1;
+        return mainFrame.getActiveTable().getPageRowIncrement() + 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.SelectPreviousPage.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectPreviousRowAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SelectPreviousRowAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -33,7 +34,7 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class SelectPreviousRowAction extends SelectBackwardAction {
 
-    public SelectPreviousRowAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SelectPreviousRowAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -42,11 +43,12 @@ public class SelectPreviousRowAction extends SelectBackwardAction {
         return 1;
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.SelectPreviousRow.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SetTabTitleAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SetTabTitleAction.java
@@ -25,35 +25,41 @@ import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.tab.TabTitleDialog;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Change the title of the selected tab.
- * In case empty string is entered, the title of the tab will be based on its current location.
+ * Change the title of the selected tab. In case empty string is entered, the title of the tab will be based on its
+ * current location.
  * 
  * @author Arik Hadas
  */
 @InvokesDialog
 public class SetTabTitleAction extends MuAction {
 
-	public SetTabTitleAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SetTabTitleAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     @Override
     public void performAction() {
-    	new TabTitleDialog(mainFrame, mainFrame.getActivePanel()).showDialog();
+        new TabTitleDialog(mainFrame, mainFrame.getActivePanel()).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SetTabTitle.getId(); }
+        public String getId() {
+            return ActionType.SetTabTitle.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowAboutAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowAboutAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.about.AboutDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -34,7 +35,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class ShowAboutAction extends MuAction {
 
-    public ShowAboutAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ShowAboutAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -43,14 +44,19 @@ public class ShowAboutAction extends MuAction {
         new AboutDialog(mainFrame).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowAbout.getId(); }
+        public String getId() {
+            return ActionType.ShowAbout.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowBookmarksQLAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowBookmarksQLAction.java
@@ -23,28 +23,34 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.QuickLists;
 
 public class ShowBookmarksQLAction extends ShowQuickListAction {
-	
-	public ShowBookmarksQLAction(MainFrame mainFrame, Map<String,Object> properties) {
-		super(mainFrame, properties);
-	}
-	
-	@Override
+
+    public ShowBookmarksQLAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    @Override
     public void performAction() {
-		openQuickList(QuickLists.BOOKMARKS);
-	}
+        openQuickList(QuickLists.BOOKMARKS);
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowBookmarksQL.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ShowBookmarksQL.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowDebugConsoleAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowDebugConsoleAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.debug.DebugConsoleDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -34,7 +35,7 @@ public class ShowDebugConsoleAction extends MuAction {
 
     private DebugConsoleDialog dialog;
 
-    public ShowDebugConsoleAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ShowDebugConsoleAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -51,9 +52,14 @@ public class ShowDebugConsoleAction extends MuAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-        public String getId() { return ActionType.ShowDebugConsole.getId(); }
+        public String getId() {
+            return ActionType.ShowDebugConsole.getId();
+        }
 
-        public ActionCategory getCategory() { return ActionCategory.MISC; }
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowFilePopupMenuAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowFilePopupMenuAction.java
@@ -27,6 +27,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.ActionProperties;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.InformationDialog;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.menu.TablePopupMenu;
@@ -34,10 +35,9 @@ import com.mucommander.ui.main.table.Column;
 import com.mucommander.ui.main.table.FileTable;
 import com.mucommander.ui.main.table.FileTableModel;
 
-
 /**
- * This action shows the popup menu for currently selected file.
- * Exactly the same popup menu appears also when right-clicking on file/folder.
+ * This action shows the popup menu for currently selected file. Exactly the same popup menu appears also when
+ * right-clicking on file/folder.
  */
 public class ShowFilePopupMenuAction extends SelectedFileAction {
 
@@ -53,7 +53,8 @@ public class ShowFilePopupMenuAction extends SelectedFileAction {
             FileTableModel tableModel = (FileTableModel) fileTable.getModel();
             int selectedRow = fileTable.getSelectedRow();
             Rectangle rect = fileTable.getCellRect(selectedRow,
-                    fileTable.convertColumnIndexToView(Column.NAME.ordinal()), true);
+                    fileTable.convertColumnIndexToView(Column.NAME.ordinal()),
+                    true);
             boolean parentFolderSelected = selectedRow == 0 && tableModel.hasParentFolder();
 
             new TablePopupMenu(mainFrame,
@@ -75,6 +76,7 @@ public class ShowFilePopupMenuAction extends SelectedFileAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static final class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.ShowFilePopupMenu.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowInEnclosingFolderAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowInEnclosingFolderAction.java
@@ -24,15 +24,17 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * This action opens the parent folder of the selected file and keeps the latter file selected.
+ * 
  * @author Arik Hadas
  */
 public class ShowInEnclosingFolderAction extends SelectedFileAction {
 
-    public ShowInEnclosingFolderAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ShowInEnclosingFolderAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -51,9 +53,14 @@ public class ShowInEnclosingFolderAction extends SelectedFileAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-        public String getId() { return ActionType.ShowInEnclosingFolder.getId(); }
+        public String getId() {
+            return ActionType.ShowInEnclosingFolder.getId();
+        }
 
-        public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowKeyboardShortcutsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowKeyboardShortcutsAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.help.ShortcutsDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -34,7 +35,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class ShowKeyboardShortcutsAction extends MuAction {
 
-    public ShowKeyboardShortcutsAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ShowKeyboardShortcutsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -43,14 +44,19 @@ public class ShowKeyboardShortcutsAction extends MuAction {
         new ShortcutsDialog(mainFrame).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowKeyboardShortcuts.getId(); }
+        public String getId() {
+            return ActionType.ShowKeyboardShortcuts.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.MISC; }
+        public ActionCategory getCategory() {
+            return ActionCategory.MISC;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowParentFoldersQLAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowParentFoldersQLAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.QuickLists;
 
@@ -33,24 +34,29 @@ import com.mucommander.ui.main.QuickLists;
  */
 
 public class ShowParentFoldersQLAction extends ShowQuickListAction {
-	
-	public ShowParentFoldersQLAction(MainFrame mainFrame, Map<String,Object> properties) {
-		super(mainFrame, properties);
-	}
-	
-	@Override
+
+    public ShowParentFoldersQLAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    @Override
     public void performAction() {
-		openQuickList(QuickLists.PARENT_FOLDERS);
-	}
+        openQuickList(QuickLists.PARENT_FOLDERS);
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowParentFoldersQL.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ShowParentFoldersQL.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowRecentExecutedFilesQLAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowRecentExecutedFilesQLAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.QuickLists;
 
@@ -33,24 +34,29 @@ import com.mucommander.ui.main.QuickLists;
  */
 
 public class ShowRecentExecutedFilesQLAction extends ShowQuickListAction {
-	
-	public ShowRecentExecutedFilesQLAction(MainFrame mainFrame, Map<String,Object> properties) {
-		super(mainFrame, properties);
-	}
-	
-	@Override
+
+    public ShowRecentExecutedFilesQLAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    @Override
     public void performAction() {
-		openQuickList(QuickLists.RECENT_EXECUTED_FILES);
-	}
+        openQuickList(QuickLists.RECENT_EXECUTED_FILES);
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowRecentExecutedFilesQL.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ShowRecentExecutedFilesQL.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowRecentLocationsQLAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowRecentLocationsQLAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.QuickLists;
 
@@ -33,24 +34,29 @@ import com.mucommander.ui.main.QuickLists;
  */
 
 public class ShowRecentLocationsQLAction extends ShowQuickListAction {
-	
-	public ShowRecentLocationsQLAction(MainFrame mainFrame, Map<String,Object> properties) {
-		super(mainFrame, properties);
-	}
-	
-	@Override
+
+    public ShowRecentLocationsQLAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    @Override
     public void performAction() {
-		openQuickList(QuickLists.RECENT_ACCESSED_LOCATIONS);
-	}
+        openQuickList(QuickLists.RECENT_ACCESSED_LOCATIONS);
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowRecentLocationsQL.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ShowRecentLocationsQL.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowRootFoldersQLAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowRootFoldersQLAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.QuickLists;
 
@@ -33,23 +34,28 @@ import com.mucommander.ui.main.QuickLists;
  */
 public class ShowRootFoldersQLAction extends ShowQuickListAction {
 
-	public ShowRootFoldersQLAction(MainFrame mainFrame, Map<String,Object> properties) {
-		super(mainFrame, properties);
-	}
-	
-	@Override
+    public ShowRootFoldersQLAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    @Override
     public void performAction() {
-		openQuickList(QuickLists.ROOTS);
-	}
+        openQuickList(QuickLists.ROOTS);
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowRootFoldersQL.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ShowRootFoldersQL.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowTabsQLAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ShowTabsQLAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.QuickLists;
 
@@ -32,24 +33,29 @@ import com.mucommander.ui.main.QuickLists;
  * @author Arik Hadas
  */
 public class ShowTabsQLAction extends ShowQuickListAction {
-	
-	public ShowTabsQLAction(MainFrame mainFrame, Map<String,Object> properties) {
-		super(mainFrame, properties);
-	}
-	
-	@Override
+
+    public ShowTabsQLAction(MainFrame mainFrame, Map<String, Object> properties) {
+        super(mainFrame, properties);
+    }
+
+    @Override
     public void performAction() {
-		openQuickList(QuickLists.TABS);
-	}
+        openQuickList(QuickLists.TABS);
+    }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ShowTabsQL.getId(); }
+    @NoIcon
+    public static class Descriptor extends AbstractActionDescriptor {
+        public String getId() {
+            return ActionType.ShowTabsQL.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByDateAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByDateAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by date.
- * If the table is already sorted by date, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by date. If the table is
+ * already sorted by date, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortByDateAction extends SortByAction {
 
-    public SortByDateAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortByDateAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.DATE);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByExtensionAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByExtensionAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by extension.
- * If the table is already sorted by extension, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by extension. If the table is
+ * already sorted by extension, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortByExtensionAction extends SortByAction {
 
-    public SortByExtensionAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortByExtensionAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.EXTENSION);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByGroupAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByGroupAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by group.
- * If the table is already sorted by group, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by group. If the table is
+ * already sorted by group, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortByGroupAction extends SortByAction {
 
-    public SortByGroupAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortByGroupAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.GROUP);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByNameAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByNameAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by name.
- * If the table is already sorted by name, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by name. If the table is
+ * already sorted by name, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortByNameAction extends SortByAction {
 
-    public SortByNameAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortByNameAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.NAME);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByOwnerAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByOwnerAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by owner.
- * If the table is already sorted by owner, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by owner. If the table is
+ * already sorted by owner, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortByOwnerAction extends SortByAction {
 
-    public SortByOwnerAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortByOwnerAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.OWNER);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByPermissionsAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortByPermissionsAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by permissions.
- * If the table is already sorted by permissions, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by permissions. If the table
+ * is already sorted by permissions, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortByPermissionsAction extends SortByAction {
 
-    public SortByPermissionsAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortByPermissionsAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.PERMISSIONS);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortBySizeAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SortBySizeAction.java
@@ -20,26 +20,28 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by size.
- * If the table is already sorted by size, the sort order will be reversed.
+ * This action sorts the currently active {@link com.mucommander.ui.main.table.FileTable} by size. If the table is
+ * already sorted by size, the sort order will be reversed.
  *
  * @author Maxence Bernard
  */
 public class SortBySizeAction extends SortByAction {
 
-    public SortBySizeAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SortBySizeAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.SIZE);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends SortByAction.Descriptor {
 
         public Descriptor() {

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitEquallyAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitEquallyAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -33,7 +34,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class SplitEquallyAction extends MuAction {
 
-    public SplitEquallyAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SplitEquallyAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -42,14 +43,19 @@ public class SplitEquallyAction extends MuAction {
         mainFrame.getFoldersSplitPane().setSplitRatio(0.5f);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SplitEqually.getId(); }
+        public String getId() {
+            return ActionType.SplitEqually.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitFileAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitFileAction.java
@@ -29,6 +29,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.InvokesDialog;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.dialog.file.SplitFileDialog;
 import com.mucommander.ui.main.MainFrame;
 
@@ -40,31 +41,34 @@ import com.mucommander.ui.main.MainFrame;
 @InvokesDialog
 public class SplitFileAction extends SelectedFileAction {
 
-    public SplitFileAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SplitFileAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
 
         setSelectedFileFilter(new AndFileFilter(
-            new AttributeFileFilter(FileAttribute.DIRECTORY, true),
-            new FileOperationFilter(FileOperation.READ_FILE)
-        ));
+                new AttributeFileFilter(FileAttribute.DIRECTORY, true),
+                new FileOperationFilter(FileOperation.READ_FILE)));
     }
 
     @Override
     public void performAction() {
         new SplitFileDialog(mainFrame,
                 mainFrame.getActiveTable().getSelectedFile(),
-                mainFrame.getInactivePanel().getCurrentFolder()
-        ).showDialog();
+                mainFrame.getInactivePanel().getCurrentFolder()).showDialog();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SplitFile.getId(); }
+        public String getId() {
+            return ActionType.SplitFile.getId();
+        }
 
-		public ActionCategory getCategory() { return null; }
+        public ActionCategory getCategory() {
+            return null;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitHorizontallyAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitHorizontallyAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -33,7 +34,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class SplitHorizontallyAction extends MuAction {
 
-    public SplitHorizontallyAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SplitHorizontallyAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -42,14 +43,19 @@ public class SplitHorizontallyAction extends MuAction {
         mainFrame.setSplitPaneOrientation(false);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SplitHorizontally.getId(); }
+        public String getId() {
+            return ActionType.SplitHorizontally.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitVerticallyAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SplitVerticallyAction.java
@@ -24,17 +24,17 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
- * Splits the folder panels vertically (top/bottom) within the MainFrame.
- * This is the default split orientation.
+ * Splits the folder panels vertically (top/bottom) within the MainFrame. This is the default split orientation.
  *
  * @author Maxence Bernard
  */
 public class SplitVerticallyAction extends MuAction {
 
-    public SplitVerticallyAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SplitVerticallyAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -43,14 +43,19 @@ public class SplitVerticallyAction extends MuAction {
         mainFrame.setSplitPaneOrientation(true);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SplitVertically.getId(); }
+        public String getId() {
+            return ActionType.SplitVertically.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SwitchActiveTableAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/SwitchActiveTableAction.java
@@ -24,18 +24,19 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
 /**
- * This action switches the currently active FileTable, that is gives focus to the FileTable that currently doesn't
- * have it.
+ * This action switches the currently active FileTable, that is gives focus to the FileTable that currently doesn't have
+ * it.
  *
  * @author Maxence Bernard
  */
 public class SwitchActiveTableAction extends MuAction {
 
-    public SwitchActiveTableAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public SwitchActiveTableAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -44,20 +45,25 @@ public class SwitchActiveTableAction extends MuAction {
         FileTable activeTable = mainFrame.getActiveTable();
         FileTable leftTable = mainFrame.getLeftPanel().getFileTable();
         FileTable rightTable = mainFrame.getRightPanel().getFileTable();
-        if(activeTable == leftTable)
+        if (activeTable == leftTable)
             rightTable.requestFocus();
-        else if(activeTable == rightTable)
+        else if (activeTable == rightTable)
             leftTable.requestFocus();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.SwitchActiveTable.getId(); }
+        public String getId() {
+            return ActionType.SwitchActiveTable.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.NAVIGATION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.NAVIGATION;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleAutoSizeAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleAutoSizeAction.java
@@ -26,6 +26,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -36,7 +37,7 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class ToggleAutoSizeAction extends MuAction {
 
-    public ToggleAutoSizeAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleAutoSizeAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -48,14 +49,19 @@ public class ToggleAutoSizeAction extends MuAction {
         MuConfigurations.getPreferences().setVariable(MuPreference.AUTO_SIZE_COLUMNS, enabled);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleAutoSize.getId(); }
+        public String getId() {
+            return ActionType.ToggleAutoSize.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleCommandBarAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleCommandBarAction.java
@@ -28,36 +28,42 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.commandbar.CommandBar;
 
 /**
- * This action shows/hides the current MainFrame's {@link com.mucommander.ui.main.commandbar.CommandBar} depending on its
- * current visible state: if it is visible, hides it, if not shows it.
+ * This action shows/hides the current MainFrame's {@link com.mucommander.ui.main.commandbar.CommandBar} depending on
+ * its current visible state: if it is visible, hides it, if not shows it.
  *
- * <p>This action's label will be updated to reflect the current visible state.
+ * <p>
+ * This action's label will be updated to reflect the current visible state.
  *
- * <p>Each time this action is executed, the new current visible state is stored in the configuration so that
- * new MainFrame windows will use it to determine whether the CommandBar has to be made visible or not.
+ * <p>
+ * Each time this action is executed, the new current visible state is stored in the configuration so that new MainFrame
+ * windows will use it to determine whether the CommandBar has to be made visible or not.
  *
  * @author Maxence Bernard
  */
 public class ToggleCommandBarAction extends MuAction {
 
-    public ToggleCommandBarAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleCommandBarAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
-        updateLabel(MuConfigurations.getPreferences().getVariable(MuPreference.COMMAND_BAR_VISIBLE, MuPreferences.DEFAULT_COMMAND_BAR_VISIBLE));
+        updateLabel(MuConfigurations.getPreferences()
+                .getVariable(MuPreference.COMMAND_BAR_VISIBLE, MuPreferences.DEFAULT_COMMAND_BAR_VISIBLE));
     }
 
     private void updateLabel(boolean visible) {
-        setLabel(Translator.get(visible?ActionType.ToggleCommandBar+".hide":ActionType.ToggleCommandBar+".show"));
+        setLabel(Translator
+                .get(visible ? ActionType.ToggleCommandBar + ".hide" : ActionType.ToggleCommandBar + ".show"));
     }
 
     @Override
     public void performAction() {
         CommandBar commandBar = mainFrame.getCommandBar();
         boolean visible = !commandBar.isVisible();
-        // Save the last command bar visible state in the configuration, this will become the default for new MainFrame windows.
+        // Save the last command bar visible state in the configuration, this will become the default for new MainFrame
+        // windows.
         MuConfigurations.getPreferences().setVariable(MuPreference.COMMAND_BAR_VISIBLE, visible);
         // Change the label to reflect the new command bar state
         updateLabel(visible);
@@ -66,17 +72,24 @@ public class ToggleCommandBarAction extends MuAction {
         mainFrame.getJFrame().validate();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleCommandBar.getId(); }
+        public String getId() {
+            return ActionType.ToggleCommandBar.getId();
+        }
 
-        public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
 
         @Override
-        public String getLabelKey() { return ActionType.ToggleCommandBar+".show"; }
+        public String getLabelKey() {
+            return ActionType.ToggleCommandBar + ".show";
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleDateColumnAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleDateColumnAction.java
@@ -20,27 +20,31 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * Shows/hides the 'Date' column of the currently active FileTable. If the column is currently visible, this action
- * will hide it and vice-versa.
+ * Shows/hides the 'Date' column of the currently active FileTable. If the column is currently visible, this action will
+ * hide it and vice-versa.
  *
  * @author Maxence Bernard
  */
 public class ToggleDateColumnAction extends ToggleColumnAction {
 
-    public ToggleDateColumnAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleDateColumnAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.DATE);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends ToggleColumnAction.Descriptor {
-        public Descriptor() { super(Column.DATE); }
+        public Descriptor() {
+            super(Column.DATE);
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleExtensionColumnAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleExtensionColumnAction.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
@@ -31,16 +32,19 @@ import com.mucommander.ui.main.table.Column;
  */
 public class ToggleExtensionColumnAction extends ToggleColumnAction {
 
-    public ToggleExtensionColumnAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleExtensionColumnAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.EXTENSION);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends ToggleColumnAction.Descriptor {
-        public Descriptor() { super(Column.EXTENSION); }
+        public Descriptor() {
+            super(Column.EXTENSION);
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleGroupColumnAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleGroupColumnAction.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
@@ -31,16 +32,19 @@ import com.mucommander.ui.main.table.Column;
  */
 public class ToggleGroupColumnAction extends ToggleColumnAction {
 
-    public ToggleGroupColumnAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleGroupColumnAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.GROUP);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends ToggleColumnAction.Descriptor {
-        public Descriptor() { super(Column.GROUP); }
+        public Descriptor() {
+            super(Column.GROUP);
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleHiddenFilesAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleHiddenFilesAction.java
@@ -27,11 +27,13 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.WindowManager;
 
 /**
  * A simple action that toggles hidden files visibility on and off.
+ * 
  * @author Nicolas Rinaudo
  */
 public class ToggleHiddenFilesAction extends MuAction {
@@ -40,10 +42,9 @@ public class ToggleHiddenFilesAction extends MuAction {
     /**
      * Creates a new <code>ToggleHiddenFilesAction</code>.
      */
-    public ToggleHiddenFilesAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleHiddenFilesAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
-
 
     // - Action code ---------------------------------------------------------------------
     // -----------------------------------------------------------------------------------
@@ -52,19 +53,26 @@ public class ToggleHiddenFilesAction extends MuAction {
      */
     @Override
     public void performAction() {
-    	MuConfigurations.getPreferences().setVariable(MuPreference.SHOW_HIDDEN_FILES,
-                                    !MuConfigurations.getPreferences().getVariable(MuPreference.SHOW_HIDDEN_FILES, MuPreferences.DEFAULT_SHOW_HIDDEN_FILES));
+        MuConfigurations.getPreferences()
+                .setVariable(MuPreference.SHOW_HIDDEN_FILES,
+                        !MuConfigurations.getPreferences()
+                                .getVariable(MuPreference.SHOW_HIDDEN_FILES, MuPreferences.DEFAULT_SHOW_HIDDEN_FILES));
         WindowManager.tryRefreshCurrentFolders();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleHiddenFiles.getId(); }
+        public String getId() {
+            return ActionType.ToggleHiddenFiles.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleLockTabAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleLockTabAction.java
@@ -24,52 +24,59 @@ import com.mucommander.text.Translator;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * This action locks/unlocks the currently selected {@link com.mucommander.ui.main.tabs.FileTableTab} depending on its
  * current locking state: if it is locked, unlock it, if not lock it.
  *
- * <p>This action's label will be updated to reflect the locking state of the currently selected tab.
+ * <p>
+ * This action's label will be updated to reflect the locking state of the currently selected tab.
  *
  * @author Arik Hadas
  */
 public class ToggleLockTabAction extends ActiveTabAction {
 
-	public ToggleLockTabAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleLockTabAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
     private void updateLabel(boolean locked) {
-        setLabel(Translator.get(locked?ActionType.ToggleLockTab+".unlock":ActionType.ToggleLockTab+".lock"));
+        setLabel(Translator.get(locked ? ActionType.ToggleLockTab + ".unlock" : ActionType.ToggleLockTab + ".lock"));
     }
 
     @Override
     public void performAction() {
-    	boolean lock = !mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked();
+        boolean lock = !mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked();
 
-    	if (lock)
-        	mainFrame.getActivePanel().getTabs().lock();
+        if (lock)
+            mainFrame.getActivePanel().getTabs().lock();
         else
-        	mainFrame.getActivePanel().getTabs().unlock();
-    	
+            mainFrame.getActivePanel().getTabs().unlock();
+
         // Change the label to reflect the new tab's locking state
         updateLabel(lock);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
-	@Override
-	protected void toggleEnabledState() {
-		updateLabel(mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked());
-	}
+    @Override
+    protected void toggleEnabledState() {
+        updateLabel(mainFrame.getActivePanel().getTabs().getCurrentTab().isLocked());
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleLockTab.getId(); }
+        public String getId() {
+            return ActionType.ToggleLockTab.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.TAB; }
+        public ActionCategory getCategory() {
+            return ActionCategory.TAB;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleOwnerColumnAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleOwnerColumnAction.java
@@ -20,6 +20,7 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
@@ -31,16 +32,19 @@ import com.mucommander.ui.main.table.Column;
  */
 public class ToggleOwnerColumnAction extends ToggleColumnAction {
 
-    public ToggleOwnerColumnAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleOwnerColumnAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.OWNER);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends ToggleColumnAction.Descriptor {
-        public Descriptor() { super(Column.OWNER); }
+        public Descriptor() {
+            super(Column.OWNER);
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/TogglePermissionsColumnAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/TogglePermissionsColumnAction.java
@@ -20,27 +20,31 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * Shows/hides the 'Permissions' column of the currently active FileTable. If the column is currently visible, this action
- * will hide it and vice-versa.
+ * Shows/hides the 'Permissions' column of the currently active FileTable. If the column is currently visible, this
+ * action will hide it and vice-versa.
  *
  * @author Maxence Bernard
  */
 public class TogglePermissionsColumnAction extends ToggleColumnAction {
 
-    public TogglePermissionsColumnAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public TogglePermissionsColumnAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.PERMISSIONS);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends ToggleColumnAction.Descriptor {
-        public Descriptor() { super(Column.PERMISSIONS); }
+        public Descriptor() {
+            super(Column.PERMISSIONS);
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleShowFoldersFirstAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleShowFoldersFirstAction.java
@@ -26,6 +26,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.FileTable;
 
@@ -37,7 +38,7 @@ import com.mucommander.ui.main.table.FileTable;
  */
 public class ToggleShowFoldersFirstAction extends MuAction {
 
-    public ToggleShowFoldersFirstAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleShowFoldersFirstAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -49,14 +50,19 @@ public class ToggleShowFoldersFirstAction extends MuAction {
         MuConfigurations.getPreferences().setVariable(MuPreference.SHOW_FOLDERS_FIRST, showFoldersFirst);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleShowFoldersFirst.getId(); }
+        public String getId() {
+            return ActionType.ToggleShowFoldersFirst.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleSizeColumnAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleSizeColumnAction.java
@@ -20,27 +20,31 @@ package com.mucommander.ui.action.impl;
 import java.util.Map;
 
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.table.Column;
 
 /**
- * Shows/hides the 'Size' column of the currently active FileTable. If the column is currently visible, this action
- * will hide it and vice-versa.
+ * Shows/hides the 'Size' column of the currently active FileTable. If the column is currently visible, this action will
+ * hide it and vice-versa.
  *
  * @author Maxence Bernard
  */
 public class ToggleSizeColumnAction extends ToggleColumnAction {
 
-    public ToggleSizeColumnAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleSizeColumnAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, Column.SIZE);
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends ToggleColumnAction.Descriptor {
-        public Descriptor() { super(Column.SIZE); }
+        public Descriptor() {
+            super(Column.SIZE);
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleStatusBarAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleStatusBarAction.java
@@ -28,36 +28,41 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.StatusBar;
 
 /**
- * This action shows/hides the current MainFrame's {@link com.mucommander.ui.main.StatusBar} depending on its
- * current visible state: if it is visible, hides it, if not shows it.
+ * This action shows/hides the current MainFrame's {@link com.mucommander.ui.main.StatusBar} depending on its current
+ * visible state: if it is visible, hides it, if not shows it.
  *
- * <p>This action's label will be updated to reflect the current visible state.
+ * <p>
+ * This action's label will be updated to reflect the current visible state.
  *
- * <p>Each time this action is executed, the new current visible state is stored in the configuration so that
- * new MainFrame windows will use it to determine whether the StatusBar has to be made visible or not.
+ * <p>
+ * Each time this action is executed, the new current visible state is stored in the configuration so that new MainFrame
+ * windows will use it to determine whether the StatusBar has to be made visible or not.
  *
  * @author Maxence Bernard
  */
 public class ToggleStatusBarAction extends MuAction {
 
-    public ToggleStatusBarAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleStatusBarAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
-        updateLabel(MuConfigurations.getPreferences().getVariable(MuPreference.STATUS_BAR_VISIBLE, MuPreferences.DEFAULT_STATUS_BAR_VISIBLE));
+        updateLabel(MuConfigurations.getPreferences()
+                .getVariable(MuPreference.STATUS_BAR_VISIBLE, MuPreferences.DEFAULT_STATUS_BAR_VISIBLE));
     }
 
     private void updateLabel(boolean visible) {
-        setLabel(Translator.get(visible?ActionType.ToggleStatusBar+".hide":ActionType.ToggleStatusBar+".show"));
+        setLabel(Translator.get(visible ? ActionType.ToggleStatusBar + ".hide" : ActionType.ToggleStatusBar + ".show"));
     }
 
     @Override
     public void performAction() {
         StatusBar statusBar = mainFrame.getStatusBar();
         boolean visible = !statusBar.isVisible();
-        // Save the last status bar visible state in the configuration, this will become the default for new MainFrame windows.
+        // Save the last status bar visible state in the configuration, this will become the default for new MainFrame
+        // windows.
         MuConfigurations.getPreferences().setVariable(MuPreference.STATUS_BAR_VISIBLE, visible);
         // Change the label to reflect the new status bar state
         updateLabel(visible);
@@ -66,17 +71,24 @@ public class ToggleStatusBarAction extends MuAction {
         mainFrame.getJFrame().validate();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleStatusBar.getId(); }
+        public String getId() {
+            return ActionType.ToggleStatusBar.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
 
         @Override
-        public String getLabelKey() { return ActionType.ToggleStatusBar+".show"; }
+        public String getLabelKey() {
+            return ActionType.ToggleStatusBar + ".show";
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleToolBarAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleToolBarAction.java
@@ -30,35 +30,40 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
  * This action shows/hides the current MainFrame's {@link com.mucommander.ui.main.toolbar.ToolBar} depending on its
  * current visible state: if it is visible, hides it, if not shows it.
  *
- * <p>This action's label will be updated to reflect the current visible state.
+ * <p>
+ * This action's label will be updated to reflect the current visible state.
  *
- * <p>Each time this action is executed, the new current visible state is stored in the configuration so that
- * new MainFrame windows will use it to determine whether the ToolBar has to be made visible or not.
+ * <p>
+ * Each time this action is executed, the new current visible state is stored in the configuration so that new MainFrame
+ * windows will use it to determine whether the ToolBar has to be made visible or not.
  *
  * @author Maxence Bernard
  */
 public class ToggleToolBarAction extends MuAction {
 
-    public ToggleToolBarAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleToolBarAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
-        updateLabel(MuConfigurations.getPreferences().getVariable(MuPreference.TOOLBAR_VISIBLE, MuPreferences.DEFAULT_TOOLBAR_VISIBLE));
+        updateLabel(MuConfigurations.getPreferences()
+                .getVariable(MuPreference.TOOLBAR_VISIBLE, MuPreferences.DEFAULT_TOOLBAR_VISIBLE));
     }
 
     private void updateLabel(boolean visible) {
-        setLabel(Translator.get(visible?ActionType.ToggleToolBar+".hide":ActionType.ToggleToolBar+".show"));
+        setLabel(Translator.get(visible ? ActionType.ToggleToolBar + ".hide" : ActionType.ToggleToolBar + ".show"));
     }
 
     @Override
     public void performAction() {
         JPanel toolBarPanel = mainFrame.getToolBarPanel();
         boolean visible = !toolBarPanel.isVisible();
-        // Save the last toolbar visible state in the configuration, this will become the default for new MainFrame windows.
+        // Save the last toolbar visible state in the configuration, this will become the default for new MainFrame
+        // windows.
         MuConfigurations.getPreferences().setVariable(MuPreference.TOOLBAR_VISIBLE, visible);
         // Change the label to reflect the new toolbar state
         updateLabel(visible);
@@ -67,17 +72,24 @@ public class ToggleToolBarAction extends MuAction {
         mainFrame.getJFrame().validate();
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleToolBar.getId(); }
+        public String getId() {
+            return ActionType.ToggleToolBar.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
 
         @Override
-        public String getLabelKey() { return ActionType.ToggleToolBar+".show"; }
+        public String getLabelKey() {
+            return ActionType.ToggleToolBar + ".show";
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTreeAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleTreeAction.java
@@ -24,19 +24,21 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.FolderPanel;
 import com.mucommander.ui.main.MainFrame;
 import com.mucommander.ui.main.tree.FoldersTreePanel;
 
 /**
  * This action toggles the visibility of a directory tree.
- * @see FoldersTreePanel   
+ * 
+ * @see FoldersTreePanel
  *
  * @author Mariusz Jakubowski
  */
 public class ToggleTreeAction extends MuAction {
 
-    public ToggleTreeAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public ToggleTreeAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties);
     }
 
@@ -46,14 +48,19 @@ public class ToggleTreeAction extends MuAction {
         folderPanel.setTreeVisible(!folderPanel.isTreeVisible());
     }
 
-	@Override
-	public ActionDescriptor getDescriptor() {
-		return new Descriptor();
-	}
+    @Override
+    public ActionDescriptor getDescriptor() {
+        return new Descriptor();
+    }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.ToggleTree.getId(); }
+        public String getId() {
+            return ActionType.ToggleTree.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.VIEW; }
+        public ActionCategory getCategory() {
+            return ActionCategory.VIEW;
+        }
     }
 }

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/ToggleUseSinglePanelAction.java
@@ -24,6 +24,7 @@ import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
 import com.mucommander.ui.action.MuAction;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -46,7 +47,6 @@ public class ToggleUseSinglePanelAction extends MuAction {
         mainFrame.getInactivePanel().getPanel().setVisible(true);
     }
 
-
     @Override
     public void performAction() {
         // we want to restore old two panel ratio
@@ -67,6 +67,7 @@ public class ToggleUseSinglePanelAction extends MuAction {
         return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
         public String getId() {
             return ActionType.ToggleUseSinglePanel.getId();

--- a/mucommander-core/src/main/java/com/mucommander/ui/action/impl/UnmarkAllAction.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/action/impl/UnmarkAllAction.java
@@ -23,6 +23,7 @@ import com.mucommander.desktop.ActionType;
 import com.mucommander.ui.action.AbstractActionDescriptor;
 import com.mucommander.ui.action.ActionCategory;
 import com.mucommander.ui.action.ActionDescriptor;
+import com.mucommander.ui.action.NoIcon;
 import com.mucommander.ui.main.MainFrame;
 
 /**
@@ -32,18 +33,23 @@ import com.mucommander.ui.main.MainFrame;
  */
 public class UnmarkAllAction extends MarkAllAction {
 
-    public UnmarkAllAction(MainFrame mainFrame, Map<String,Object> properties) {
+    public UnmarkAllAction(MainFrame mainFrame, Map<String, Object> properties) {
         super(mainFrame, properties, false);
     }
 
     @Override
     public ActionDescriptor getDescriptor() {
-    	return new Descriptor();
+        return new Descriptor();
     }
 
+    @NoIcon
     public static class Descriptor extends AbstractActionDescriptor {
-		public String getId() { return ActionType.UnmarkAll.getId(); }
+        public String getId() {
+            return ActionType.UnmarkAll.getId();
+        }
 
-		public ActionCategory getCategory() { return ActionCategory.SELECTION; }
+        public ActionCategory getCategory() {
+            return ActionCategory.SELECTION;
+        }
     }
 }


### PR DESCRIPTION
Add NoIcon annotation to explicitly state that no icon is set for a particular action, and in case the annotation is set for an action, we don't create a warning of 'attempt to load non-existing icon' for that action.