### PR TITLE
Use IBM Collator (ICU4J)

### DIFF
--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.apache.commons:commons-collections4:4.5.0'
     implementation 'org.apache.commons:commons-lang3:3.20.0'
 
-    implementation("com.ibm.icu:icu4j:78.2")
+    implementation("com.ibm.icu:icu4j:78.3")
 
     testImplementation 'org.testng:testng:7.11.0'
     testImplementation(platform('org.junit:junit-bom:5.14.1'))

--- a/mucommander-commons-file/build.gradle
+++ b/mucommander-commons-file/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation 'org.apache.commons:commons-collections4:4.5.0'
     implementation 'org.apache.commons:commons-lang3:3.20.0'
 
+    implementation("com.ibm.icu:icu4j:78.2")
+
     testImplementation 'org.testng:testng:7.11.0'
     testImplementation(platform('org.junit:junit-bom:5.14.1'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/mucommander-commons-file/src/main/java/com/mucommander/commons/file/util/FileComparator.java
+++ b/mucommander-commons-file/src/main/java/com/mucommander/commons/file/util/FileComparator.java
@@ -18,16 +18,15 @@
 
 package com.mucommander.commons.file.util;
 
-import java.text.Collator;
+import com.ibm.icu.text.Collator;
+import com.mucommander.commons.file.AbstractFile;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.commons.lang3.StringUtils;
-
-import com.mucommander.commons.file.AbstractFile;
 
 
 /**

--- a/mucommander-commons-file/src/test/java/com/mucommander/commons/file/util/FileComparatorTest.java
+++ b/mucommander-commons-file/src/test/java/com/mucommander/commons/file/util/FileComparatorTest.java
@@ -227,5 +227,17 @@ public class FileComparatorTest {
         Assert.assertEquals(files[1], fileB);
         Assert.assertEquals(files[2], fileC);
     }
+
+    @Test
+    public void testHyphenShouldComeBeforeAnyLetter() throws Exception {
+        TestFile fileA = new TestFile(FileFactory.getTemporaryFolder() + "a", true, 500, 1, null);
+        TestFile fileB = new TestFile(FileFactory.getTemporaryFolder() + "-b", true, 500, 1, null);
+
+        AbstractFile[] files = new AbstractFile[]{fileA, fileB};
+        Arrays.sort(files, new FileComparator(CRITERION.NAME, true, true, AbstractFile::getName, Locale.getDefault(), FileComparator.Mode.NATURAL));
+
+        Assert.assertEquals(files[0], fileB);
+        Assert.assertEquals(files[1], fileA);
+    }
     
 }

--- a/mucommander-commons-io/build.gradle
+++ b/mucommander-commons-io/build.gradle
@@ -1,7 +1,7 @@
 repositories.mavenCentral()
 
 dependencies {
-    comprise 'com.ibm.icu:icu4j:59.2'
+    comprise 'com.ibm.icu:icu4j:78.3'
 
     testImplementation 'org.testng:testng:7.11.0'
 }

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -38,7 +38,7 @@ New features:
 -
 
 Improvements:
--
+- Improved file name sorting to use ICU4J collation for more accurate locale-aware ordering (e.g., hyphens now sort before letters).
 
 Localization:
 - Korean translation updated.


### PR DESCRIPTION
After reading the comment by @Lehi79 in #890, I was doing some investigation and apparently the JVM's default collator ([RuleBasedCollator](https://docs.oracle.com/javase/8/docs/api/java/text/RuleBasedCollator.html)) is handling leading hyphen incorrectly (at least IMO, but I guess the definition of correct is open to interpretation...). It orders `a` and `-b` like so (ignores the leading hyphen):
```
a
-b
```

The [ICU4J implementation](https://unicode-org.github.io/icu/userguide/icu4j/) seems to be more complete and I was able to verify it handles leading hyphens correctly, so for example this is going to be a correct order:
```
-b
a
```

I added a unit test which confirms the behavior and all the rest of the tests are still passing. The ICU4J implementation is also much more configurable so if we want to expose more knobs to the user this will be possible.