### PR TITLE
Granting the application permission to access the module 'sun.awt.X11'

### DIFF
--- a/package/unix/mucommander.sh
+++ b/package/unix/mucommander.sh
@@ -42,6 +42,7 @@ cd `dirname "$BASE_FOLDER"`
 
 # Starts mucommander.
 $JAVA --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED \
+      --add-opens java.desktop/sun.awt.X11=ALL-UNNAMED \
       --add-opens java.base/java.io=ALL-UNNAMED \
       --add-opens java.base/java.net=ALL-UNNAMED \
       --add-opens java.transaction.xa/javax.transaction.xa=ALL-UNNAMED \


### PR DESCRIPTION
To supress the Warning: 'Unexpected error setting WM_CLASS: Unable to make field private static java.lang.String sun.awt.X11.XToolkit.awtAppClassName accessible: module java.desktop does not "opens sun.awt.X11" to unnamed module @35aa28cd'.

This warning occurs because modern Java versions (Java 11 and later) restrict access to internal packages like sun.awt.X11 to improve security. 