### PR TITLE
Focus on file after pasting a full path into the location bar

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/core/BrowseLocationThread.java
+++ b/mucommander-core/src/main/java/com/mucommander/core/BrowseLocationThread.java
@@ -281,11 +281,26 @@ public class BrowseLocationThread extends ChangeFolderThread {
                             }
                             // else just continue and browse file's contents
                         }
-                        // File is a regular file: show download dialog which allows to download (copy) the file
-                        // to a directory specified by the user
+                        // File is a regular, non-browsable file (e.g. the user typed/pasted a file path
+                        // into the location bar): navigate to its parent folder and select it there,
+                        // mirroring how dropping such a file onto the location bar is handled (see
+                        // FileDropTransferHandler.importData()), instead of prompting to download it.
+                        //
+                        // Note: this must be done by continuing the current loop iteration (below) rather
+                        // than by calling folderPanel.tryChangeCurrentFolder(parent, file, false) here -
+                        // LocationChanger refuses to start a new folder-change thread while one is already
+                        // in progress, and this very thread is still registered as in-progress at this
+                        // point, so such a call would silently be a no-op.
                         else {
-                            showDownloadDialog(file);
-                            break;
+                            AbstractFile parent = file.getParent();
+                            if (parent == null) {
+                                // No parent to navigate to (shouldn't normally happen) - fall back to the
+                                // download prompt
+                                showDownloadDialog(file);
+                                break;
+                            }
+                            fileToSelect = file;
+                            file = parent;
                         }
 
                         this.folder = file;

--- a/mucommander-core/src/main/java/com/mucommander/ui/dnd/FileDropTransferHandler.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/dnd/FileDropTransferHandler.java
@@ -17,9 +17,11 @@
 
 package com.mucommander.ui.dnd;
 
+import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.event.InputEvent;
 
+import javax.swing.JComponent;
 import javax.swing.TransferHandler;
 
 import org.slf4j.Logger;
