### PR TITLE
Move args.txt creation to execution phase to fix clean run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -545,14 +545,15 @@ task runJpms(type: JavaExec) {
     // subsequent token is treated as a program argument rather than a JVM flag.
     argFileArgs << '--module' << 'org.mucommander/com.mucommander.main.muCommander'
 
-    def argFile = layout.buildDirectory.file('runJpms/args.txt').get().asFile
-    argFile.parentFile.mkdirs()
-    // Per the @argfile format: quote any token containing whitespace, escaping backslashes/quotes within it.
-    argFile.text = argFileArgs.collect { arg ->
-        arg.contains(' ') ? '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"' : arg
-    }.join('\n')
-
-    jvmArgs "@${argFile}"
+    doFirst {
+        def argFile = layout.buildDirectory.file('runJpms/args.txt').get().asFile
+        argFile.parentFile.mkdirs()
+        // Per the @argfile format: quote any token containing whitespace, escaping backslashes/quotes within it.
+        argFile.text = argFileArgs.collect { arg ->
+            arg.contains(' ') ? '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"' : arg
+        }.join('\n')
+        jvmArgs "@${argFile}"
+    }
 }
 
 task run(dependsOn: 'runJpms') {


### PR DESCRIPTION
The runJpms task was creating args.txt during configuration phase, causing `./gradlew clean run` to fail when clean deleted the file before execution. Moving file creation to doFirst ensures it happens after clean completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JPMS task execution by generating runtime argument files immediately before execution.
  * Preserved JVM argument handling, including whitespace, quote, and backslash escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->