### PR TITLE
zip64 support

### DIFF
--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/CentralDirectoryParsingZipExtraField.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/CentralDirectoryParsingZipExtraField.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.mucommander.commons.file.archive.zip.provider;
+
+import java.util.zip.ZipException;
+
+/**
+ * {@link ZipExtraField ZipExtraField} that knows how to parse central directory data.
+ *
+ * <p>--------------------------------------------------------------------------------------------------------------<br>
+ * <br>
+ * This class is based off the <code>org.apache.tools.zip</code> package of the <i>Apache Ant</i> project. The Ant
+ * code has been modified under the terms of the Apache License which you can find in the bundled muCommander license
+ * file.</p>
+ *
+ * @author Apache Ant, Maxence Bernard
+ */
+public interface CentralDirectoryParsingZipExtraField extends ZipExtraField {
+
+    /**
+     * Populate data from this array as if it was in central directory data.
+     * @param data an array of bytes
+     * @param offset the start offset
+     * @param length the number of bytes in the array from offset
+     *
+     * @throws ZipException on error
+     */
+    void parseFromCentralDirectoryData(byte[] data, int offset, int length)
+        throws ZipException;
+}

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/CentralDirectoryParsingZipExtraField.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/CentralDirectoryParsingZipExtraField.java
@@ -29,7 +29,7 @@ import java.util.zip.ZipException;
  * code has been modified under the terms of the Apache License which you can find in the bundled muCommander license
  * file.</p>
  *
