### PR TITLE
Ref #1378: Add support for kar files

### DIFF
--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/ZipFormatProvider.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/ZipFormatProvider.java
@@ -38,7 +38,7 @@ public class ZipFormatProvider implements ArchiveFormatProvider {
 
     /** extensions of archive filenames */
     public static final String[] EXTENSIONS = new String[]
-            {".zip", ".jar", ".war", ".wal", ".wmz", ".xpi", ".ear", ".sar", ".odt", ".ods", ".odp", ".odg", ".odf", ".egg", ".epub", ".cbz"};
+            {".zip", ".jar", ".war", ".wal", ".wmz", ".xpi", ".ear", ".sar", ".odt", ".ods", ".odp", ".odg", ".odf", ".egg", ".epub", ".cbz", ".kar"};
 
 
     @Override

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -46,6 +46,7 @@ Improvements:
 - Bumped RSyntaxTextArea to the newest version.
 - Startup arguments on Linux can now accept paths with spaces.
 - Updated JediTerm version to the newest.
+- Added support for KAR (KAraf aRchive) files.
 
 Localization:
 -


### PR DESCRIPTION
Fixes #1378 

## Motivation

Kar files are just zip files that are not yet supported

## Modification

* Add kar to the list of zip extensions

## Result

It is now possible to go into Kar files 