### PR TITLE
Define windows start menu group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -647,7 +647,8 @@ task msi(dependsOn: 'winAppImage', type: Exec) {
                 '--win-shortcut', \
                 '--win-shortcut-prompt', \
                 '--win-dir-chooser', \
-                '--vendor', 'Arik Hadas'
+                '--vendor', 'Arik Hadas', \
+                '--win-menu-group', "muCommander"
 }
 
 configurations.default.canBeResolved=true

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -44,7 +44,7 @@ Localization:
 -
 
 Bug fixes:
--
+- MSI installer: change start menu directory name from `Unknown` to `muCommander`
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
This is a small config change for `jpackage` msi bundle to correctly define the windows start menu directory (change `Unknown` to `muCommander`). This solves #1306

Screenshots after the change:
![image](https://github.com/user-attachments/assets/b06643bd-aa74-492e-8d18-90a5fc9f04e2)

![image](https://github.com/user-attachments/assets/5b9aa787-632e-4971-be48-2f2e4aa5d0d0)
