### PR TITLE
Fix tray icon color in macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -415,6 +415,7 @@ task macAppImage(dependsOn: 'createBundlesDir', type: Exec) {
                 '--runtime-image', 'jre/macOS/'+project.ext.arch, \
                 '--java-options', '\
                          -Dsun.java2d.d3d=false -Dsun.java2d.noddraw=false -Dsun.java2d.metal=true \
+                         -Dapple.awt.enableTemplateImages=true \
                          -Xshare:auto -XX:-UsePerfData -XX:+TieredCompilation -XX:TieredStopAtLevel=1 \
                         --add-exports java.desktop/com.apple.laf=ALL-UNNAMED \
                         --add-exports java.desktop/com.apple.eio=ALL-UNNAMED \


### PR DESCRIPTION
Following the addition of monochrome icon for macOS: https://github.com/mucommander/mucommander/pull/1259.
Use 'enableTemplateImages' on build for letting macOS to adjust icon's color based on the wallpaper: https://github.com/openjdk/jdk/pull/481

Dark Background:
<img width="278" alt="Screenshot 2024-09-18 at 13 19 26" src="https://github.com/user-attachments/assets/f8005d36-79b9-4c78-9f39-558a49887c12">

Light Background:
<img width="284" alt="Screenshot 2024-09-18 at 13 20 43" src="https://github.com/user-attachments/assets/e47a07e0-5b62-4a3d-b5c9-25398afb5938">

