### PR TITLE
Fix stacktrace while starting muC #1338 and default system arch when buidling DMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Then, you can run a debugger that connects to this port using your favorite IDE 
 ### Packaging
 The creation of a DMG file for macOS (produced in build/distributions):
 ```
-./gradlew clean dmg -PskipDmgSign
+./gradlew clean dmg -PskipDmgSign -Parch=[x86_64|aarch64]
 ```
 
 Note: as the application is not signed, the following error may appear when trying to start it on macOS: "muCommander damaged and cannot be opened".

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ ext {
     revision = git.head().id
     // Whether or not to bundle the JRE in order to create a 'standalone' executable
     bundleJRE = project.hasProperty('mucommanderBundleJRE') ? mucommanderBundleJRE.toBoolean() : false
-    arch = project.hasProperty('arch') ? arch : "x86_64"
+    arch = project.hasProperty('arch') ? arch : System.getProperty('os.arch') // defaults to system architecture
     identity = project.hasProperty('identity') ? identity : ""
 }
 

--- a/mucommander-protocol-s3/build.gradle
+++ b/mucommander-protocol-s3/build.gradle
@@ -12,6 +12,8 @@ dependencies {
 
     implementation ('org.jets3t:jets3t:0.9.7') {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
+        exclude group: 'org.apache.tomcat', module: 'tomcat-servlet-api'
+
     }
     implementation 'commons-logging:commons-logging:1.3.2'
     implementation 'javax.xml:jaxrpc-api:1.1'


### PR DESCRIPTION
1) Fix stacktrace while starting muC #1338 (1st stacktrace). I don't have S3 to check if it works without that dependency.
2) default system arch when buidling DMG - can we have system arch as a default? 

@ahadas please review