### PR TITLE
Replace hadoop-core with hadoop-client

### DIFF
--- a/mucommander-protocol-hadoop/build.gradle
+++ b/mucommander-protocol-hadoop/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api project(':mucommander-protocol-api')
     api project(':mucommander-translator')
 
-    implementation 'org.apache.hadoop:hadoop-core:1.0.4'
+    implementation 'org.apache.hadoop:hadoop-client:3.4.1'
     implementation 'commons-logging:commons-logging:1.3.2'
 
     // Use JUnit test framework


### PR DESCRIPTION
'hadoop' is current not loaded snyk finds vulnerabilities in hadoop-core 1.0.4, it's replaced with hadoop-client 3.4.1. this change would need to be tested when we start using the hadoop protocol again.