### PR TITLE
Add null check for zip file extended timestamp entry

### DIFF
--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
@@ -19,6 +19,7 @@
 package com.mucommander.commons.file.archive.zip.provider;
 
 import java.util.Calendar;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Vector;
 import java.util.stream.Stream;
@@ -460,6 +461,7 @@ public class ZipEntry implements Cloneable {
                         .filter(f -> f instanceof ExtendedTimestampExtraField)
                         .map(f -> (ExtendedTimestampExtraField) f)
                         .map(ExtendedTimestampExtraField::getJavaTime)
+                        .filter(Objects::nonNull)
                         .findFirst();
     }
 


### PR DESCRIPTION
This PR addresses #1252.

In a case where extended timestamp entry exists in a zip entry but `FLAG_MODTIME` is not present, the `javaTime` field of `ExtendedTimestampExtraField` is going to be null. This in turn lead to NullPointerException being thrown from `ZipEntry::getTimeExtended`.