### PR TITLE
JediTerm version bump to 3.47 (to the latest one)

### DIFF
--- a/jetbrains-jediterm/build.gradle
+++ b/jetbrains-jediterm/build.gradle
@@ -9,13 +9,15 @@ dependencies {
     // The following libs are required by JediTerm.
     implementation 'org.checkerframework:checker-qual:3.24.0'
 
-    comprise 'org.jetbrains.jediterm:jediterm-core:3.44'        // if you change version here, remember to change it also in mucommander-core
-    comprise 'org.jetbrains.jediterm:jediterm-ui:3.44'          // if you change version here, remember to change it also in mucommander-core
-    comprise 'org.jetbrains.pty4j:pty4j:0.12.35'
+    // JediTerm deps: if you change any version below, remember to change it also in mucommander-core
+    comprise 'org.jetbrains.jediterm:jediterm-core:3.47'
+    comprise 'org.jetbrains.jediterm:jediterm-ui:3.47'
+    comprise 'org.jetbrains.pty4j:pty4j:0.13.2'
     comprise 'org.jetbrains.pty4j:purejavacomm:0.0.11.1'
 
-    implementation 'org.jetbrains:annotations:25.0.0'
+    implementation 'org.jetbrains:annotations:26.0.1'
     runtimeOnly 'org.jetbrains.intellij.deps:trove4j:1.0.20200330'
+    // JediTerm deps end
 
     implementation 'org.apache.logging.log4j:log4j-1.2-api:2.22.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.22.1'

--- a/mucommander-core/build.gradle
+++ b/mucommander-core/build.gradle
@@ -26,10 +26,13 @@ dependencies {
 
     compileOnly 'com.formdev:flatlaf:2.2'
     compileOnly 'org.violetlib:vaqua:10'
-    compileOnly 'org.jetbrains.jediterm:jediterm-core:3.44'
-    compileOnly 'org.jetbrains.jediterm:jediterm-ui:3.44'
-    compileOnly 'org.jetbrains.pty4j:pty4j:0.12.35'
-    compileOnly 'org.jetbrains:annotations:25.0.0'
+
+    // JediTerm deps: if you change any version below, remember to change it also in jetbrains-jediterm
+    compileOnly 'org.jetbrains.jediterm:jediterm-core:3.47'
+    compileOnly 'org.jetbrains.jediterm:jediterm-ui:3.47'
+    compileOnly 'org.jetbrains.pty4j:pty4j:0.13.2'
+    compileOnly 'org.jetbrains:annotations:26.0.1'
+    // JediTerm deps end
 
     implementation 'ch.qos.logback:logback-core:1.2.3'
     implementation 'ch.qos.logback:logback-classic:1.2.3'


### PR DESCRIPTION
JediTerm version bump to 3.47 (to the latest one).

Tested on Sequoia, m3 (arm).