### PR TITLE
fix identification of 'duti' and add debug log

### DIFF
--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -451,11 +451,12 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
             }
             return false;       // continue searching
         };
+        var findDutiCmd = "command -v duti";
         // first try without '-l' - it is ~10x faster, may not have a proper env settings tho
-        runCommand(new String[]{getMacOsUserShell(), "-c", "type -p -f duti"}, false, 0, linePredicate);
+        runCommand(new String[]{getMacOsUserShell(), "-c", findDutiCmd}, false, 0, linePredicate);
         if (StringUtils.isNullOrEmpty(dutiCmdPath)) {
             // retry the proper way, i.e. with -l - it may take more time to execute, but may have better env settings
-            runCommand(new String[]{getMacOsUserShell(), "-l", "-c", "type -p -f duti"}, false, 0, linePredicate);
+            runCommand(new String[]{getMacOsUserShell(), "-l", "-c", findDutiCmd}, false, 0, linePredicate);
         }
 
         if (!StringUtils.isNullOrEmpty(dutiCmdPath)) {

--- a/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
+++ b/mucommander-os-macos/src/main/java/com/mucommander/desktop/macos/OSXDesktopAdapter.java
@@ -490,6 +490,9 @@ public class OSXDesktopAdapter extends DefaultDesktopAdapter {
             if (!(processExited = proc.waitFor(1000, TimeUnit.MILLISECONDS)) || (exitCode = proc.exitValue()) != expectedExitCode) {
                 LOGGER.error("Unexpected result from running: '{}', timed out?: {}, exit code: {}", commands, !processExited, exitCode);
                 if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Stdout output of running the command: {}",
+                            new BufferedReader(new InputStreamReader(proc.getInputStream())).lines().
+                                    collect(Collectors.joining(System.lineSeparator())));
                     LOGGER.debug("Stderr output of running the command: {}",
                             new BufferedReader(new InputStreamReader(proc.getErrorStream())).lines().
                                     collect(Collectors.joining(System.lineSeparator())));


### PR DESCRIPTION
apparently, 'type' on macOS 15.4 doesn't seem to respect the '-p' flag and returns "duti is /opt/homebrew/bin/duti" for 'type -p -f duti'
    
this leads to the following error: Error executing command: [duti is /opt/homebrew/bin/duti, -h]. Error msg: Cannot run program "duti is /opt/homebrew/bin/duti": error=2, No such file or directory
    
thus, replacing 'type -p -f' with 'command -v'

also add more information in the log that may help investigating #1326 