### PR TITLE
Handle illegal NTFS chars

### DIFF
--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/AbstractFile.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/AbstractFile.java
@@ -30,6 +30,9 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.swing.Icon;
 
+import com.mucommander.commons.file.protocol.FileProtocols;
+import com.mucommander.commons.file.util.WindowsFileNameSanitizer;
+import com.mucommander.commons.runtime.OsFamily;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -799,6 +802,11 @@ public abstract class AbstractFile implements FileAttributes {
      */
     public AbstractFile getChild(String relativePath, AbstractFile template) throws IOException {
         FileURL childURL = (FileURL)getURL().clone();
+
+        if (childURL.getScheme().equals(FileProtocols.FILE) && OsFamily.WINDOWS.isCurrent()) {
+            relativePath = WindowsFileNameSanitizer.sanitizeFileName(relativePath);
+        }
+
         childURL.setPath(addTrailingSeparator(childURL.getPath())+ relativePath);
 
         return FileFactory.getFile(childURL, true);

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/util/WindowsFileNameSanitizer.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/util/WindowsFileNameSanitizer.java
@@ -1,0 +1,32 @@
+package com.mucommander.commons.file.util;
+
+import java.util.Set;
+
+public class WindowsFileNameSanitizer {
+
+    private static final Set<Character> ILLEGAL_CHARS = Set.of(
+            '<', '>', ':', '"', '/', '\\', '|', '?', '*', '`'
+    );
+
+    public static String sanitizeFileName(String input) {
+        StringBuilder sanitized = new StringBuilder();
+
+        for (char c : input.toCharArray()) {
+            if (ILLEGAL_CHARS.contains(c)) {
+                sanitized.append(String.format("%%%02X", (int) c));
+            } else {
+                sanitized.append(c);
+            }
+        }
+
+        return sanitized.toString();
+    }
+
+    // Example usage
+    public static void main(String[] args) {
+        String original = "report<final>*version?.txt";
+        String safe = sanitizeFileName(original);
+        System.out.println("Sanitized: " + safe);
+    }
+
+}

--- a/mucommander-commons-file/src/test/java/com/mucommander/commons/file/util/WindowsFileNameSanitizerTest.java
+++ b/mucommander-commons-file/src/test/java/com/mucommander/commons/file/util/WindowsFileNameSanitizerTest.java
@@ -1,0 +1,16 @@
+package com.mucommander.commons.file.util;
+
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+public class WindowsFileNameSanitizerTest {
+
+    @Test
+    public void sanitizeFileName_whenCalledWithIllegalChars_thenSanitizeCorrectly() {
+        String input = "report<final>*version?.txt";
+        String expected = "report%3Cfinal%3E%2Aversion%3F.txt";
+
+        Assert.assertEquals(expected, WindowsFileNameSanitizer.sanitizeFileName(input));
+    }
+
+}


### PR DESCRIPTION
This is a possible solution for #1327.

When copying over files from a remote location into a windows machine, if there is an NTFS illegal char, muC will fail copying it over. In this PR I added logic to replace these chars with ASCII percent encoding.