### PR TITLE
Modules tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -464,58 +464,93 @@ task runJpms(type: JavaExec) {
                      externalDeps +
                      localLibs
 
-    classpath = classpathLibs  // Cloud protocol dependencies as unnamed modules
     mainClass = 'com.mucommander.main.muCommander' // Required by Gradle even when using --module
 
-    jvmArgs '--class-path', classpathLibs.asPath  // Explicitly set classpath for unnamed modules
-    jvmArgs '--module-path', modulePath.asPath
-    jvmArgs '--add-modules', 'ALL-MODULE-PATH,jdk.httpserver'  // Add jdk.httpserver for Google OAuth
+    // Windows imposes a hard limit (~32K chars) on a process's command line. The module path,
+    // class path and all the --add-exports/--add-opens/--add-reads flags below easily exceed that,
+    // so we write them all to a JDK "@argfile" instead - only the short "@file" token then needs
+    // to reach CreateProcess. See: https://docs.oracle.com/javase/9/tools/java.htm (Command-Line Argument Files)
+    def argFileArgs = []
+    argFileArgs << '--class-path' << classpathLibs.asPath  // Explicitly set classpath for unnamed modules
+    argFileArgs << '--module-path' << modulePath.asPath
+    argFileArgs << '--add-modules' << 'ALL-MODULE-PATH,jdk.httpserver'  // Add jdk.httpserver for Google OAuth
 
     // Required JVM access grants for JPMS (must come before --module)
-    jvmArgs '--add-exports', 'java.desktop/com.apple.laf=ALL-UNNAMED'
-    jvmArgs '--add-exports', 'java.desktop/com.apple.eio=ALL-UNNAMED'
-    jvmArgs '--add-exports', 'java.desktop/com.apple.eawt=ALL-UNNAMED'
-    jvmArgs '--add-exports', 'java.desktop/com.apple.laf=org.mucommander.os.macos'
-    jvmArgs '--add-exports', 'java.desktop/com.apple.eio=org.mucommander.os.macos'
-    jvmArgs '--add-exports', 'java.desktop/com.apple.eawt=org.mucommander.os.macos'
-    jvmArgs '--add-opens', 'java.desktop/javax.swing.plaf.basic=org.mucommander.core'
-    jvmArgs '--add-opens', 'java.base/java.io=org.mucommander.commons.file'
-    jvmArgs '--add-opens', 'java.base/java.net=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.transaction.xa/javax.transaction.xa=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.management/javax.management=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.rmi/java.rmi=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.security.jgss/org.ietf.jgss=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.sql/java.sql=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.base/sun.net.www.protocol.http=ALL-UNNAMED'
-    jvmArgs '--add-opens', 'java.base/sun.net.www.protocol.https=ALL-UNNAMED'
+    argFileArgs << '--add-exports' << 'java.desktop/com.apple.laf=ALL-UNNAMED'
+    argFileArgs << '--add-exports' << 'java.desktop/com.apple.eio=ALL-UNNAMED'
+    argFileArgs << '--add-exports' << 'java.desktop/com.apple.eawt=ALL-UNNAMED'
+    argFileArgs << '--add-exports' << 'java.desktop/com.apple.laf=org.mucommander.os.macos'
+    argFileArgs << '--add-exports' << 'java.desktop/com.apple.eio=org.mucommander.os.macos'
+    argFileArgs << '--add-exports' << 'java.desktop/com.apple.eawt=org.mucommander.os.macos'
+    argFileArgs << '--add-opens' << 'java.desktop/javax.swing.plaf.basic=org.mucommander.core'
+    argFileArgs << '--add-opens' << 'java.base/java.io=org.mucommander.commons.file'
+    argFileArgs << '--add-opens' << 'java.base/java.net=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.transaction.xa/javax.transaction.xa=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.management/javax.management=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.rmi/java.rmi=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.security.jgss/org.ietf.jgss=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.sql/java.sql=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.base/sun.net.www.protocol.http=ALL-UNNAMED'
+    argFileArgs << '--add-opens' << 'java.base/sun.net.www.protocol.https=ALL-UNNAMED'
 
     // Allow cloud protocols to read from unnamed module (classpath) for their non-modular dependencies
-    jvmArgs '--add-reads', 'org.mucommander.protocol.gcs=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.protocol.gdrive=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.protocol.dropbox=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.protocol.onedrive=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.protocol.s3=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.protocol.registry=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.os.macos=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.os.linux=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.os.win=ALL-UNNAMED'
-    jvmArgs '--add-reads', 'org.mucommander.os.openvms=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.gcs=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.gdrive=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.dropbox=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.onedrive=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.s3=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.registry=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.os.macos=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.os.linux=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.os.win=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.os.openvms=ALL-UNNAMED'
 
-    jvmArgs '--module', 'org.mucommander/com.mucommander.main.muCommander'
+    // sevenzipjbindings/apache-bzip2 have no real module descriptor or Automatic-Module-Name,
+    // so they compile as unnamed-module (classpath) dependencies via --add-reads=ALL-UNNAMED,
+    // but at runtime they land on the module path (via ALL-MODULE-PATH) as automatic modules
+    // named after their jar file (e.g. "sevenzipjbindings-1.6.3.jar" -> "sevenzipjbindings").
+    // Grant explicit reads to those automatic module names here.
+    argFileArgs << '--add-reads' << 'org.mucommander.format.sevenzip=sevenzipjbindings'
+    argFileArgs << '--add-reads' << 'org.mucommander.format.rpm=sevenzipjbindings'
+    argFileArgs << '--add-reads' << 'org.mucommander.format.bzip2=apache.bzip2'
+
+    // The external net.sf.sevenzipjbinding jars are non-modular and deliberately kept on the
+    // runtime classpath (see classpathLibs above), so these modules also need ALL-UNNAMED reads
+    // (already granted at compile time via compileJava's --add-reads, but that doesn't carry
+    // over to this separate runtime JVM launch).
+    argFileArgs << '--add-reads' << 'org.mucommander.format.sevenzip=ALL-UNNAMED'
+    argFileArgs << '--add-reads' << 'org.mucommander.format.rpm=ALL-UNNAMED'
+
+    // viewer-binary's bined/binary_data jars and vsphere's vim25.jar are likewise non-modular
+    // (no Automatic-Module-Name), not comprise-embedded, and not in classpathLibs, so they land
+    // on the module path as automatic modules named after their jar files at runtime.
+    argFileArgs << '--add-reads' << 'org.mucommander.viewer.binary=bined.core,bined.swing,bined.operation,bined.operation.swing,bined.highlight.swing,binary.data,binary.data.array'
+    argFileArgs << '--add-reads' << 'org.mucommander.protocol.vsphere=vim25'
+
+    argFileArgs << '--module' << 'org.mucommander/com.mucommander.main.muCommander'
 
     // Java library path for Libguestfs
-    jvmArgs '-Djava.library.path=/usr/local/lib'
+    argFileArgs << '-Djava.library.path=/usr/local/lib'
 
     // Performance optimizations
-    jvmArgs '-Dsun.java2d.metal=false' // see: https://github.com/mucommander/mucommander/issues/1372
-    jvmArgs '-Xshare:auto', '-XX:-UsePerfData', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1' // faster start
+    argFileArgs << '-Dsun.java2d.metal=false' // see: https://github.com/mucommander/mucommander/issues/1372
+    argFileArgs << '-Xshare:auto' << '-XX:-UsePerfData' << '-XX:+TieredCompilation' << '-XX:TieredStopAtLevel=1' // faster start
 
     // Debug configuration
     def debugSuspend = (project.findProperty('suspend') as String) ?: 'y'
     if (project.hasProperty('debug')) {
         logger.info('Launching muCommander in debug mode...')
-        jvmArgs "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=${debugSuspend},address=${project.debug}"
+        argFileArgs << '-Xdebug' << "-Xrunjdwp:transport=dt_socket,server=y,suspend=${debugSuspend},address=${project.debug}"
     }
+
+    def argFile = layout.buildDirectory.file('runJpms/args.txt').get().asFile
+    argFile.parentFile.mkdirs()
+    // Per the @argfile format: quote any token containing whitespace, escaping backslashes/quotes within it.
+    argFile.text = argFileArgs.collect { arg ->
+        arg.contains(' ') ? '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"' : arg
+    }.join('\n')
+
+    jvmArgs "@${argFile}"
 }
 
 task run(dependsOn: 'runJpms') {

--- a/build.gradle
+++ b/build.gradle
@@ -527,8 +527,6 @@ task runJpms(type: JavaExec) {
     argFileArgs << '--add-reads' << 'org.mucommander.viewer.binary=bined.core,bined.swing,bined.operation,bined.operation.swing,bined.highlight.swing,binary.data,binary.data.array'
     argFileArgs << '--add-reads' << 'org.mucommander.protocol.vsphere=vim25'
 
-    argFileArgs << '--module' << 'org.mucommander/com.mucommander.main.muCommander'
-
     // Java library path for Libguestfs
     argFileArgs << '-Djava.library.path=/usr/local/lib'
 
@@ -542,6 +540,10 @@ task runJpms(type: JavaExec) {
         logger.info('Launching muCommander in debug mode...')
         argFileArgs << '-Xdebug' << "-Xrunjdwp:transport=dt_socket,server=y,suspend=${debugSuspend},address=${project.debug}"
     }
+
+    // --module must be the last JVM option: once the java launcher sees it, every
+    // subsequent token is treated as a program argument rather than a JVM flag.
+    argFileArgs << '--module' << 'org.mucommander/com.mucommander.main.muCommander'
 
     def argFile = layout.buildDirectory.file('runJpms/args.txt').get().asFile
     argFile.parentFile.mkdirs()

--- a/mucommander-bonjour/src/main/resources/module-info/module-info.java
+++ b/mucommander-bonjour/src/main/resources/module-info/module-info.java
@@ -25,6 +25,8 @@ module org.mucommander.bonjour {
     requires org.mucommander.preferences;
     requires java.desktop;
     requires jmdns;
+    requires org.slf4j;
+    requires org.mucommander.commons.util;
 
     provides BrowsableItemsMenuService
         with com.mucommander.bonjour.BonjourMenuService;

--- a/mucommander-core/src/main/resources/module-info/module-info.java
+++ b/mucommander-core/src/main/resources/module-info/module-info.java
@@ -33,6 +33,7 @@ open module org.mucommander.core {
     requires ch.qos.logback.classic;
     requires ch.qos.logback.core;
     requires org.apache.commons.collections4;
+    requires json.smart;
 
     // Optional L&F modules (from unnamed module)
     requires static com.formdev.flatlaf;

--- a/mucommander-protocol-adb/src/main/resources/module-info/module-info.java
+++ b/mucommander-protocol-adb/src/main/resources/module-info/module-info.java
@@ -27,8 +27,11 @@ module org.mucommander.protocol.adb {
     requires org.slf4j;
     requires org.mucommander.commons.file;
     requires org.mucommander.commons.runtime;
+    requires org.mucommander.commons.io;
+    requires org.mucommander.commons.util;
     requires org.mucommander.protocol.api;
     requires org.mucommander.translator;
+    requires org.mucommander.process;
     requires org.mucommander.core;
     requires java.desktop;
 

--- a/mucommander-protocol-gdrive/src/main/java/module-info.java
+++ b/mucommander-protocol-gdrive/src/main/java/module-info.java
@@ -18,8 +18,10 @@
 open module org.mucommander.protocol.gdrive {
     requires org.slf4j;
     requires org.mucommander.commons.file;
+    requires org.mucommander.commons.io;
     requires org.mucommander.protocol.api;
     requires org.mucommander.translator;
+    requires org.mucommander.preferences;
     requires org.mucommander.core;
     requires java.desktop;
 

--- a/mucommander-protocol-nfs/src/main/resources/module-info/module-info.java
+++ b/mucommander-protocol-nfs/src/main/resources/module-info/module-info.java
@@ -18,6 +18,7 @@
 module org.mucommander.protocol.nfs {
     requires org.slf4j;
     requires org.mucommander.commons.file;
+    requires org.mucommander.commons.io;
     requires org.mucommander.protocol.api;
     requires org.mucommander.translator;
     requires java.desktop;

--- a/mucommander-protocol-ovirt/src/main/resources/module-info/module-info.java
+++ b/mucommander-protocol-ovirt/src/main/resources/module-info/module-info.java
@@ -18,6 +18,8 @@
 module org.mucommander.protocol.ovirt {
     requires org.slf4j;
     requires org.mucommander.commons.file;
+    requires org.mucommander.commons.io;
+    requires org.mucommander.commons.util;
     requires org.mucommander.protocol.api;
     requires org.mucommander.translator;
     requires java.desktop;

--- a/mucommander-protocol-smb/src/main/resources/module-info/module-info.java
+++ b/mucommander-protocol-smb/src/main/resources/module-info/module-info.java
@@ -18,6 +18,7 @@
 module org.mucommander.protocol.smb {
     requires org.slf4j;
     requires org.mucommander.commons.file;
+    requires org.mucommander.commons.io;
     requires org.mucommander.protocol.api;
     requires org.mucommander.translator;
     requires java.desktop;

--- a/mucommander-viewer-binary/src/main/resources/module-info/module-info.java
+++ b/mucommander-viewer-binary/src/main/resources/module-info/module-info.java
@@ -23,6 +23,8 @@ module org.mucommander.viewer.binary {
     requires org.mucommander.encoding;
     requires org.mucommander.preferences;
     requires org.mucommander.commons.util;
+    requires org.mucommander.commons.runtime;
+    requires org.mucommander.commons.io;
     requires org.mucommander.os.api;
     requires org.mucommander.core;
     requires java.desktop;


### PR DESCRIPTION
I was building the project locally on my machine and noticed:

1. The build didn't run correctly on windows because of some argument length limitation
2. Some module imports were missing, preventing the app from working with 7z files, bonjour and more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JPMS application launching by consolidating runtime options, module access settings, library paths, and debugging options.
  * Added missing module requirements to improve compilation and runtime resolution across Bonjour, core, protocol, and binary viewer features.
* **Chores**
  * Updated launch configuration handling for more reliable argument processing and module startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->