### PR TITLE
Checking for 'duti' command now checks well known paths first, and uses -i as last resort #1326

### DIFF
--- a/mucommander-commons-runtime/src/main/java/com/mucommander/commons/runtime/JavaVersion.java
+++ b/mucommander-commons-runtime/src/main/java/com/mucommander/commons/runtime/JavaVersion.java
@@ -99,6 +99,15 @@ public enum JavaVersion implements ComparableRuntimeProperty {
     }
 
     /**
+     * Returns <code>true</code> if the JVM architecture is ARM (aarch64)
+     *
+     * @return <code>true</code> if the JVM architecture is ARM, and <code>false</code> otherwise.
+     */
+    public static boolean isArm64Architecture() {
+        return "aarch64".equals(currentArchitecture);
+    }
+
+    /**
      * Returns the Java version of the current runtime environment.
      *
      * @return the Java version of the current runtime environment

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -40,7 +40,8 @@ New features:
 Improvements:
 - When selecting a different shell, the change takes effect immediately in the terminal.
 - The configuration of custom commands is now stored in YAML format rather than XML.
-- Fixed unnecessary stack-traces in the logs while starting or running the appliaction.
+- Improved reliability of "duti" command execution for "Open With" functionality on macOS.
+- Dropped unnecessary stack-traces in the logs while starting or running the appliaction.
 - Bumped JediTerm and its dependencies to the newest version.
 - Bumped RSyntaxTextArea to the newest version.
 


### PR DESCRIPTION
Checking for 'duti' command now checks well known paths first, and uses -i as last resort #1326