### PR TITLE
Fix breadcrumbs visibility issues

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/ui/main/LocationBar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/LocationBar.java
@@ -31,6 +31,8 @@ import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 /**
  * A wrapper panel that sits in place of the location text field in each FolderPanel.
@@ -53,7 +55,8 @@ import java.awt.event.MouseEvent;
  * in both panels. The breadcrumb dynamically follows the mouse - if the user moves the mouse
  * from one panel to another while still holding Ctrl, the breadcrumb switches accordingly.
  * The breadcrumb is immediately hidden when Ctrl is released, or if any other key is pressed
- * or the mouse is clicked before the delay expires.
+ * or the mouse is clicked before the delay expires. It is also hidden if the window loses
+ * focus while Ctrl/Meta is held, since no key-released event is delivered in that case.
  */
 public class LocationBar extends JPanel {
 
@@ -153,6 +156,18 @@ public class LocationBar extends JPanel {
                 }
             }
             return false; // never consume — other Ctrl shortcuts must keep working
+        });
+
+        // If the window loses focus while Ctrl/Meta is held (e.g. Alt-Tab), no
+        // KEY_RELEASED event is ever delivered to this app, so fall back to hiding
+        // the breadcrumb here.
+        folderPanel.getMainFrame().getJFrame().addWindowFocusListener(new WindowAdapter() {
+            @Override
+            public void windowLostFocus(WindowEvent e) {
+                cancelBreadcrumbTimer();
+                modifierHeld = false;
+                cardLayout.show(LocationBar.this, CARD_TEXT_FIELD);
+            }
         });
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/LocationBar.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/LocationBar.java
@@ -17,6 +17,9 @@
 
 package com.mucommander.ui.main;
 
+import com.mucommander.ui.event.LocationEvent;
+import com.mucommander.ui.event.LocationListener;
+
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
@@ -73,6 +76,14 @@ public class LocationBar extends JPanel {
 
     /** Timer that delays showing the breadcrumb to avoid noise from quick keyboard shortcuts */
     private final Timer showBreadcrumbTimer;
+
+    /**
+     * Refreshes the breadcrumb when the location changes while it is shown.
+     * Held as a field because {@link com.mucommander.ui.event.LocationManager} stores
+     * listeners in a {@link java.util.WeakHashMap} - an unreferenced anonymous/lambda
+     * listener would be garbage collected almost immediately.
+     */
+    private final LocationListener breadcrumbLocationListener;
 
     /** Tracks whether Ctrl/Meta is currently being held down */
     private boolean modifierHeld;
@@ -157,6 +168,18 @@ public class LocationBar extends JPanel {
             }
             return false; // never consume — other Ctrl shortcuts must keep working
         });
+
+        // Keep the breadcrumb in sync if the location changes while it is being shown
+        // (e.g. navigating via a quick-list or shortcut while Ctrl/Meta is held).
+        breadcrumbLocationListener = new LocationListener() {
+            @Override
+            public void locationChanged(LocationEvent locationEvent) {
+                if (breadcrumbBar.isShowing()) {
+                    breadcrumbBar.setFile(folderPanel.getCurrentFolder());
+                }
+            }
+        };
+        folderPanel.getLocationManager().addLocationListener(breadcrumbLocationListener);
 
         // If the window loses focus while Ctrl/Meta is held (e.g. Alt-Tab), no
         // KEY_RELEASED event is ever delivered to this app, so fall back to hiding

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -44,7 +44,8 @@ Localization:
 -
 
 Bug fixes:
--
+- Hide the breadcrumbs component when navigating away from application window while holding down the ctrl/cmd key.
+- Dynamically update the path displayed in the breadcrumbs component in case the current path changes while its displayed.
 
 Known issues:
 - Some translations may not be up-to-date.


### PR DESCRIPTION
This PR address #1481:

1. When the window loses focus, the breadcrumbs component is now hidden
2. When the breadcrumbs component is shown and navigation happens, the path changes (added location change listener)