### PR TITLE
Surround passed arguments in quotes

### DIFF
--- a/package/unix/mucommander.sh
+++ b/package/unix/mucommander.sh
@@ -52,5 +52,5 @@ $JAVA --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED \
       --add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED \
       --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED \
       $EXTRA_OPTIONS \
-      -Djava.library.path=/usr/local/lib -cp mucommander-@MU_VERSION@.jar com.mucommander.main.muCommander $@
+      -Djava.library.path=/usr/local/lib -cp mucommander-@MU_VERSION@.jar com.mucommander.main.muCommander "$@"
 


### PR DESCRIPTION
This ensures that folders with spaces in their paths are still opened properly.