### PR TITLE
Fix a race that leads to menu items that are set with an icon

### DIFF
--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/helper/MenuToolkit.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/helper/MenuToolkit.java
@@ -170,14 +170,36 @@ public class MenuToolkit {
     }
 
     public static JMenuItem addMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper) {
-        return addMenuItem(menu, action, mnemonicHelper, JMenuItem::new);
+        return addMenuItem(menu, action, mnemonicHelper, MenuToolkit::iconlessMenuItem);
     }
 
+    /**
+     * If the provided action has an icon, it would by default get displayed in the menu item.
+     * Since icons have nothing to do in menus, let's make sure the menu item has no icon.
+     */
+    private static JMenuItem iconlessMenuItem(AbstractAction action) {
+        return new JMenuItem(action) {
+            public void setIcon(javax.swing.Icon defaultIcon) {
+                // noop
+            }
+        };
+    }
 
     public static JCheckBoxMenuItem addCheckBoxMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper) {
-        return addMenuItem(menu, action, mnemonicHelper, JCheckBoxMenuItem::new);
+        return addMenuItem(menu, action, mnemonicHelper, MenuToolkit::iconlessCheckBoxMenuItem);
     }
 
+    /**
+     * If the provided action has an icon, it would by default get displayed in the menu item.
+     * Since icons have nothing to do in menus, let's make sure the menu item has no icon.
+     */
+    private static JCheckBoxMenuItem iconlessCheckBoxMenuItem(AbstractAction action) {
+        return new JCheckBoxMenuItem(action) {
+            public void setIcon(javax.swing.Icon defaultIcon) {
+                // noop
+            }
+        };
+    }
 
     private static <T extends JMenuItem> T addMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper, Function<AbstractAction, T> newMenuItem) {
         T menuItem = newMenuItem.apply(action);
@@ -187,10 +209,6 @@ public class MenuToolkit {
             if(mnemonic!=0)
                 menuItem.setMnemonic(mnemonic);
         }
-
-        // If the provided action has an icon, it would by default get displayed in the menu item.
-        // Since icons have nothing to do in menus, let's make sure the menu item has no icon. 
-        menuItem.setIcon(null);
 
         menu.add(menuItem);
 

--- a/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/helper/MenuToolkit.java
+++ b/mucommander-commons-util/src/main/java/com/mucommander/commons/util/ui/helper/MenuToolkit.java
@@ -20,6 +20,7 @@ package com.mucommander.commons.util.ui.helper;
 
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.util.function.Function;
 
 import javax.swing.AbstractAction;
 import javax.swing.JCheckBoxMenuItem;
@@ -169,17 +170,17 @@ public class MenuToolkit {
     }
 
     public static JMenuItem addMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper) {
-        return addMenuItem(menu, action, mnemonicHelper, false);
+        return addMenuItem(menu, action, mnemonicHelper, JMenuItem::new);
     }
 
 
     public static JCheckBoxMenuItem addCheckBoxMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper) {
-        return (JCheckBoxMenuItem)addMenuItem(menu, action, mnemonicHelper, true);
+        return addMenuItem(menu, action, mnemonicHelper, JCheckBoxMenuItem::new);
     }
 
 
-    private static JMenuItem addMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper, boolean createCheckBoxMenuItem) {
-        JMenuItem menuItem = createCheckBoxMenuItem?new JCheckBoxMenuItem(action):new JMenuItem(action);
+    private static <T extends JMenuItem> T addMenuItem(JMenu menu, AbstractAction action, MnemonicHelper mnemonicHelper, Function<AbstractAction, T> newMenuItem) {
+        T menuItem = newMenuItem.apply(action);
 
         if(mnemonicHelper!=null) {
             char mnemonic = mnemonicHelper.getMnemonic(action.toString());

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -39,6 +39,7 @@ Improvements:
 - Image preview: faster display of large JPEG files, added support for the following image formats: webp, psd (and psb)
 - Retrieve 'owner' and 'group' properties of local files on file systems that support these properties.
 - RAR files are now handled on Apple silicon the same way as on Intel. This accelerates browsing folders with many RAR files on Apple silicon.
+- Fix a race condition that lead to having menu items with icons.
 
 Localization:
 -


### PR DESCRIPTION
Now that actions are initialized by several threads during startup, the following race could happen:
1. An action is being initialized
2. A menu items with that action is being initialized
3. The icon of the menu items is dropped (set to `null`)
4. The icon of the action is set and as a result the button behind the menu item is set with that icon
5. Consequently, the menu item is set with an icon

In order to solve this, the `setIcon` method of menu items is now overridden and ignores requests to set an icon for the menu item.