### PR TITLE
Drop files from the root folder of an app image for macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -448,7 +448,6 @@ task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
     doLast {
        copy {
           from "package"
-          include "license.txt"
           include "readme.txt"
           into "${buildDir}/muCommander.app/Contents"
        }

--- a/build.gradle
+++ b/build.gradle
@@ -449,7 +449,7 @@ task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
        copy {
           from "package"
           include "readme.txt"
-          into "${buildDir}/muCommander.app/Contents"
+          into "${buildDir}/muCommander.app/Contents/Resources"
        }
        delete("${buildDir}/muCommander.app/Contents/app/run.bat")
        delete("${buildDir}/muCommander.app/Contents/app/run.sh")


### PR DESCRIPTION
Fix #1155 
With this, the dmg package can be created with Apple silicon using `./gradlew dmg -PskipDmgSign -Parch=aarch64`