### PR TITLE
Bump org.apache.logging.log4j:log4j-core from 2.22.1 to 2.25.3

### DIFF
--- a/jetbrains-jediterm/build.gradle
+++ b/jetbrains-jediterm/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     runtimeOnly 'org.jetbrains.intellij.deps:trove4j:1.0.20200330'
     // JediTerm deps end
 
-    implementation 'org.apache.logging.log4j:log4j-1.2-api:2.22.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.22.1'
+    implementation 'org.apache.logging.log4j:log4j-1.2-api:2.25.3'
+    implementation 'org.apache.logging.log4j:log4j-core:2.25.3'
 }
 
 jar {


### PR DESCRIPTION
Bumps org.apache.logging.log4j:log4j-core from 2.22.1 to 2.25.3.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-version: 2.25.3 dependency-type: direct:production ...