@@ -75,19 +77,43 @@ public class FileDropTransferHandler extends TransferHandler {
     private final boolean changeFolderOnlyMode;
 
     /**
+     * The component's previous TransferHandler (if any), e.g. the LAF-installed one that implements
+     * ordinary text cut/copy/paste for a text field. {@code setTransferHandler} replaces the handler
+     * wholesale, and TransferHandler is also what keyboard-triggered clipboard operations (Ctrl+C/X/V)
+     * delegate to - so without forwarding non-drop transfers here, installing this handler on a text
+     * field would silently break its normal clipboard shortcuts.
+     */
+    private final TransferHandler fallbackHandler;
+
+    /**
      * @param folderPanel          the panel to navigate / copy-move into
      * @param changeFolderOnlyMode if {@code true} only folder navigation is performed on drop;
      *                             if {@code false} copy/move is also possible
      */
     public FileDropTransferHandler(FolderPanel folderPanel, boolean changeFolderOnlyMode) {
+        this(folderPanel, changeFolderOnlyMode, null);
+    }
+
+    /**
+     * @param folderPanel          the panel to navigate / copy-move into
+     * @param changeFolderOnlyMode if {@code true} only folder navigation is performed on drop;
+     *                             if {@code false} copy/move is also possible
+     * @param fallbackHandler      the component's previous TransferHandler, to which non-drop transfers
+     *                             (keyboard cut/copy/paste) are forwarded; {@code null} if the component
+     *                             has no clipboard behavior worth preserving (e.g. a plain button)
+     */
+    public FileDropTransferHandler(FolderPanel folderPanel, boolean changeFolderOnlyMode, TransferHandler fallbackHandler) {
         this.folderPanel = folderPanel;
         this.changeFolderOnlyMode = changeFolderOnlyMode;
+        this.fallbackHandler = fallbackHandler;
     }
 
     @Override
     public boolean canImport(TransferSupport support) {
         if (!support.isDrop()) {
-            return false;
+            // Not a drag-and-drop transfer, so this is a keyboard/menu-triggered clipboard paste -
+            // defer to whatever the component normally does with pasted text.
+            return fallbackHandler != null && fallbackHandler.canImport(support);
         }
 
         // Accept any of the three flavors we know how to handle
@@ -111,6 +137,10 @@ public class FileDropTransferHandler extends TransferHandler {
 
     @Override
     public boolean importData(TransferSupport support) {
+        if (!support.isDrop()) {
+            return fallbackHandler != null && fallbackHandler.importData(support);
+        }
+
         if (!canImport(support)) {
             return false;
         }
@@ -147,6 +177,22 @@ public class FileDropTransferHandler extends TransferHandler {
             }
         }
         return true;
+    }
+
+    @Override
+    public int getSourceActions(JComponent c) {
+        // Keyboard-triggered cut/copy (Ctrl+C/X) check this before calling exportToClipboard - forward
+        // it so text selection can still be copied out of a component using this handler.
+        return fallbackHandler != null ? fallbackHandler.getSourceActions(c) : super.getSourceActions(c);
+    }
+
+    @Override
+    public void exportToClipboard(JComponent comp, Clipboard clip, int action) throws IllegalStateException {
+        if (fallbackHandler != null) {
+            fallbackHandler.exportToClipboard(comp, clip, action);
+        } else {
+            super.exportToClipboard(comp, clip, action);
+        }
     }
 
     /**

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/FolderPanel.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/FolderPanel.java
@@ -166,9 +166,13 @@ public class FolderPanel implements FocusListener, QuickListContainer, ActiveTab
             registerCycleThruFolderPanelAction(locationTextField);
 
             // Allow the location field to change the current directory when a file/folder is dropped on it.
-            FileDropTransferHandler dropHandler = new FileDropTransferHandler(this, true);
-            locationTextField.setTransferHandler(dropHandler);
-            driveButton.setTransferHandler(dropHandler);
+            // Preserve the field's original (LAF-installed) TransferHandler as a fallback so that
+            // keyboard-triggered clipboard cut/copy/paste - which also goes through TransferHandler -
+            // keeps working; otherwise replacing it outright would silently break text paste into the
+            // location bar.
+            locationTextField.setTransferHandler(
+                    new FileDropTransferHandler(this, true, locationTextField.getTransferHandler()));
+            driveButton.setTransferHandler(new FileDropTransferHandler(this, true));
             locationTextField.addFocusListener(this);
         }).start();
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
@@ -282,12 +282,14 @@ public class LocationTextField extends ProgressTextField implements LocationList
         // Remember that the folder change was initiated by the location field
         folderChangeInitiatedByLocationField = true;
 
-        // If the entered/pasted location points to an existing regular file rather than a directory,
-        // navigate to its parent folder and select it there - mirroring how dropping a file onto the
-        // location bar is handled (see FileDropTransferHandler) - instead of falling through to
-        // BrowseLocationThread's generic file handling, which offers to "download" it.
+        // If the entered/pasted location points to an existing non-browsable file (i.e. not a directory
+        // and not an archive that can be browsed into), navigate to its parent folder and select it
+        // there - mirroring how dropping a file onto the location bar is handled (see
+        // FileDropTransferHandler) - instead of falling through to BrowseLocationThread's generic file
+        // handling, which offers to "download" it. Browsable files (archives) keep going through that
+        // generic path so the existing "download or browse" prompt still applies to them.
         AbstractFile file = FileFactory.getFile(location);
-        if (file != null && file.exists() && !file.isDirectory()) {
+        if (file != null && file.exists() && !file.isBrowsable()) {
             AbstractFile parent = file.getParent();
             if (parent != null)
                 return folderPanel.tryChangeCurrentFolder(parent, file, false) == null;

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
@@ -281,9 +281,7 @@ public class LocationTextField extends ProgressTextField implements LocationList
         // Remember that the folder change was initiated by the location field
         folderChangeInitiatedByLocationField = true;
 
-        // Change folder. If the entered/pasted location turns out to point to a non-browsable file
-        // rather than a directory, BrowseLocationThread navigates to its parent folder and selects it
-        // there instead of showing the "download" prompt - see the resolution logic in its run() method.
+        // Change folder
         return folderPanel.tryChangeCurrentFolder(location) == null;
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
@@ -28,7 +28,6 @@ import javax.swing.SwingUtilities;
 import com.mucommander.bookmark.Bookmark;
 import com.mucommander.bookmark.BookmarkManager;
 import com.mucommander.commons.file.AbstractFile;
-import com.mucommander.commons.file.FileFactory;
 import com.mucommander.commons.file.FileURL;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 import com.mucommander.commons.file.protocol.local.UNCFile;
@@ -282,20 +281,9 @@ public class LocationTextField extends ProgressTextField implements LocationList
         // Remember that the folder change was initiated by the location field
         folderChangeInitiatedByLocationField = true;
 
-        // If the entered/pasted location points to an existing non-browsable file (i.e. not a directory
-        // and not an archive that can be browsed into), navigate to its parent folder and select it
-        // there - mirroring how dropping a file onto the location bar is handled (see
-        // FileDropTransferHandler) - instead of falling through to BrowseLocationThread's generic file
-        // handling, which offers to "download" it. Browsable files (archives) keep going through that
-        // generic path so the existing "download or browse" prompt still applies to them.
-        AbstractFile file = FileFactory.getFile(location);
-        if (file != null && file.exists() && !file.isBrowsable()) {
-            AbstractFile parent = file.getParent();
-            if (parent != null)
-                return folderPanel.tryChangeCurrentFolder(parent, file, false) == null;
-        }
-
-        // Change folder
+        // Change folder. If the entered/pasted location turns out to point to a non-browsable file
+        // rather than a directory, BrowseLocationThread navigates to its parent folder and selects it
+        // there instead of showing the "download" prompt - see the resolution logic in its run() method.
         return folderPanel.tryChangeCurrentFolder(location) == null;
     }
 

--- a/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
+++ b/mucommander-core/src/main/java/com/mucommander/ui/main/LocationTextField.java
@@ -28,6 +28,7 @@ import javax.swing.SwingUtilities;
 import com.mucommander.bookmark.Bookmark;
 import com.mucommander.bookmark.BookmarkManager;
 import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.commons.file.FileFactory;
 import com.mucommander.commons.file.FileURL;
 import com.mucommander.commons.file.protocol.local.LocalFile;
 import com.mucommander.commons.file.protocol.local.UNCFile;
@@ -280,6 +281,17 @@ public class LocationTextField extends ProgressTextField implements LocationList
 
         // Remember that the folder change was initiated by the location field
         folderChangeInitiatedByLocationField = true;
+
+        // If the entered/pasted location points to an existing regular file rather than a directory,
+        // navigate to its parent folder and select it there - mirroring how dropping a file onto the
+        // location bar is handled (see FileDropTransferHandler) - instead of falling through to
+        // BrowseLocationThread's generic file handling, which offers to "download" it.
+        AbstractFile file = FileFactory.getFile(location);
+        if (file != null && file.exists() && !file.isDirectory()) {
+            AbstractFile parent = file.getParent();
+            if (parent != null)
+                return folderPanel.tryChangeCurrentFolder(parent, file, false) == null;
+        }
 
         // Change folder
         return folderPanel.tryChangeCurrentFolder(location) == null;

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -40,7 +40,7 @@ New features:
 Improvements:
 - Terminal: Font and color updates now apply instantly.
 - Support zip64 files (zip files larger than 4gb).
-- Pasting or typing a full file path into the location bar now navigates to its parent folder and selects the file.
+- Pasting or typing a path to a non-browsable file into the location bar now navigates to its parent folder and selects the file.
 
 Localization:
 -

--- a/package/readme.txt
+++ b/package/readme.txt
@@ -40,6 +40,7 @@ New features:
 Improvements:
 - Terminal: Font and color updates now apply instantly.
 - Support zip64 files (zip files larger than 4gb).
+- Pasting or typing a full file path into the location bar now navigates to its parent folder and selects the file.
 
 Localization:
 -


### PR DESCRIPTION
This addresses #1498. Note that ctrl+v didn't actually work on windows so fixing that as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entering or pasting a complete file path in the location bar now navigates to its parent directory and selects the file.
  * Clipboard actions in the location bar remain available alongside file drag-and-drop support.

* **Bug Fixes**
  * Improved handling of regular files by avoiding unnecessary download prompts when their parent directory can be opened.

* **Documentation**
  * Updated the v1.6.3 changelog with the enhanced file-path navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->