### PR TITLE
fix load of file viewers/editors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,7 +379,12 @@ task runJpms(type: JavaExec) {
     dependsOn 'prepareJpmsModules', 'copyConfigForJpms',
               ':mucommander-core:jar',
               ':jetbrains-jediterm:jar',
-              ':mucommander-os-macos:jar'
+              ':mucommander-os-macos:jar',
+              ':mucommander-viewer-text:jar',
+              ':mucommander-viewer-image:jar',
+              ':mucommander-viewer-pdf:jar',
+              ':mucommander-viewer-binary:jar',
+              ':sevenzipjbindings:jar'
 
     // Build module path using classes directories (which now include resources)
     // For external dependencies, use JARs

--- a/mucommander-core/src/main/java/com/mucommander/module/FileEditorsLoader.java
+++ b/mucommander-core/src/main/java/com/mucommander/module/FileEditorsLoader.java
@@ -38,7 +38,9 @@ public class FileEditorsLoader {
     private static final List<FileEditorService> SERVICES = new ArrayList<>();
 
     public static void load() {
-        for (FileEditorService service : ServiceLoader.load(FileEditorService.class)) {
+        // Use ModuleLayer.boot() to ensure ServiceLoader sees all modules on the module path
+        ServiceLoader<FileEditorService> loader = ServiceLoader.load(ModuleLayer.boot(), FileEditorService.class);
+        for (FileEditorService service : loader) {
             addEditorService(service);
             LOGGER.info("FileEditorService is registered: " + service);
         }

--- a/mucommander-core/src/main/java/com/mucommander/module/FileViewersLoader.java
+++ b/mucommander-core/src/main/java/com/mucommander/module/FileViewersLoader.java
@@ -38,7 +38,9 @@ public class FileViewersLoader {
     private static final List<FileViewerService> SERVICES = new ArrayList<>();
 
     public static void load() {
-        for (FileViewerService service : ServiceLoader.load(FileViewerService.class)) {
+        // Use ModuleLayer.boot() to ensure ServiceLoader sees all modules on the module path
+        ServiceLoader<FileViewerService> loader = ServiceLoader.load(ModuleLayer.boot(), FileViewerService.class);
+        for (FileViewerService service : loader) {
             addViewerService(service);
             LOGGER.info("FileViewerService is registered: " + service);
         }


### PR DESCRIPTION
without these changes, file viewers and editors are sometimes loaded and sometimes not after the transition to JPMS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of file editor and viewer extensions, helping ensure they are detected consistently.
  * Improved macOS and file viewer-related build task preparation for JPMS launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->