### PR TITLE
Package sevenzipjbindings as JAR for automatic module naming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -387,7 +387,7 @@ task runJpms(type: JavaExec) {
     // For modules that embed dependencies (comprise), use JAR files instead of class directories
     // Note: Cloud protocols are excluded - they compile with --add-reads=ALL-UNNAMED and should
     // use classes directory while their dependencies remain on classpath as unnamed modules
-    def modulesWithEmbeddedDeps = ['mucommander-core', 'jetbrains-jediterm', 'mucommander-os-macos', 'mucommander-viewer-text', 'mucommander-viewer-binary', 'mucommander-viewer-image', 'mucommander-viewer-pdf']
+    def modulesWithEmbeddedDeps = ['mucommander-core', 'jetbrains-jediterm', 'mucommander-os-macos', 'mucommander-viewer-text', 'mucommander-viewer-binary', 'mucommander-viewer-image', 'mucommander-viewer-pdf', 'sevenzipjbindings']
     def ourProjectClasses = files()
     project.subprojects.findAll { it.plugins.hasPlugin('java') && it.name != 'sun-net-www' }.each {
         if (modulesWithEmbeddedDeps.contains(it.name)) {

--- a/mucommander-format-sevenzip/src/main/java/module-info.java
+++ b/mucommander-format-sevenzip/src/main/java/module-info.java
@@ -18,6 +18,8 @@
 module org.mucommander.format.sevenzip {
     requires org.mucommander.commons.file;
     requires org.slf4j;
+    // sevenzipjbindings (wrapper) is an automatic module on module path, accessed via --add-reads
+    // sevenzipjbinding (external library) is on classpath, accessed via --add-reads=ALL-UNNAMED
 
     exports com.mucommander.commons.file.archive.sevenzip;
 


### PR DESCRIPTION
The sevenzipjbindings module must be packaged as a JAR on the module path (not as a classes directory) so that JPMS automatic module naming derives the correct module name from the JAR filename, allowing --add-reads configuration to grant proper access to SevenZip format providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JPMS runtime launching for SevenZip support by correctly including its embedded dependencies.
  * Clarified module and classpath handling to improve compatibility when using SevenZip functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->