### PR TITLE
Consider nested volumes in testVolumes

### DIFF
--- a/mucommander-commons-file/src/test/java/com/mucommander/commons/file/protocol/local/LocalFileTest.java
+++ b/mucommander-commons-file/src/test/java/com/mucommander/commons/file/protocol/local/LocalFileTest.java
@@ -21,14 +21,11 @@ import com.mucommander.commons.file.AbstractFile;
 import com.mucommander.commons.file.AbstractFileTest;
 import com.mucommander.commons.file.FileFactory;
 import com.mucommander.commons.file.FileOperation;
-import com.mucommander.commons.file.protocol.local.LocalFile;
-
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
-
 
 /**
  * An {@link AbstractFileTest} implementation for {@link LocalFile}.
@@ -137,7 +134,7 @@ public class LocalFileTest extends AbstractFileTest {
         assert volumes.length>0;
 
         for (AbstractFile volume : volumes)
-            testVolume(volume);
+            testVolume(volume, volumes);
     }
 
     /**


### PR DESCRIPTION
previously, the test checked that an arbitrary child of a volume is located on the volume without considering the case of nested volumes, e.g., /boot/efi/ which is a child of /boot/ but is not located on /boot/.