### PR TITLE
Restore dmg filename with release and arch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -985,6 +985,20 @@ task dmg(dependsOn: 'macAppImage', type: Exec) {
                 '--license-file', 'package/license.txt', \
                 '--about-url', 'https://www.mucommander.com', \
                 '--dest', "${buildDir}/distributions"
+
+    doLast {
+        def defaultDmg = file("${buildDir}/distributions/muCommander-${project.version}.dmg")
+        if (!defaultDmg.exists()) {
+            throw new GradleException("Source DMG not found: ${defaultDmg.absolutePath}")
+        }
+
+        def targetDmg = file("${buildDir}/distributions/mucommander-${project.version}-${project.ext.release}-${project.ext.arch}.dmg")
+        if (!defaultDmg.renameTo(targetDmg)) {
+            throw new GradleException("Failed to rename DMG from ${defaultDmg.name} to ${targetDmg.name}")
+        }
+
+        println "Created: ${targetDmg.name}"
+    }
 }
 
 // Disable macAppBundle plugin tasks by default to avoid conflict with the dmg task above


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DMG installer filenames now include the project version, release channel, and system architecture.
  * The generated installer filename is logged when the artifact is available.

* **Bug Fixes**
  * DMG packaging now reports a clear error when the expected installer is missing or cannot be renamed, helping identify failed builds more quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->