### PR TITLE
Skip macAppBundle plugin tasks when running 'dmg' task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -987,6 +987,16 @@ task dmg(dependsOn: 'macAppImage', type: Exec) {
                 '--dest', "${buildDir}/distributions"
 }
 
+// Disable macAppBundle plugin tasks by default to avoid conflict with the dmg task above
+// To create noarch DMG, explicitly run: ./gradlew createDmg
+def macAppBundleTaskNames = ['createDmg', 'copyBackgroundImage', 'copyIcon', 'copyStub', 'bundleJRE',
+                              'copyToResourcesJava', 'generatePlist', 'generatePkgInfo', 'createApp',
+                              'createAppZip', 'codeSign', 'runSetFile']
+tasks.matching { it.name in macAppBundleTaskNames }.configureEach {
+    enabled = gradle.startParameter.taskNames.contains('createDmg') ||
+              gradle.startParameter.taskNames.contains(':createDmg')
+}
+
 task linuxAppImage(dependsOn: 'createJpmsPackaging', type: Exec) {
     workingDir "${projectDir}"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Legacy macOS application bundle tasks are now disabled by default.
  * These tasks are automatically enabled when creating a DMG installer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->