- * @author Apache Ant, Maxence Bernard
+ * @author Apache Ant
  */
 public interface CentralDirectoryParsingZipExtraField extends ZipExtraField {
 

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtraFieldUtils.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ExtraFieldUtils.java
@@ -45,6 +45,7 @@ public class ExtraFieldUtils {
         register(AsiExtraField.class);
         register(JarMarker.class);
         register(ExtendedTimestampExtraField.class);
+        register(Zip64ExtendedInformationExtraField.class);
     }
 
     /**
@@ -88,12 +89,25 @@ public class ExtraFieldUtils {
 
     /**
      * Split the array into ExtraFields and populate them with the
-     * give data.
+     * give data as if they were read from the local file data.
      * @param data an array of bytes
      * @return an array of ExtraFields
      * @throws ZipException on error
      */
     public static ZipExtraField[] parse(byte[] data) throws ZipException {
+        return parse(data, true);
+    }
+
+    /**
+     * Split the array into ExtraFields and populate them with the
+     * given data.
+     * @param data an array of bytes
+     * @param local whether the data originates from the local file data (as opposed to the
+     * central directory data)
+     * @return an array of ExtraFields
+     * @throws ZipException on error
+     */
+    public static ZipExtraField[] parse(byte[] data, boolean local) throws ZipException {
         Vector<ZipExtraField> v = new Vector<>();
         int start = 0;
         while (start <= data.length - 4) {
@@ -105,7 +119,12 @@ public class ExtraFieldUtils {
             }
             try {
                 ZipExtraField ze = createExtraField(headerId);
-                ze.parseFromLocalFileData(data, start + 4, length);
+                if (!local && ze instanceof CentralDirectoryParsingZipExtraField) {
+                    ((CentralDirectoryParsingZipExtraField) ze)
+                        .parseFromCentralDirectoryData(data, start + 4, length);
+                } else {
+                    ze.parseFromLocalFileData(data, start + 4, length);
+                }
                 v.addElement(ze);
             } catch (InstantiationException ie) {
                 throw new ZipException(ie.getMessage());

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/Zip64ExtendedInformationExtraField.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/Zip64ExtendedInformationExtraField.java
@@ -35,7 +35,7 @@ import java.util.zip.ZipException;
  * code has been modified under the terms of the Apache License which you can find in the bundled muCommander license
  * file.</p>
  *
- * @author Apache Ant, Maxence Bernard
+ * @author Apache Ant
  */
 public class Zip64ExtendedInformationExtraField implements CentralDirectoryParsingZipExtraField {
 

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/Zip64ExtendedInformationExtraField.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/Zip64ExtendedInformationExtraField.java
@@ -1,0 +1,316 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.mucommander.commons.file.archive.zip.provider;
+
+import java.util.zip.ZipException;
+
+/**
+ * Holds size and other extended information for entries that use Zip64 features.
+ *
+ * <p>See <a href="https://www.pkware.com/documents/casestudies/APPNOTE.TXT">PKWARE's
+ * APPNOTE.TXT, section 4.5.3</a>.</p>
+ *
+ * <p>The implementation relies on data being read from the local file header and assumes that
+ * both size values are always present.</p>
+ *
+ * <p>--------------------------------------------------------------------------------------------------------------<br>
+ * <br>
+ * This class is based off the <code>org.apache.tools.zip</code> package of the <i>Apache Ant</i> project. The Ant
+ * code has been modified under the terms of the Apache License which you can find in the bundled muCommander license
+ * file.</p>
+ *
+ * @author Apache Ant, Maxence Bernard
+ */
+public class Zip64ExtendedInformationExtraField implements CentralDirectoryParsingZipExtraField {
+
+    /** Size in bytes of a four byte (32 bit) field */
+    private static final int WORD = 4;
+
+    /** Size in bytes of an eight byte (64 bit) field */
+    private static final int DWORD = 8;
+
+    static final ZipShort HEADER_ID = new ZipShort(0x0001);
+
+    private static final String LFH_MUST_HAVE_BOTH_SIZES_MSG =
+        "Zip64 extended information must contain"
+        + " both size values in the local file header.";
+    private static final byte[] EMPTY = new byte[0];
+
+    private ZipEightByteInteger size, compressedSize, relativeHeaderOffset;
+    private ZipLong diskStart;
+
+    /**
+     * Stored in {@link #parseFromCentralDirectoryData parseFromCentralDirectoryData} so it can be
+     * reused when {@link #reparseCentralDirectoryData reparseCentralDirectoryData} is called.
+     *
+     * <p>Not used for anything else</p>
+     */
+    private byte[] rawCentralDirectoryData;
+
+    /**
+     * This constructor should only be used by the code that reads archives.
+     */
+    public Zip64ExtendedInformationExtraField() {
+    }
+
+    /**
+     * Creates an extra field based on the original and compressed size.
+     *
+     * @param size the entry's original size
+     * @param compressedSize the entry's compressed size
+     * @throws IllegalArgumentException if size or compressedSize is null
+     */
+    public Zip64ExtendedInformationExtraField(ZipEightByteInteger size, ZipEightByteInteger compressedSize) {
+        this(size, compressedSize, null, null);
+    }
+
+    /**
+     * Creates an extra field based on all four possible values.
+     *
+     * @param size the entry's original size
+     * @param compressedSize the entry's compressed size
+     * @param relativeHeaderOffset the entry's offset
+     * @param diskStart the disk on which the entry starts
+     * @throws IllegalArgumentException if size or compressedSize is null
+     */
+    public Zip64ExtendedInformationExtraField(ZipEightByteInteger size, ZipEightByteInteger compressedSize,
+            ZipEightByteInteger relativeHeaderOffset, ZipLong diskStart) {
+        this.size = size;
+        this.compressedSize = compressedSize;
+        this.relativeHeaderOffset = relativeHeaderOffset;
+        this.diskStart = diskStart;
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return HEADER_ID;
+    }
+
+    @Override
+    public ZipShort getLocalFileDataLength() {
+        return new ZipShort(size != null ? 2 * DWORD : 0);
+    }
+
+    @Override
+    public ZipShort getCentralDirectoryLength() {
+        return new ZipShort((size != null ? DWORD : 0)
+                + (compressedSize != null ? DWORD : 0)
+                + (relativeHeaderOffset != null ? DWORD : 0)
+                + (diskStart != null ? WORD : 0));
+    }
+
+    @Override
+    public byte[] getLocalFileDataData() {
+        if (size != null || compressedSize != null) {
+            if (size == null || compressedSize == null) {
+                throw new IllegalArgumentException(LFH_MUST_HAVE_BOTH_SIZES_MSG);
+            }
+            byte[] data = new byte[2 * DWORD];
+            addSizes(data);
+            return data;
+        }
+        return EMPTY;
+    }
+
+    @Override
+    public byte[] getCentralDirectoryData() {
+        byte[] data = new byte[getCentralDirectoryLength().getValue()];
+        int off = addSizes(data);
+        if (relativeHeaderOffset != null) {
+            System.arraycopy(relativeHeaderOffset.getBytes(), 0, data, off, DWORD);
+            off += DWORD;
+        }
+        if (diskStart != null) {
+            System.arraycopy(diskStart.getBytes(), 0, data, off, WORD);
+            off += WORD;
+        }
+        return data;
+    }
+
+    @Override
+    public void parseFromLocalFileData(byte[] buffer, int offset, int length) throws ZipException {
+        if (length == 0) {
+            // no local file data at all, may happen if an archive only holds a Zip64 extended
+            // information extra field inside the central directory but not inside the local file header
+            return;
+        }
+        if (length < 2 * DWORD) {
+            throw new ZipException(LFH_MUST_HAVE_BOTH_SIZES_MSG);
+        }
+        size = new ZipEightByteInteger(buffer, offset);
+        offset += DWORD;
+        compressedSize = new ZipEightByteInteger(buffer, offset);
+        offset += DWORD;
+        int remaining = length - 2 * DWORD;
+        if (remaining >= DWORD) {
+            relativeHeaderOffset = new ZipEightByteInteger(buffer, offset);
+            offset += DWORD;
+            remaining -= DWORD;
+        }
+        if (remaining >= WORD) {
+            diskStart = new ZipLong(buffer, offset);
+        }
+    }
+
+    @Override
+    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) throws ZipException {
+        // store for processing in reparseCentralDirectoryData
+        rawCentralDirectoryData = new byte[length];
+        System.arraycopy(buffer, offset, rawCentralDirectoryData, 0, length);
+
+        // if there is no size information in here, we can only hope things will get resolved
+        // by local file header data later. But there are some cases that can be detected:
+        // * all data is there
+        // * length == 24 -> both sizes and offset
+        // * length % 8 == 4 -> at least we can identify the diskStart field
+        if (length >= 3 * DWORD + WORD) {
+            parseFromLocalFileData(buffer, offset, length);
+        } else if (length == 3 * DWORD) {
+            size = new ZipEightByteInteger(buffer, offset);
+            offset += DWORD;
+            compressedSize = new ZipEightByteInteger(buffer, offset);
+            offset += DWORD;
+            relativeHeaderOffset = new ZipEightByteInteger(buffer, offset);
+        } else if (length % DWORD == WORD) {
+            diskStart = new ZipLong(buffer, offset + length - WORD);
+        }
+    }
+
+    /**
+     * Parses the raw bytes read from the central directory extra field with knowledge which fields
+     * are expected to be there.
+     *
+     * <p>All four fields inside the Zip64 extended information extra field are optional and must
+     * only be present if their corresponding entry inside the central directory contains the
+     * correct magic value.</p>
+     *
+     * @param hasUncompressedSize whether the central directory's uncompressed size field is set to 0xFFFFFFFF
+     * @param hasCompressedSize whether the central directory's compressed size field is set to 0xFFFFFFFF
+     * @param hasRelativeHeaderOffset whether the central directory's relative header offset field is set to 0xFFFFFFFF
+     * @param hasDiskStart whether the central directory's disk start field is set to 0xFFFF
+     * @throws ZipException if the expected length of the central directory data is incorrect
+     */
+    public void reparseCentralDirectoryData(boolean hasUncompressedSize, boolean hasCompressedSize,
+            boolean hasRelativeHeaderOffset, boolean hasDiskStart) throws ZipException {
+        if (rawCentralDirectoryData != null) {
+            int expectedLength = (hasUncompressedSize ? DWORD : 0)
+                    + (hasCompressedSize ? DWORD : 0)
+                    + (hasRelativeHeaderOffset ? DWORD : 0)
+                    + (hasDiskStart ? WORD : 0);
+            if (rawCentralDirectoryData.length < expectedLength) {
+                throw new ZipException("central directory zip64 extended information extra field's length"
+                        + " doesn't match central directory data.  Expected length "
+                        + expectedLength + " but is " + rawCentralDirectoryData.length);
+            }
+            int offset = 0;
+            if (hasUncompressedSize) {
+                size = new ZipEightByteInteger(rawCentralDirectoryData, offset);
+                offset += DWORD;
+            }
+            if (hasCompressedSize) {
+                compressedSize = new ZipEightByteInteger(rawCentralDirectoryData, offset);
+                offset += DWORD;
+            }
+            if (hasRelativeHeaderOffset) {
+                relativeHeaderOffset = new ZipEightByteInteger(rawCentralDirectoryData, offset);
+                offset += DWORD;
+            }
+            if (hasDiskStart) {
+                diskStart = new ZipLong(rawCentralDirectoryData, offset);
+            }
+        }
+    }
+
+    /**
+     * The uncompressed size stored in this extra field.
+     * @return the uncompressed size
+     */
+    public ZipEightByteInteger getSize() {
+        return size;
+    }
+
+    /**
+     * Sets the uncompressed size stored in this extra field.
+     * @param size the uncompressed size
+     */
+    public void setSize(ZipEightByteInteger size) {
+        this.size = size;
+    }
+
+    /**
+     * The compressed size stored in this extra field.
+     * @return the compressed size
+     */
+    public ZipEightByteInteger getCompressedSize() {
+        return compressedSize;
+    }
+
+    /**
+     * Sets the compressed size stored in this extra field.
+     * @param compressedSize the compressed size
+     */
+    public void setCompressedSize(ZipEightByteInteger compressedSize) {
+        this.compressedSize = compressedSize;
+    }
+
+    /**
+     * The relative header offset stored in this extra field.
+     * @return the relative header offset
+     */
+    public ZipEightByteInteger getRelativeHeaderOffset() {
+        return relativeHeaderOffset;
+    }
+
+    /**
+     * Sets the relative header offset stored in this extra field.
+     * @param relativeHeaderOffset the relative header offset
+     */
+    public void setRelativeHeaderOffset(ZipEightByteInteger relativeHeaderOffset) {
+        this.relativeHeaderOffset = relativeHeaderOffset;
+    }
+
+    /**
+     * The disk start number stored in this extra field.
+     * @return the disk start number
+     */
+    public ZipLong getDiskStartNumber() {
+        return diskStart;
+    }
+
+    /**
+     * Sets the disk start number stored in this extra field.
+     * @param diskStart the disk start number
+     */
+    public void setDiskStartNumber(ZipLong diskStart) {
+        this.diskStart = diskStart;
+    }
+
+    private int addSizes(byte[] data) {
+        int off = 0;
+        if (size != null) {
+            System.arraycopy(size.getBytes(), 0, data, 0, DWORD);
+            off += DWORD;
+        }
+        if (compressedSize != null) {
+            System.arraycopy(compressedSize.getBytes(), 0, data, off, DWORD);
+            off += DWORD;
+        }
+        return off;
+    }
+}

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipConstants.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipConstants.java
@@ -54,6 +54,23 @@ public interface ZipConstants {
     public static final long MAX_ZIP32_SIZE = 4294967295l;
 
     /**
+     * Maximum number of entries (or central directory size/offset) representable in a Zip32 file, i.e. (2^16)-1.
+     */
+    public static final int MAX_ZIP32_ENTRIES = 0xFFFF;
+
+    /**
+     * Value stored in 4-byte size/offset fields to indicate that the real value is stored in a
+     * Zip64 extended information extra field.
+     */
+    public static final long ZIP64_MAGIC = 0xFFFFFFFFL;
+
+    /**
+     * Value stored in 2-byte count fields to indicate that the real value is stored in the
+     * Zip64 end of central directory record.
+     */
+    public static final int ZIP64_MAGIC_SHORT = 0xFFFF;
+
+    /**
      * Size of write buffers
      */
     final static int WRITE_BUFFER_SIZE = 65536;
@@ -82,4 +99,14 @@ public interface ZipConstants {
      * End of central dir signature
      */
     static final byte[] EOCD_SIG = ZipLong.getBytes(0X06054B50L);
+
+    /**
+     * Zip64 end of central directory record signature
+     */
+    static final byte[] ZIP64_EOCD_SIG = ZipLong.getBytes(0X06064B50L);
+
+    /**
+     * Zip64 end of central directory locator signature
+     */
+    static final byte[] ZIP64_EOCD_LOC_SIG = ZipLong.getBytes(0X07064B50L);
 }

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEightByteInteger.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEightByteInteger.java
@@ -1,0 +1,156 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.mucommander.commons.file.archive.zip.provider;
+
+/**
+ * Utility class that represents an eight byte integer with conversion
+ * rules for the big endian byte order of ZIP files.
+ *
+ * <p>--------------------------------------------------------------------------------------------------------------<br>
+ * <br>
+ * This class is based off the <code>org.apache.tools.zip</code> package of the <i>Apache Ant</i> project. The Ant
+ * code has been modified under the terms of the Apache License which you can find in the bundled muCommander license
+ * file.</p>
+ *
+ * @author Apache Ant, Maxence Bernard
+ */
+public final class ZipEightByteInteger implements Cloneable {
+
+    /** A {@code ZipEightByteInteger} instance representing the value 0 */
+    public static final ZipEightByteInteger ZERO = new ZipEightByteInteger(0);
+
+    private long value;
+
+    /**
+     * Create instance from a number.
+     * @param value the long to store as a ZipEightByteInteger
+     */
+    public ZipEightByteInteger(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Create instance from bytes.
+     * @param bytes the bytes to store as a ZipEightByteInteger
+     */
+    public ZipEightByteInteger(byte[] bytes) {
+        this(bytes, 0);
+    }
+
+    /**
+     * Create instance from the eight bytes starting at offset.
+     * @param bytes the bytes to store as a ZipEightByteInteger
+     * @param offset the offset to start
+     */
+    public ZipEightByteInteger(byte[] bytes, int offset) {
+        value = ZipEightByteInteger.getLongValue(bytes, offset);
+    }
+
+    /**
+     * Get value as eight bytes in big endian byte order.
+     * @return value as eight bytes in big endian order
+     */
+    public byte[] getBytes() {
+        return ZipEightByteInteger.getBytes(value);
+    }
+
+    /**
+     * Get value as Java long.
+     * @return value as a long
+     */
+    public long getLongValue() {
+        return value;
+    }
+
+    /**
+     * Converts the given long value as eight bytes in big endian byte order.
+     * @param value the long value to convert
+     * @return the converted value as a byte array in big endian byte order
+     */
+    public static byte[] getBytes(long value) {
+        return getBytes(value, new byte[8], 0);
+    }
+
+    /**
+     * Converts the given long value as eight bytes in big endian byte order. The specified byte array is used to
+     * store the result, starting at the given offset. The returned byte array is the same as the given one.
+     * @param value the long value to convert
+     * @param result the byte array in which to store the value in big endian byte order
+     * @param off offset at which to start writing the result in the array
+     * @return the converted value as a byte array in big endian byte order
+     */
+    public static byte[] getBytes(long value, byte[] result, int off) {
+        result[off]   = (byte) ((value & 0xFFL));
+        result[off+1] = (byte) ((value & 0xFF00L) >> 8);
+        result[off+2] = (byte) ((value & 0xFF0000L) >> 16);
+        result[off+3] = (byte) ((value & 0xFF000000L) >> 24);
+        result[off+4] = (byte) ((value & 0xFF00000000L) >> 32);
+        result[off+5] = (byte) ((value & 0xFF0000000000L) >> 40);
+        result[off+6] = (byte) ((value & 0xFF000000000000L) >> 48);
+        result[off+7] = (byte) ((value & 0xFF00000000000000L) >> 56);
+        return result;
+    }
+
+    /**
+     * Helper method to get the value as a Java long from eight bytes starting at given array offset
+     * @param bytes the array of bytes
+     * @param offset the offset to start
+     * @return the corresponding Java long value
+     */
+    public static long getLongValue(byte[] bytes, int offset) {
+        long value = (bytes[offset+7] << 56) & 0xFF00000000000000L;
+        value += ((long)bytes[offset+6] << 48) & 0xFF000000000000L;
+        value += ((long)bytes[offset+5] << 40) & 0xFF0000000000L;
+        value += ((long)bytes[offset+4] << 32) & 0xFF00000000L;
+        value += ((long)bytes[offset+3] << 24) & 0xFF000000L;
+        value += ((long)bytes[offset+2] << 16) & 0xFF0000L;
+        value += ((long)bytes[offset+1] << 8) & 0xFF00L;
+        value += ((long)bytes[offset] & 0xFFL);
+        return value;
+    }
+
+    /**
+     * Helper method to get the value as a Java long from an eight-byte array
+     * @param bytes the array of bytes
+     * @return the corresponding Java long value
+     */
+    public static long getLongValue(byte[] bytes) {
+        return getLongValue(bytes, 0);
+    }
+
+    /**
+     * Override to make two instances with same value equal.
+     * @param o an object to compare
+     * @return true if the objects are equal
+     */
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof ZipEightByteInteger)) {
+            return false;
+        }
+        return value == ((ZipEightByteInteger) o).getLongValue();
+    }
+
+    /**
+     * Override to make two instances with same value equal.
+     * @return the value stored in the ZipEightByteInteger
+     */
+    public int hashCode() {
+        return (int) (value ^ (value >>> 32));
+    }
+}

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEightByteInteger.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEightByteInteger.java
@@ -28,7 +28,7 @@ package com.mucommander.commons.file.archive.zip.provider;
  * code has been modified under the terms of the Apache License which you can find in the bundled muCommander license
  * file.</p>
  *
- * @author Apache Ant, Maxence Bernard
+ * @author Apache Ant
  */
 public final class ZipEightByteInteger implements Cloneable {
 

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipEntry.java
@@ -292,6 +292,25 @@ public class ZipEntry implements Cloneable {
     }
 
     /**
+     * Returns the extra field corresponding to the given type, or <code>null</code> if there is none.
+     *
+     * @param type the type of extra field to look up
+     * @return the extra field corresponding to the given type, or <code>null</code> if there is none
+     */
+    public ZipExtraField getExtraField(ZipShort type) {
+        if (extraFields == null)
+            return null;
+
+        for (int i=0, nbFields=extraFields.size(); i<nbFields; i++) {
+            ZipExtraField field = extraFields.elementAt(i);
+            if (field.getHeaderId().equals(type))
+                return field;
+        }
+
+        return null;
+    }
+
+    /**
      * Removes the first extra field corresponding to the given type.
      *
      * @param type the type of extra field to remove
@@ -391,10 +410,10 @@ public class ZipEntry implements Cloneable {
      * Sets the uncompressed size of the entry data.
      *
      * @param size the uncompressed size in bytes
-     * @throws IllegalArgumentException if the specified size is less than 0 or greater than 0xFFFFFFFF bytes
+     * @throws IllegalArgumentException if the specified size is negative
      */
     public void setSize(long size) {
-        if(!isValidUnsignedInt(size))
+        if(size < 0)
 	        throw new IllegalArgumentException("Invalid entry size");
 
 	    this.size = size;
@@ -414,9 +433,10 @@ public class ZipEntry implements Cloneable {
      * Sets the size of the compressed entry data.
      *
      * @param csize the compressed size to set to
+     * @throws IllegalArgumentException if the specified size is negative
      */
     public void setCompressedSize(long csize) {
-        if(!isValidUnsignedInt(csize))
+        if(csize < 0)
 	        throw new IllegalArgumentException("Invalid entry size");
 
         this.compressedSize = csize;
@@ -552,6 +572,27 @@ public class ZipEntry implements Cloneable {
         else {
             try {
                 setExtraFields(ExtraFieldUtils.parse(extra));
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Parses the given bytes as central directory extra fields and replaces all current extra fields with the
+     * parsed ones.
+     *
+     * @param extra an array of bytes to be parsed into extra fields, as found in the central directory
+     * @throws IllegalArgumentException if the byte array cannot be parsed into extra fields
+     */
+    public void setCentralDirectoryExtra(byte[] extra) throws IllegalArgumentException {
+        if(extra==null || extra.length==0) {
+            extraFields = null;
+        }
+        else {
+            try {
+                setExtraFields(ExtraFieldUtils.parse(extra, false));
             }
             catch (Exception e) {
                 throw new IllegalArgumentException(e.getMessage());

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipFile.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipFile.java
@@ -473,7 +473,7 @@ public class ZipFile implements ZipConstants {
                 @Override
                 public void close() throws IOException {
                     // Write data info in the local file header
-                    ZipOutputStream.finalizeEntryData(entry, this, raos, false, zipBuffer);
+                    ZipOutputStream.finalizeEntryData(entry, this, raos, false, entryInfo.encoding, zipBuffer);
 
                     // Write the central directory that was squashed by the new entry (at least partially)
                     ZipEntry tempZe;
@@ -835,7 +835,7 @@ public class ZipFile implements ZipConstants {
             int commentLen = ZipShort.getValue(cfh, 28);
             // off += 2;
 
-            // skip disk number
+            int diskStart = ZipShort.getValue(cfh, 30);
             // off += 2;
 
             ze.setInternalAttributes(ZipShort.getValue(cfh, 32));
@@ -866,7 +866,11 @@ public class ZipFile implements ZipConstants {
             // Read and set extra bytes
             byte extra[] = new byte[extraLen];
             rais.readFully(extra);
-            ze.setExtra(extra);
+            ze.setCentralDirectoryExtra(extra);
+
+            // Resolve the real values of any fields that contain a Zip64 magic placeholder value,
+            // using the Zip64 extended information extra field (if any).
+            resolveZip64Values(ze, entryInfo, diskStart);
 
             // Read comment bytes
             byte[] comment = new byte[commentLen];
@@ -922,6 +926,44 @@ public class ZipFile implements ZipConstants {
                 entryInfo.comment = null;
             }
         }
+    }
+
+    /**
+     * Resolves the real values of any of the given entry's central directory fields that contain a Zip64 magic
+     * placeholder value (size, compressed size, local header offset and disk start number), using the values
+     * stored in the entry's Zip64 extended information extra field, if any.
+     *
+     * @param ze the entry being parsed
+     * @param entryInfo the entry's {@link ZipEntryInfo}, whose {@link ZipEntryInfo#headerOffset} is updated if it
+     * contains a Zip64 magic placeholder value
+     * @param diskStart the disk number start field, as read from the central file header
+     * @throws ZipException if the Zip64 extended information extra field is present but doesn't hold the
+     * expected fields
+     */
+    private void resolveZip64Values(ZipEntry ze, ZipEntryInfo entryInfo, int diskStart) throws ZipException {
+        boolean hasZip64Size = ze.getCompressedSize() == ZIP64_MAGIC;
+        boolean hasZip64UncompressedSize = ze.getSize() == ZIP64_MAGIC;
+        boolean hasZip64Offset = entryInfo.headerOffset == ZIP64_MAGIC;
+        boolean hasZip64DiskStart = diskStart == ZIP64_MAGIC_SHORT;
+
+        if (!hasZip64Size && !hasZip64UncompressedSize && !hasZip64Offset && !hasZip64DiskStart)
+            return;
+
+        Zip64ExtendedInformationExtraField z64 = (Zip64ExtendedInformationExtraField)
+            ze.getExtraField(Zip64ExtendedInformationExtraField.HEADER_ID);
+        if (z64 == null)
+            return;
+
+        z64.reparseCentralDirectoryData(hasZip64UncompressedSize, hasZip64Size, hasZip64Offset, hasZip64DiskStart);
+
+        if (hasZip64UncompressedSize)
+            ze.setSize(z64.getSize().getLongValue());
+
+        if (hasZip64Size)
+            ze.setCompressedSize(z64.getCompressedSize().getLongValue());
+
+        if (hasZip64Offset)
+            entryInfo.headerOffset = z64.getRelativeHeaderOffset().getLongValue();
     }
 
     /**
@@ -1003,6 +1045,46 @@ public class ZipFile implements ZipConstants {
         /* size of the central directory   */ + 4;
 
     /**
+     * Length of the "Zip64 end of central directory locator" - which should be located right
+     * in front of the "End of central directory record" if one is present at all.
+     */
+    private static final int ZIP64_EOCDL_LENGTH =
+        /* zip64 end of central dir locator sig */ 4
+        /* number of the disk with the start    */
+        /* of the zip64 end of central dir      */ + 4
+        /* relative offset of the zip64 end of  */
+        /* central directory record             */ + 8
+        /* total number of disks                */ + 4;
+
+    /**
+     * Offset of the field that holds the location of the "Zip64 end of central directory record"
+     * inside the "Zip64 end of central directory locator", relative to the start of the locator.
+     */
+    private static final int ZIP64_EOCDL_LOCATOR_OFFSET =
+        /* zip64 end of central dir locator sig */ 4
+        /* number of the disk with the start    */
+        /* of the zip64 end of central dir      */ + 4;
+
+    /**
+     * Offset of the field that holds the location of the first central directory entry inside
+     * the "Zip64 end of central directory record", relative to the start of that record.
+     */
+    private static final int ZIP64_EOCD_CFD_LOCATOR_OFFSET =
+        /* zip64 end of central dir signature */ 4
+        /* size of zip64 end of central       */
+        /* directory record                   */ + 8
+        /* version made by                    */ + 2
+        /* version needed to extract          */ + 2
+        /* number of this disk                */ + 4
+        /* number of the disk with the        */
+        /* start of the central directory     */ + 4
+        /* total number of entries in the     */
+        /* central directory on this disk     */ + 8
+        /* total number of entries in the     */
+        /* central directory                  */ + 8
+        /* size of the central directory      */ + 8;
+
+    /**
      * Searches for the end of central dir record, parses
      * it and positions the stream at the first central directory
      * record.
@@ -1049,32 +1131,80 @@ public class ZipFile implements ZipConstants {
                 throw new ZipException("Invalid Zip stream (EOCD signature not found)");
             }
 
+            // Absolute offset of the EOCD record within the file
+            long eocdOffset = (length - bufLen) + off;
+
             // Parse the offset to the central directory start
-            off += CFD_LOCATOR_OFFSET;
+            int cdLocatorOff = off + CFD_LOCATOR_OFFSET;
             byte[] cdStart = new byte[4];
-            System.arraycopy(buf, off, cdStart, 0, 4);
-            off += 4;
+            System.arraycopy(buf, cdLocatorOff, cdStart, 0, 4);
 
             // Fetch the global zip file comment
+            int commentLenOff = cdLocatorOff + 4 + 2;
             byte[] commentLen = new byte[2];
-            System.arraycopy(buf, off, commentLen, 0, 2);
-            off += 2;
+            System.arraycopy(buf, commentLenOff - 2, commentLen, 0, 2);
 
             // Fetch the global zip file comment
             byte commentBytes[] = new byte[ZipShort.getValue(commentLen)];
-            System.arraycopy(buf, off, commentBytes, 0, commentBytes.length);
+            System.arraycopy(buf, commentLenOff, commentBytes, 0, commentBytes.length);
 
             // If no default encoding has been specified, try to guess the comment's encoding.
             // Note that the Zip format doesn't provide any way of knowing the encoding, not even a bit to indicate UTF-8
             // like bit 11 in GPBF.
             comment = getString(commentBytes, defaultEncoding!=null?defaultEncoding:EncodingDetector.detectEncoding(commentBytes));
 
-            // Seek to the start of the central directory
+            // Check whether a Zip64 end of central directory locator immediately precedes the
+            // end of central directory record.
+            if (eocdOffset >= ZIP64_EOCDL_LENGTH) {
+                rais.seek(eocdOffset - ZIP64_EOCDL_LENGTH);
+                byte[] zip64Locator = new byte[ZIP64_EOCDL_LENGTH];
+                rais.readFully(zip64Locator);
+
+                if (matchesSignature(zip64Locator, 0, ZIP64_EOCD_LOC_SIG)) {
+                    // Offset of the Zip64 end of central directory record
+                    long zip64EocdOffset = ZipEightByteInteger.getLongValue(zip64Locator, ZIP64_EOCDL_LOCATOR_OFFSET);
+
+                    rais.seek(zip64EocdOffset);
+                    byte[] zip64EocdSig = new byte[4];
+                    rais.readFully(zip64EocdSig);
+                    if (!matchesSignature(zip64EocdSig, 0, ZIP64_EOCD_SIG)) {
+                        throw new ZipException("Archive's Zip64 end of central directory locator is corrupt");
+                    }
+
+                    rais.seek(zip64EocdOffset + ZIP64_EOCD_CFD_LOCATOR_OFFSET);
+                    byte[] cdOffset64 = new byte[8];
+                    rais.readFully(cdOffset64);
+
+                    // Seek to the start of the central directory
+                    rais.seek(ZipEightByteInteger.getLongValue(cdOffset64));
+                    return;
+                }
+            }
+
+            // Not a Zip64 archive: seek to the start of the central directory using the regular
+            // (32-bit) end of central directory record
             rais.seek(ZipLong.getValue(cdStart));
         }
         finally {
             BufferPool.releaseByteArray(buf);
         }
+    }
+
+    /**
+     * Returns <code>true</code> if the given byte array contains the specified signature at the given offset.
+     *
+     * @param data the byte array to look into
+     * @param offset the offset at which the signature is expected
+     * @param signature the signature to compare against
+     * @return <code>true</code> if the given byte array contains the specified signature at the given offset
+     */
+    private static boolean matchesSignature(byte[] data, int offset, byte[] signature) {
+        for (int i=0; i<signature.length; i++) {
+            if (data[offset+i] != signature[i])
+                return false;
+        }
+
+        return true;
     }
 
     /**

--- a/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipOutputStream.java
+++ b/mucommander-format-zip/src/main/java/com/mucommander/commons/file/archive/zip/provider/ZipOutputStream.java
@@ -97,11 +97,20 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
     /** 20 as ZipShort */
     private static final byte[] SHORT_20 = ZipShort.getBytes(20);
 
+    /** 45 as ZipShort, the version needed to extract a Zip64 entry */
+    private static final byte[] SHORT_45 = ZipShort.getBytes(45);
+
     /** 2048 as ZipShort */
     private static final byte[] SHORT_2048 = ZipShort.getBytes(2048);
 
     /** 2056 as ZipShort */
     private static final byte[] SHORT_2056 = ZipShort.getBytes(2056);
+
+    /** {@link ZipConstants#ZIP64_MAGIC_SHORT} as ZipShort */
+    private static final byte[] SHORT_MAX = ZipShort.getBytes(ZIP64_MAGIC_SHORT);
+
+    /** {@link ZipConstants#ZIP64_MAGIC} as ZipLong */
+    private static final byte[] LONG_MAX = ZipLong.getBytes(ZIP64_MAGIC);
 
 
     /**
@@ -203,7 +212,7 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
         if (entry == null)
             return;
 
-        finalizeEntryData(entry, zeos, out, !hasRandomAccess, zipBuffer);
+        finalizeEntryData(entry, zeos, out, !hasRandomAccess, encoding, zipBuffer);
         written += entry.getCompressedSize();
 
         if(!hasRandomAccess)
@@ -228,10 +237,11 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
      * @param out the
      * @param useDataDescriptor if true, a data descriptor will be written to out. If false, size and CRC information
      * will be written in the local file header (requires out to be a RandomAccessOutputStream).
+     * @param encoding the encoding used for writing the entry's filename in the local file header
      * @param zipBuffer a ZipBuffer instance used to convert integer values to Zip variants
      * @throws IOException if an I/O error occurred
      */
-    protected static void finalizeEntryData(ZipEntry entry, ZipEntryOutputStream zeos, OutputStream out, boolean useDataDescriptor, ZipBuffer zipBuffer) throws IOException {
+    protected static void finalizeEntryData(ZipEntry entry, ZipEntryOutputStream zeos, OutputStream out, boolean useDataDescriptor, String encoding, ZipBuffer zipBuffer) throws IOException {
         long crc = zeos.getCrc();
 
         if (entry.getMethod() == DEFLATED) {
@@ -257,12 +267,52 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
 
             long save = raos.getOffset();
 
+            boolean isZip64 = entry.getCompressedSize() >= MAX_ZIP32_SIZE || entry.getSize() >= MAX_ZIP32_SIZE;
+
             raos.seek(entry.getEntryInfo().headerOffset + 14);
             raos.write(ZipLong.getBytes(entry.getCrc(), zipBuffer.longBuffer));
-            raos.write(ZipLong.getBytes(entry.getCompressedSize(), zipBuffer.longBuffer));
-            raos.write(ZipLong.getBytes(entry.getSize(), zipBuffer.longBuffer));
+            if (isZip64) {
+                raos.write(LONG_MAX);
+                raos.write(LONG_MAX);
+            }
+            else {
+                raos.write(ZipLong.getBytes(entry.getCompressedSize(), zipBuffer.longBuffer));
+                raos.write(ZipLong.getBytes(entry.getSize(), zipBuffer.longBuffer));
+            }
+
+            // writeLocalFileHeader always reserves a Zip64 extended information extra field for entries
+            // written with random access, so that the actual sizes can be patched in here, even if they
+            // turn out to exceed 4GB.
+            long zip64ExtraOffset = getZip64LocalExtraDataOffset(entry);
+            if (zip64ExtraOffset >= 0) {
+                byte[] name = getBytes(entry.getName(), encoding);
+                raos.seek(entry.getEntryInfo().headerOffset + 30 + name.length + zip64ExtraOffset);
+                raos.write(ZipEightByteInteger.getBytes(entry.getSize()));
+                raos.write(ZipEightByteInteger.getBytes(entry.getCompressedSize()));
+            }
+
             raos.seek(save);
         }
+    }
+
+    /**
+     * Returns the offset, within this entry's local file data extra fields, of the data of its
+     * {@link Zip64ExtendedInformationExtraField}, or <code>-1</code> if the entry has no such extra field.
+     *
+     * @param entry the entry to look up
+     * @return the offset of the Zip64 extended information extra field's data within the entry's local file
+     * data extra fields, or <code>-1</code> if the entry has no such extra field
+     */
+    private static long getZip64LocalExtraDataOffset(ZipEntry entry) {
+        long offset = 0;
+        for (ZipExtraField field : entry.getExtraFields()) {
+            if (field.getHeaderId().equals(Zip64ExtendedInformationExtraField.HEADER_ID))
+                return offset + 4;
+
+            offset += 4 + field.getLocalFileDataLength().getValue();
+        }
+
+        return -1;
     }
 
     /**
@@ -363,9 +413,23 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
 
         int zipMethod = ze.getMethod();
 
+        // For entries written with random access, reserve a Zip64 extended information extra field upfront so
+        // that the actual sizes can be patched in by #finalizeEntryData once known, even if they turn out to
+        // exceed 4GB. This isn't possible for entries written with a data descriptor, as the local file header
+        // has already been flushed by the time the sizes are known.
+        boolean reserveZip64 = !useDataDescriptor;
+        if (reserveZip64) {
+            long size = ze.getSize() >= 0 ? ze.getSize() : 0;
+            long compressedSize = ze.getCompressedSize() >= 0 ? ze.getCompressedSize() : 0;
+            ze.addExtraField(new Zip64ExtendedInformationExtraField(new ZipEightByteInteger(size), new ZipEightByteInteger(compressedSize)));
+        }
+        else {
+            ze.removeExtraField(Zip64ExtendedInformationExtraField.HEADER_ID);
+        }
+
         // version needed to extract
         // general purpose bit flag
-        writeVersionAndGPBF(out, encoding, useDataDescriptor);
+        writeVersionAndGPBF(out, encoding, useDataDescriptor, reserveZip64);
         // nbWritten += 4;
 
         // compression method
@@ -421,6 +485,11 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
      * @throws IOException if an I/O error occurred
      */
     protected static long writeDataDescriptor(ZipEntry ze, OutputStream out, ZipBuffer zipBuffer) throws IOException {
+        if (ze.getCompressedSize() >= MAX_ZIP32_SIZE || ze.getSize() >= MAX_ZIP32_SIZE) {
+            throw new ZipException("Entry " + ze.getName() + " is too large (" + ze.getSize()
+                + " bytes) to be written without random access (Zip64 data descriptors are not supported)");
+        }
+
         out.write(DD_SIG);
         out.write(ZipLong.getBytes(ze.getCrc(), zipBuffer.longBuffer));
         out.write(ZipLong.getBytes(ze.getCompressedSize(), zipBuffer.longBuffer));
@@ -458,6 +527,21 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
      * @return the number of bytes that were written, i.e. the size of the central file header 
      */
     protected static long writeCentralFileHeader(ZipEntry ze, OutputStream out, String encoding, long localFileHeaderOffset, boolean useDataDescriptor, ZipBuffer zipBuffer) throws IOException {
+        boolean hasZip64CompressedSize = ze.getCompressedSize() >= MAX_ZIP32_SIZE;
+        boolean hasZip64Size = ze.getSize() >= MAX_ZIP32_SIZE;
+        boolean hasZip64Offset = localFileHeaderOffset >= MAX_ZIP32_SIZE;
+        boolean needsZip64 = hasZip64CompressedSize || hasZip64Size || hasZip64Offset;
+
+        if (needsZip64) {
+            ZipEightByteInteger size = hasZip64Size ? new ZipEightByteInteger(ze.getSize()) : null;
+            ZipEightByteInteger compressedSize = hasZip64CompressedSize ? new ZipEightByteInteger(ze.getCompressedSize()) : null;
+            ZipEightByteInteger relativeHeaderOffset = hasZip64Offset ? new ZipEightByteInteger(localFileHeaderOffset) : null;
+            ze.addExtraField(new Zip64ExtendedInformationExtraField(size, compressedSize, relativeHeaderOffset, null));
+        }
+        else {
+            ze.removeExtraField(Zip64ExtendedInformationExtraField.HEADER_ID);
+        }
+
         out.write(CFH_SIG);
         // nbWritten += 4;
 
@@ -467,7 +551,7 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
 
         // version needed to extract
         // general purpose bit flag
-        writeVersionAndGPBF(out, encoding, useDataDescriptor);
+        writeVersionAndGPBF(out, encoding, useDataDescriptor, needsZip64);
         // nbWritten += 4;
 
         // compression method
@@ -482,8 +566,8 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
         // compressed length
         // uncompressed length
         out.write(ZipLong.getBytes(ze.getCrc(), zipBuffer.longBuffer));
-        out.write(ZipLong.getBytes(ze.getCompressedSize(), zipBuffer.longBuffer));
-        out.write(ZipLong.getBytes(ze.getSize(), zipBuffer.longBuffer));
+        out.write(hasZip64CompressedSize ? LONG_MAX : ZipLong.getBytes(ze.getCompressedSize(), zipBuffer.longBuffer));
+        out.write(hasZip64Size ? LONG_MAX : ZipLong.getBytes(ze.getSize(), zipBuffer.longBuffer));
         // nbWritten += 12;
 
         // file name length
@@ -518,7 +602,7 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
         // nbWritten += 4;
 
         // relative offset of LFH
-        out.write(ZipLong.getBytes(localFileHeaderOffset, zipBuffer.longBuffer));
+        out.write(hasZip64Offset ? LONG_MAX : ZipLong.getBytes(localFileHeaderOffset, zipBuffer.longBuffer));
         // nbWritten += 4;
 
         long nbWritten = 46;
@@ -545,31 +629,38 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
      * @param out the OutputStream to write the fields to
      * @param encoding the encoding used for writing the filename and optional comment
      * @param useDataDescriptor true if a data descriptor is used for the entry
+     * @param zip64 true if the entry requires Zip64 features (and thus version 4.5)
      * @return the number of bytes that were written, i.e. 4
      * @throws IOException if an I/O error occurred
      */
-    protected static long writeVersionAndGPBF(OutputStream out, String encoding, boolean useDataDescriptor) throws IOException {
+    protected static long writeVersionAndGPBF(OutputStream out, String encoding, boolean useDataDescriptor, boolean zip64) throws IOException {
         boolean isUTF8 = isUTF8(encoding);
 
         // General purpose bit flag :
         // Bit 11 signals UTF-8 is used
         // Bit 3 signals a data descriptor is used
 
-        if (useDataDescriptor) {
+        if (zip64) {
+            // requires version 4.5 to support the Zip64 extended information extra field
+            out.write(SHORT_45);
+        }
+        else if (useDataDescriptor) {
             // requires version 2 as we are going to store length info in the data descriptor
             out.write(SHORT_20);
+        }
+        else {
+            // Version
+            out.write(SHORT_10);
+        }
 
-            // General purpose bit flag
+        // General purpose bit flag
+        if (useDataDescriptor) {
             out.write(isUTF8?
                 SHORT_2056                  // Bit 3 | Bit 11 = 2056
                 :SHORT_8                    // Bit 3          = 8
             );
         }
         else {
-            // Version
-            out.write(SHORT_10);
-
-            // General purpose bit flag
             out.write(isUTF8?
                 SHORT_2048                  // Bit 11 = 2048
                 :SHORT_0                    // No bit set
@@ -595,19 +686,56 @@ public class ZipOutputStream extends OutputStream implements ZipConstants {
     protected static void writeCentralDirectoryEnd(OutputStream out, int nbEntries, long cdLength, long cdOffset, String comment, String encoding, ZipBuffer zipBuffer)
             throws IOException {
 
+        boolean needsZip64 = nbEntries >= MAX_ZIP32_ENTRIES || cdLength >= MAX_ZIP32_SIZE || cdOffset >= MAX_ZIP32_SIZE;
+
+        if (needsZip64) {
+            // Zip64 end of central directory record
+            out.write(ZIP64_EOCD_SIG);
+
+            // size of the record, excluding the signature and this 8-byte field
+            out.write(ZipEightByteInteger.getBytes(44));
+
+            // version made by / version needed to extract
+            out.write(SHORT_45);
+            out.write(SHORT_45);
+
+            // number of this disk / disk with the start of the central directory
+            out.write(LONG_0);
+            out.write(LONG_0);
+
+            // number of entries on this disk / total number of entries
+            out.write(ZipEightByteInteger.getBytes(nbEntries));
+            out.write(ZipEightByteInteger.getBytes(nbEntries));
+
+            // size and offset of the central directory
+            out.write(ZipEightByteInteger.getBytes(cdLength));
+            out.write(ZipEightByteInteger.getBytes(cdOffset));
+
+            // Zip64 end of central directory locator
+            out.write(ZIP64_EOCD_LOC_SIG);
+
+            // number of the disk with the start of the Zip64 EOCD record
+            out.write(LONG_0);
+
+            // relative offset of the Zip64 EOCD record
+            out.write(ZipEightByteInteger.getBytes(cdOffset + cdLength));
+
+            // total number of disks
+            out.write(ZipLong.getBytes(1, zipBuffer.longBuffer));
+        }
+
         out.write(EOCD_SIG);
 
         // disk numbers
         out.write(LONG_0);      // 2x SHORT_0
 
         // number of entries
-        ZipShort.getBytes(nbEntries, zipBuffer.shortBuffer);
-        out.write(zipBuffer.shortBuffer);
-        out.write(zipBuffer.shortBuffer);
+        out.write(needsZip64 ? SHORT_MAX : ZipShort.getBytes(nbEntries, zipBuffer.shortBuffer));
+        out.write(needsZip64 ? SHORT_MAX : zipBuffer.shortBuffer);
 
         // length and location of CD
-        out.write(ZipLong.getBytes(cdLength, zipBuffer.longBuffer));
-        out.write(ZipLong.getBytes(cdOffset, zipBuffer.longBuffer));
+        out.write(cdLength >= MAX_ZIP32_SIZE ? LONG_MAX : ZipLong.getBytes(cdLength, zipBuffer.longBuffer));
+        out.write(cdOffset >= MAX_ZIP32_SIZE ? LONG_MAX : ZipLong.getBytes(cdOffset, zipBuffer.longBuffer));
 
         // ZIP file comment
         byte[] data = getBytes(comment, encoding);

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -39,6 +39,7 @@ New features:
 
 Improvements:
 - Terminal: Font and color updates now apply instantly.
+- Support zip64 files (zip files larger than 4gb).
 
 Localization:
 -


### PR DESCRIPTION
This address #1484

## Disclaimer 
After debugging the issue myself by hand, I've used claude code to do the actual implementation.

## Background
We basically forked Apache Ant's zip package (which I already tweaked in the past to support extended date/time field). The version of this package we had did not have zip64 support and failed silently. The actual part which failed is the `ZipFile::positionAtCentralDirectory` which simply did not work for zip64. This is because the central directory is found in the very end of the file, and with zip64 this lookup process is a bit different. [Here](https://blog.yaakov.online/zip64-go-big-or-go-home/) is a blog post explaining the issue in a clear way.

## The fix
As mentioned above, I've used claude code to port over the Apache Ant zip64 support to our project. At some point in the future we might consider using a proper library but for the time being and as a quick fix I thought that's a good path to take, especially since AI is doing most of the hard work.

